### PR TITLE
Add easier cli for model

### DIFF
--- a/libs/datasets/beds.py
+++ b/libs/datasets/beds.py
@@ -60,9 +60,10 @@ class BedsDataset(object):
     def get_state_level(self, state):
         aggregation_filter = self.data.aggregate_level == AggregationLevel.STATE.value
 
-        licensed_beds = self.data[(self.data.state == state) & aggregation_filter].licensed_beds
-        if len(licensed_beds):
-            return licensed_beds.iloc[0]
+        data = self.data[(self.data.state == state) & aggregation_filter]
+        beds_max = data[[self.Fields.STAFFED_BEDS, self.Fields.LICENSED_BEDS]].max(axis=1)
+        if len(beds_max):
+            return beds_max.iloc[0]
 
         return None
 
@@ -75,16 +76,13 @@ class BedsDataset(object):
 
         if fips:
             fips_filter = self.data.fips == fips
-            licensed_beds = self.data[
-                state_filter & aggregation_filter & fips_filter
-            ].licensed_beds
+            data = self.data[state_filter & aggregation_filter & fips_filter]
         else:
             county_filter = self.data.county == county
-            licensed_beds = self.data[
-                state_filter & aggregation_filter & county_filter
-            ].licensed_beds
+            data = self.data[state_filter & aggregation_filter & county_filter]
 
-        if len(licensed_beds):
-            return licensed_beds.iloc[0]
+        beds_max = data[[self.Fields.STAFFED_BEDS, self.Fields.LICENSED_BEDS]].max(axis=1)
+        if len(beds_max):
+            return beds_max.iloc[0]
 
         return None

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -69,7 +69,7 @@ class TimeseriesDataset(object):
             group = [self.Fields.COUNTRY]
 
         data = self.data[self.data[self.Fields.AGGREGATE_LEVEL] == aggregation_level.value].reset_index()
-        return data.iloc[data.groupby(group).date.idxmax(),:]
+        return data.iloc[data.groupby(group).date.idxmax(), :]
 
     def get_subset(
         self,

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ jupyter==1.0.0
 simplejson==3.17.0
 boto3==1.12.28
 seaborn==0.10.0
+click==7.1.1

--- a/run.py
+++ b/run.py
@@ -381,7 +381,7 @@ def run_state_level_forecast(
     timeseries = timeseries.get_subset(
         AggregationLevel.STATE, after=min_date, country=country, state=state
     )
-    output_dir = pathlib.Path(OUTPUT_DIR) / "state"
+    output_dir = pathlib.Path(OUTPUT_DIR)
     if output_dir.exists() and not state:
         backup = output_dir.name + "." + str(int(time.time()))
         output_dir.rename(output_dir.parent / backup)

--- a/run.py
+++ b/run.py
@@ -204,7 +204,7 @@ def model_state(timeseries, population, starting_beds, interventions=None):
     return results
 
 
-def build_county_summary(country="USA", state=None):
+def build_county_summary(country="USA", state=None, output_dir=OUTPUT_DIR):
     """Builds county summary json files."""
     beds_data = DHBeds.local().beds()
     population_data = FIPSPopulation.local().population()
@@ -213,7 +213,7 @@ def build_county_summary(country="USA", state=None):
         AggregationLevel.COUNTY, after=min_date, country=country, state=state
     )
 
-    output_dir = pathlib.Path(OUTPUT_DIR) / "county_summaries"
+    output_dir = pathlib.Path(output_dir) / "county_summaries"
     _logger.info(f"Outputting to {output_dir}")
     if not output_dir.exists():
         _logger.info(f"{output_dir} does not exist, creating")
@@ -283,7 +283,6 @@ def forecast_each_county(
     cases = timeseries.get_data(state=state, country=country, fips=fips)
     beds = beds_data.get_county_level(state, fips=fips)
     population = population_data.get_county_level(country, state, fips=fips)
-
     total_cases = sum(cases.cases)
     if not population or not beds or not total_cases:
         _logger.debug(
@@ -303,7 +302,9 @@ def forecast_each_county(
         write_results(website_data, output_dir, f"{state}.{fips}.{i}.json")
 
 
-def run_county_level_forecast(min_date, max_date, country="USA", state=None):
+def run_county_level_forecast(
+    min_date, max_date, country="USA", state=None, output_dir=OUTPUT_DIR
+):
     beds_data = DHBeds.local().beds()
     population_data = FIPSPopulation.local().population()
     timeseries = JHUDataset.local().timeseries()
@@ -311,7 +312,7 @@ def run_county_level_forecast(min_date, max_date, country="USA", state=None):
         AggregationLevel.COUNTY, after=min_date, country=country, state=state
     )
 
-    output_dir = pathlib.Path(OUTPUT_DIR) / "county"
+    output_dir = pathlib.Path(output_dir) / "county"
     _logger.info(f"Outputting to {output_dir}")
     if output_dir.exists():
         backup = output_dir.name + "." + str(int(time.time()))
@@ -344,7 +345,9 @@ def run_county_level_forecast(min_date, max_date, country="USA", state=None):
     pool.join()
 
 
-def run_state_level_forecast(min_date, max_date, country="USA", state=None):
+def run_state_level_forecast(
+    min_date, max_date, country="USA", state=None, output_dir=OUTPUT_DIR
+):
     # DH Beds dataset does not have all counties, so using the legacy state
     # level bed data.
     legacy_dataset = LegacyJHUDataset(min_date)

--- a/run_model.py
+++ b/run_model.py
@@ -5,7 +5,7 @@ import logging
 import click
 from libs import build_params
 import run
-
+print(run)
 WEB_DEPLOY_PATH = "../covid-projections/public/data"
 
 
@@ -33,7 +33,7 @@ def run_county(state=None, deploy=False):
     run.run_county_level_forecast(
         min_date, max_date, country="USA", state=state, output_dir=output_dir
     )
-    run.build_county_summary()
+    run.build_county_summary(min_date, state=state, output_dir=output_dir)
 
 
 @main.command("state")

--- a/run_model.py
+++ b/run_model.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+import datetime
+import logging
+import click
+from libs import build_params
+import run
+
+WEB_DEPLOY_PATH = "../covid-projections/public/data"
+
+
+@click.group()
+def main():
+    pass
+
+
+@main.command("county")
+@click.option("--state", "-s")
+@click.option(
+    "--deploy",
+    is_flag=True,
+    help="Output data files to public data directory in local covid-projections.",
+)
+def run_county(state=None, deploy=False):
+    """Run county level model."""
+    min_date = datetime.datetime(2020, 3, 7)
+    max_date = datetime.datetime(2020, 7, 6)
+
+    output_dir = build_params.OUTPUT_DIR
+    if deploy:
+        output_dir = WEB_DEPLOY_PATH
+
+    run.run_county_level_forecast(
+        min_date, max_date, country="USA", state=state, output_dir=output_dir
+    )
+    run.build_county_summary()
+
+
+@main.command("state")
+@click.option("--state", "-s")
+@click.option(
+    "--deploy",
+    is_flag=True,
+    help="Output data files to public data directory in local covid-projections.",
+)
+def run_state(state=None, deploy=False):
+    """Run State level model."""
+    min_date = datetime.datetime(2020, 3, 7)
+    max_date = datetime.datetime(2020, 7, 6)
+
+    output_dir = build_params.OUTPUT_DIR
+    if deploy:
+        output_dir = WEB_DEPLOY_PATH
+
+    run.run_county_level_forecast(
+        min_date, max_date, country="USA", state=state, output_dir=output_dir
+    )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/run_model.py
+++ b/run_model.py
@@ -52,7 +52,7 @@ def run_state(state=None, deploy=False):
     if deploy:
         output_dir = WEB_DEPLOY_PATH
 
-    run.run_county_level_forecast(
+    run.run_state_level_forecast(
         min_date, max_date, country="USA", state=state, output_dir=output_dir
     )
 


### PR DESCRIPTION
This adds a more direct cli - couple advantages:
 1. Can choose if you want to run the county or state model.
 2. Can pass `--deploy` flag which will save files to the public data directory in `covid-projections`
 3. You can choose a specific state to run on

example:
```
./run_model.py state --deploy
```