### PR TITLE
Add a sanity check for runs of run.py

### DIFF
--- a/libs/CovidDatasets.py
+++ b/libs/CovidDatasets.py
@@ -11,72 +11,13 @@ from urllib.request import urlopen
 import tempfile
 from zipfile import ZipFile
 
-# Dict to transform longhand state names to abbreviations
-us_state_abbrev = {
-    'Alabama': 'AL',
-    'Alaska': 'AK',
-    'American Samoa': 'AS',
-    'Arizona': 'AZ',
-    'Arkansas': 'AR',
-    'California': 'CA',
-    'Colorado': 'CO',
-    'Connecticut': 'CT',
-    'Delaware': 'DE',
-    'District of Columbia': 'DC',
-    'Florida': 'FL',
-    'Georgia': 'GA',
-    'Guam': 'GU',
-    'Hawaii': 'HI',
-    'Idaho': 'ID',
-    'Illinois': 'IL',
-    'Indiana': 'IN',
-    'Iowa': 'IA',
-    'Kansas': 'KS',
-    'Kentucky': 'KY',
-    'Louisiana': 'LA',
-    'Maine': 'ME',
-    'Maryland': 'MD',
-    'Massachusetts': 'MA',
-    'Michigan': 'MI',
-    'Minnesota': 'MN',
-    'Mississippi': 'MS',
-    'Missouri': 'MO',
-    'Montana': 'MT',
-    'Nebraska': 'NE',
-    'Nevada': 'NV',
-    'New Hampshire': 'NH',
-    'New Jersey': 'NJ',
-    'New Mexico': 'NM',
-    'New York': 'NY',
-    'North Carolina': 'NC',
-    'North Dakota': 'ND',
-    'Northern Mariana Islands': 'MP',
-    'Ohio': 'OH',
-    'Oklahoma': 'OK',
-    'Oregon': 'OR',
-    'Pennsylvania': 'PA',
-    'Puerto Rico': 'PR',
-    'Rhode Island': 'RI',
-    'South Carolina': 'SC',
-    'South Dakota': 'SD',
-    'Tennessee': 'TN',
-    'Texas': 'TX',
-    'Utah': 'UT',
-    'Vermont': 'VT',
-    'Virgin Islands': 'VI',
-    'Virginia': 'VA',
-    'Washington': 'WA',
-    'West Virginia': 'WV',
-    'Wisconsin': 'WI',
-    'Wyoming': 'WY'
-}
-
+from libs.build_params import US_STATE_ABBREV as us_state_abbrev
 
 local_public_data_dir = tempfile.TemporaryDirectory()
 local_public_data = local_public_data_dir.name
 
 def get_public_data_base_url():
-    # COVID_DATA_PUBLIC could be set, to for instance 
+    # COVID_DATA_PUBLIC could be set, to for instance
     # "https://raw.githubusercontent.com/covid-projections/covid-data-public/master"
     # which would not locally copy the data.
 

--- a/libs/build_params.py
+++ b/libs/build_params.py
@@ -1,0 +1,120 @@
+'''
+Constants to use for a build. In a separate file to avoid
+auto-importing a dataset when we don't necessarily need to.
+'''
+
+import datetime
+
+r0 = 2.4
+
+INTERVENTIONS = [
+    None,  # No Intervention
+    {  # Flatten the Curve
+        datetime.date(2020, 3, 23): 1.3,
+        datetime.date(2020, 4, 20): 1.1,
+        datetime.date(2020, 5, 22): 0.8,
+        datetime.date(2020, 6, 23): r0
+    },
+    {  # Full Containment
+        datetime.date(2020, 3, 23): 1.3,
+        datetime.date(2020, 3, 31): 0.3,
+        datetime.date(2020, 4, 28): 0.2,
+        datetime.date(2020, 5,  6): 0.1,
+        datetime.date(2020, 5, 10): 0.35,
+        datetime.date(2020, 5, 18): r0
+    },
+    {  # @TODO: Model w/ FlatteningTheCurve (2 wk delay)
+        datetime.date(2020, 3, 23): 1.3,
+        datetime.date(2020, 4, 20): 1.1,
+        datetime.date(2020, 5, 22): 0.8,
+        datetime.date(2020, 6, 23): r0
+    },
+    {  # @TODO: Model w/ FlatteningTheCurve (1 mo delay)
+        datetime.date(2020, 3, 23): 1.3,
+        datetime.date(2020, 4, 20): 1.1,
+        datetime.date(2020, 5, 22): 0.8,
+        datetime.date(2020, 6, 23): r0
+    },
+    {  # @TODO: Full Containment (1 wk dly)
+        datetime.date(2020, 3, 23): 1.3,
+        datetime.date(2020, 3, 31): 0.3,
+        datetime.date(2020, 4, 28): 0.2,
+        datetime.date(2020, 5,  6): 0.1,
+        datetime.date(2020, 5, 10): 0.35,
+        datetime.date(2020, 5, 18): r0
+    },
+    {  # @TODO: Full Containment (2 wk dly)
+        datetime.date(2020, 3, 23): 1.3,
+        datetime.date(2020, 3, 31): 0.3,
+        datetime.date(2020, 4, 28): 0.2,
+        datetime.date(2020, 5,  6): 0.1,
+        datetime.date(2020, 5, 10): 0.35,
+        datetime.date(2020, 5, 18): r0
+    },
+    {  # Social Distancing
+        datetime.date(2020, 3, 23): 1.7,
+        datetime.date(2020, 6, 23): r0
+    },
+]
+
+OUTPUT_DIR = 'results/test'
+
+# Dict to transform longhand state names to abbreviations
+US_STATE_ABBREV =  {
+    'Alabama': 'AL',
+    'Alaska': 'AK',
+    'American Samoa': 'AS',
+    'Arizona': 'AZ',
+    'Arkansas': 'AR',
+    'California': 'CA',
+    'Colorado': 'CO',
+    'Connecticut': 'CT',
+    'Delaware': 'DE',
+    'District of Columbia': 'DC',
+    'Florida': 'FL',
+    'Georgia': 'GA',
+    'Guam': 'GU',
+    'Hawaii': 'HI',
+    'Idaho': 'ID',
+    'Illinois': 'IL',
+    'Indiana': 'IN',
+    'Iowa': 'IA',
+    'Kansas': 'KS',
+    'Kentucky': 'KY',
+    'Louisiana': 'LA',
+    'Maine': 'ME',
+    'Maryland': 'MD',
+    'Massachusetts': 'MA',
+    'Michigan': 'MI',
+    'Minnesota': 'MN',
+    'Mississippi': 'MS',
+    'Missouri': 'MO',
+    'Montana': 'MT',
+    'Nebraska': 'NE',
+    'Nevada': 'NV',
+    'New Hampshire': 'NH',
+    'New Jersey': 'NJ',
+    'New Mexico': 'NM',
+    'New York': 'NY',
+    'North Carolina': 'NC',
+    'North Dakota': 'ND',
+    'Northern Mariana Islands': 'MP',
+    'Ohio': 'OH',
+    'Oklahoma': 'OK',
+    'Oregon': 'OR',
+    'Pennsylvania': 'PA',
+    'Puerto Rico': 'PR',
+    'Rhode Island': 'RI',
+    'South Carolina': 'SC',
+    'South Dakota': 'SD',
+    'Tennessee': 'TN',
+    'Texas': 'TX',
+    'Utah': 'UT',
+    'Vermont': 'VT',
+    'Virgin Islands': 'VI',
+    'Virginia': 'VA',
+    'Washington': 'WA',
+    'West Virginia': 'WV',
+    'Wisconsin': 'WI',
+    'Wyoming': 'WY'
+}

--- a/run.py
+++ b/run.py
@@ -4,6 +4,7 @@ logging.basicConfig(level=logging.INFO)
 import datetime
 import time
 import simplejson
+from libs.build_params import r0, OUTPUT_DIR, INTERVENTIONS
 from libs.CovidTimeseriesModel import CovidTimeseriesModel
 from libs.CovidDatasets import CDSDataset
 
@@ -72,60 +73,6 @@ def model_state(country, state, interventions=None):
         'rolling_intervals_for_current_infected': int(round(TOTAL_INFECTED_PERIOD / MODEL_INTERVAL, 0)),
     }
     return CovidTimeseriesModel().forecast(model_parameters=MODEL_PARAMETERS)
-
-r0 = 2.4
-
-INTERVENTIONS = [
-    None,  # No Intervention
-    {  # Flatten the Curve
-        datetime.date(2020, 3, 23): 1.3,
-        datetime.date(2020, 4, 20): 1.1,
-        datetime.date(2020, 5, 22): 0.8,
-        datetime.date(2020, 6, 23): r0
-    },
-    {  # Full Containment
-        datetime.date(2020, 3, 23): 1.3,
-        datetime.date(2020, 3, 31): 0.3,
-        datetime.date(2020, 4, 28): 0.2,
-        datetime.date(2020, 5,  6): 0.1,
-        datetime.date(2020, 5, 10): 0.35,
-        datetime.date(2020, 5, 18): r0
-    },
-    {  # @TODO: Model w/ FlatteningTheCurve (2 wk delay)
-        datetime.date(2020, 3, 23): 1.3,
-        datetime.date(2020, 4, 20): 1.1,
-        datetime.date(2020, 5, 22): 0.8,
-        datetime.date(2020, 6, 23): r0
-    },
-    {  # @TODO: Model w/ FlatteningTheCurve (1 mo delay)
-        datetime.date(2020, 3, 23): 1.3,
-        datetime.date(2020, 4, 20): 1.1,
-        datetime.date(2020, 5, 22): 0.8,
-        datetime.date(2020, 6, 23): r0
-    },
-    {  # @TODO: Full Containment (1 wk dly)
-        datetime.date(2020, 3, 23): 1.3,
-        datetime.date(2020, 3, 31): 0.3,
-        datetime.date(2020, 4, 28): 0.2,
-        datetime.date(2020, 5,  6): 0.1,
-        datetime.date(2020, 5, 10): 0.35,
-        datetime.date(2020, 5, 18): r0
-    },
-    {  # @TODO: Full Containment (2 wk dly)
-        datetime.date(2020, 3, 23): 1.3,
-        datetime.date(2020, 3, 31): 0.3,
-        datetime.date(2020, 4, 28): 0.2,
-        datetime.date(2020, 5,  6): 0.1,
-        datetime.date(2020, 5, 10): 0.35,
-        datetime.date(2020, 5, 18): r0
-    },
-    {  # Social Distancing
-        datetime.date(2020, 3, 23): 1.7,
-        datetime.date(2020, 6, 23): r0
-    },
-]
-
-OUTPUT_DIR = 'results/test'
 
 if __name__ == '__main__':
     Dataset = CDSDataset()

--- a/run.py
+++ b/run.py
@@ -125,14 +125,17 @@ INTERVENTIONS = [
     },
 ]
 
-Dataset = CDSDataset()
-for state in Dataset.get_all_states_by_country('USA'):
-    for i in range(0, len(INTERVENTIONS)):
-        intervention = INTERVENTIONS[i]
-        record_results(
-            model_state('USA', state, intervention),
-            'results/test',
-            state,
-            i,
-            Dataset.get_population_by_country_state('USA', state)
-        )
+OUTPUT_DIR = 'results/test'
+
+if __name__ == '__main__':
+    Dataset = CDSDataset()
+    for state in Dataset.get_all_states_by_country('USA'):
+        for i in range(0, len(INTERVENTIONS)):
+            intervention = INTERVENTIONS[i]
+            record_results(
+                model_state('USA', state, intervention),
+                OUTPUT_DIR,
+                state,
+                i,
+                Dataset.get_population_by_country_state('USA', state)
+            )

--- a/validate.py
+++ b/validate.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 import sys
 
-import libs.build_params as build_params
+from libs import build_params
 
 def run_run_py(datasource: str) -> None:
   '''

--- a/validate.py
+++ b/validate.py
@@ -4,28 +4,33 @@ import os
 import subprocess
 import sys
 
-from run import INTERVENTIONS, OUTPUT_DIR
-from libs.CovidDatasets import us_state_abbrev
-
-STATE_COUNT = 53  # states + a few territories
+from libs.build_params import INTERVENTIONS, OUTPUT_DIR, US_STATE_ABBREV
 
 def run_run_py(datasource: str) -> None:
   '''
   Check that we successfully ran `python run.py`
   '''
-  env = dict(os.environ)
+  env = os.environ.copy()
   env['COVID_DATA_PUBLIC'] = datasource
   start = datetime.now()
-  result = subprocess.run(['python', 'run.py'], env=env, capture_output=True)
-  end = datetime.now()
   # Will raise an appropriate exception if run.py crashed
-  result.check_returncode()
+  subprocess.run(['python', 'run.py'], cwd=os.getcwd(),
+      #shell=True,
+      env=env, capture_output=True, check=True)
+  end = datetime.now()
   duration = end - start
-  print(f'duration {duration}')
+  print(f'run.py duration {duration}')
 
 def clear_result_dir(result_dir: str) -> None:
   for f in os.listdir(result_dir):
-    os.unlink(f)
+    os.unlink(os.path.join(result_dir, f))
+
+
+UNSUPPORTED_REGIONS = [
+  'AS',
+  'GU',
+  'MP'
+]
 
 def validate_results(result_dir: str) -> None:
   '''
@@ -34,7 +39,9 @@ def validate_results(result_dir: str) -> None:
   '''
   per_state_expected = len(INTERVENTIONS)
   missing_or_empty = []
-  for state in us_state_abbrev.values():
+  for state in US_STATE_ABBREV.values():
+    if state in UNSUPPORTED_REGIONS:
+      continue
     for i in range(per_state_expected):
       fname = os.path.join(result_dir, '.'.join([state, str(i), 'json']))
       try:
@@ -54,6 +61,7 @@ if __name__ == '__main__':
   parser.add_argument('-d', '--data-source', required=True, help='Path or URL to an instance of the covid-data-public repo')
 
   args = parser.parse_args()
+  clear_result_dir(OUTPUT_DIR)
   try:
     run_run_py(args.data_source)
   except subprocess.CalledProcessError as e:

--- a/validate.py
+++ b/validate.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 import sys
 
-from libs.build_params import INTERVENTIONS, OUTPUT_DIR, US_STATE_ABBREV
+import libs.build_params as build_params
 
 def run_run_py(datasource: str) -> None:
   '''
@@ -37,9 +37,9 @@ def validate_results(result_dir: str) -> None:
   For each state, check that we have a file for each intervention,
   and that the file is non-empty
   '''
-  per_state_expected = len(INTERVENTIONS)
+  per_state_expected = len(build_params.INTERVENTIONS)
   missing_or_empty = []
-  for state in US_STATE_ABBREV.values():
+  for state in build_params.US_STATE_ABBREV.values():
     if state in UNSUPPORTED_REGIONS:
       continue
     for i in range(per_state_expected):
@@ -61,11 +61,11 @@ if __name__ == '__main__':
   parser.add_argument('-d', '--data-source', required=True, help='Path or URL to an instance of the covid-data-public repo')
 
   args = parser.parse_args()
-  clear_result_dir(OUTPUT_DIR)
+  clear_result_dir(build_params.OUTPUT_DIR)
   try:
     run_run_py(args.data_source)
   except subprocess.CalledProcessError as e:
     print(f'run.py failed with code {e.returncode}')
     print(e.stderr.decode('utf-8'))
     sys.exit(e.returncode)
-  validate_results(OUTPUT_DIR)
+  validate_results(build_params.OUTPUT_DIR)

--- a/validate.py
+++ b/validate.py
@@ -1,0 +1,63 @@
+import argparse
+from datetime import datetime
+import os
+import subprocess
+import sys
+
+from run import INTERVENTIONS, OUTPUT_DIR
+from libs.CovidDatasets import us_state_abbrev
+
+STATE_COUNT = 53  # states + a few territories
+
+def run_run_py(datasource: str) -> None:
+  '''
+  Check that we successfully ran `python run.py`
+  '''
+  env = dict(os.environ)
+  env['COVID_DATA_PUBLIC'] = datasource
+  start = datetime.now()
+  result = subprocess.run(['python', 'run.py'], env=env, capture_output=True)
+  end = datetime.now()
+  # Will raise an appropriate exception if run.py crashed
+  result.check_returncode()
+  duration = end - start
+  print(f'duration {duration}')
+
+def clear_result_dir(result_dir: str) -> None:
+  for f in os.listdir(result_dir):
+    os.unlink(f)
+
+def validate_results(result_dir: str) -> None:
+  '''
+  For each state, check that we have a file for each intervention,
+  and that the file is non-empty
+  '''
+  per_state_expected = len(INTERVENTIONS)
+  missing_or_empty = []
+  for state in us_state_abbrev.values():
+    for i in range(per_state_expected):
+      fname = os.path.join(result_dir, '.'.join([state, str(i), 'json']))
+      try:
+        result = os.stat(fname)
+        if result.st_size == 0:
+          missing_or_empty.append(fname)
+      except FileNotFoundError:
+        missing_or_empty.append(fname)
+  if len(missing_or_empty) > 0:
+    raise RuntimeError(f'Missing or empty expected files: {", ".join(missing_or_empty)}')
+
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser(
+    description='Validate run.py against a dataset. For example, with a local checkout, try `python validate.py -d `pwd`/../covid-data-public`',
+  )
+  parser.add_argument('-d', '--data-source', required=True, help='Path or URL to an instance of the covid-data-public repo')
+
+  args = parser.parse_args()
+  try:
+    run_run_py(args.data_source)
+  except subprocess.CalledProcessError as e:
+    print(f'run.py failed with code {e.returncode}')
+    print(e.stderr.decode('utf-8'))
+    sys.exit(e.returncode)
+  validate_results(OUTPUT_DIR)


### PR DESCRIPTION
`validate.py` wraps a run of `run.py`, validating that `run.py` does not crash and produces the expected number of non-empty result files. 

Will need to be updated as support for additional territories are added (Guam, American Samoa, Northern Mariana Islands)