### PR TITLE
Fix errors from 'result/test' being missing.

### DIFF
--- a/run.py
+++ b/run.py
@@ -17,6 +17,7 @@ def record_results(res, directory, name, num, pop):
     # Set the population
     vals['Population'] = pop
     # Write the results to the specified directory
+    os.makedirs(directory, exist_ok=True)
     with open( os.path.join(directory, name.upper() + '.' + str(num) + '.json').format(name), 'w') as out:
         simplejson.dump(vals[[
                 'Date',

--- a/validate.py
+++ b/validate.py
@@ -22,8 +22,9 @@ def run_run_py(datasource: str) -> None:
   print(f'run.py duration {duration}')
 
 def clear_result_dir(result_dir: str) -> None:
-  for f in os.listdir(result_dir):
-    os.unlink(os.path.join(result_dir, f))
+  if os.path.exists(result_dir):
+    for f in os.listdir(result_dir):
+      os.unlink(os.path.join(result_dir, f))
 
 
 UNSUPPORTED_REGIONS = [


### PR DESCRIPTION
Fix validate to only clear the result dir if it exists, fix run.py to create the result dir if it does not exist

Fixes #47 