### PR TITLE
Adding in a max_bed_count column + simple tests on beds dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ results/*.csv
 results/*.json
 results/test/*.csv
 results/test/*.json
-results/test.*/county
+results/test.*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/libs/datasets/beds.py
+++ b/libs/datasets/beds.py
@@ -1,7 +1,5 @@
-from typing import List, Iterator
-import enum
+from typing import Optional
 import pandas as pd
-import datetime
 from libs.datasets import dataset_utils
 from libs.datasets.dataset_utils import AggregationLevel
 from libs.datasets import custom_aggregations
@@ -9,6 +7,7 @@ from libs.datasets import custom_aggregations
 
 class BedsDataset(object):
     class Fields(object):
+        COUNTRY = "country"
         STATE = "state"
         FIPS = "fips"
         STAFFED_BEDS = "staffed_beds"
@@ -16,13 +15,44 @@ class BedsDataset(object):
         ICU_BEDS = "icu_beds"
         AGGREGATE_LEVEL = "aggregate_level"
 
-        # Fields generated in `from_source`
         COUNTY = "county"
         SOURCE = "source"
         GENERATED = "generated"
+        # Combined beds are the max of staffed and licensed beds.
+        # The need for this may be dataset specific, but there are cases in the
+        # DH Beds dataset where a source only has either staffed or licensed.
+        # To provide a better best guess, we take the max of the two in `from_source`.
+        MAX_BED_COUNT = "max_bed_count"
+
+    # Key for grouping data at the state level.
+    # This includes other keys that should be preserved - for example, this will preserve
+    # the source field during a groupby.
+    STATE_GROUP_KEY = [
+        Fields.SOURCE,
+        Fields.AGGREGATE_LEVEL,
+        Fields.GENERATED,
+        Fields.COUNTRY,
+        Fields.STATE,
+    ]
 
     def __init__(self, data):
         self.data = data
+
+    @property
+    def state_data(self) -> pd.DataFrame:
+        """Returns a new BedsDataset containing only state data."""
+        is_state = (
+            self.data[self.Fields.AGGREGATE_LEVEL] == AggregationLevel.STATE.value
+        )
+        return self.data[is_state]
+
+    @property
+    def county_data(self) -> pd.DataFrame:
+        """Returns a new BedsDataset containing only county data."""
+        is_county = (
+            self.data[self.Fields.AGGREGATE_LEVEL] == AggregationLevel.COUNTY.value
+        )
+        return self.data[is_county]
 
     @classmethod
     def from_source(cls, source: "DataSource", fill_missing_state=True):
@@ -30,27 +60,31 @@ class BedsDataset(object):
 
         Remaps columns from source dataset, fills in missing data
         by computing aggregates, and adds standardized county names from fips.
+
+        Args:
+            source: Data source.
+            fill_missing_state: If True, fills in missing state level data by
+                aggregating county level for a given state.
         """
         if not source.BEDS_FIELD_MAP:
             raise ValueError("Source must have beds field map.")
 
         data = source.data
+
         to_common_fields = {value: key for key, value in source.BEDS_FIELD_MAP.items()}
         final_columns = to_common_fields.values()
         data = data.rename(columns=to_common_fields)[final_columns]
         data[cls.Fields.SOURCE] = source.SOURCE_NAME
         data[cls.Fields.GENERATED] = False
 
-        group = [cls.Fields.SOURCE, cls.Fields.AGGREGATE_LEVEL, cls.Fields.STATE, cls.Fields.GENERATED]
-        data = custom_aggregations.update_with_combined_new_york_counties(
-            data, group, are_boroughs_zero=False
-        )
+        # Generating max bed count.
+        columns_to_consider = [cls.Fields.STAFFED_BEDS, cls.Fields.LICENSED_BEDS]
+        data[cls.Fields.MAX_BED_COUNT] = data[columns_to_consider].max(axis=1)
 
         if fill_missing_state:
-            state_groupby_fields = [cls.Fields.SOURCE, cls.Fields.STATE]
             non_matching = dataset_utils.aggregate_and_get_nonmatching(
                 data,
-                state_groupby_fields,
+                cls.STATE_GROUP_KEY,
                 AggregationLevel.COUNTY,
                 AggregationLevel.STATE,
             ).reset_index()
@@ -63,32 +97,43 @@ class BedsDataset(object):
 
         return cls(data)
 
-    def get_state_level(self, state):
-        aggregation_filter = self.data.aggregate_level == AggregationLevel.STATE.value
+    def get_state_level(self, state) -> Optional[int]:
+        """Get beds for a specific state.
 
-        data = self.data[(self.data.state == state) & aggregation_filter]
-        beds_max = data[[self.Fields.STAFFED_BEDS, self.Fields.LICENSED_BEDS]].max(axis=1)
-        if len(beds_max):
-            return beds_max.iloc[0]
+        Args:
+            state: State to query.
 
+        Returns: Beds for a state.
+        """
+        state_filter = self.state_data.state == state
+        beds = self.state_data[state_filter]
+
+        if len(beds):
+            return beds.iloc[0][self.Fields.MAX_BED_COUNT]
         return None
 
-    def get_county_level(self, state, county=None, fips=None):
+    def get_county_level(self, state, county=None, fips=None) -> Optional[int]:
+        """Get beds for a specific county (from fips code or county).
+
+        Args:
+            state: State to query
+            county: Optional name of county.
+            fips: Optional fips code.
+
+        Returns: Beds for a county.
+        """
         if not (county or fips) or (county and fips):
             raise ValueError("Must only pass fips or county")
 
-        aggregation_filter = self.data.aggregate_level == AggregationLevel.COUNTY.value
-        state_filter = self.data.state == state
-
+        data = self.county_data
+        state_filter = data.state == state
         if fips:
-            fips_filter = self.data.fips == fips
-            data = self.data[state_filter & aggregation_filter & fips_filter]
-        else:
-            county_filter = self.data.county == county
-            data = self.data[state_filter & aggregation_filter & county_filter]
+            location_filter = data.fips == fips
+        elif county:
+            location_filter = data.county == county
 
-        beds_max = data[[self.Fields.STAFFED_BEDS, self.Fields.LICENSED_BEDS]].max(axis=1)
-        if len(beds_max):
-            return beds_max.iloc[0]
+        beds = data[state_filter & location_filter]
+        if len(beds):
+            return beds.iloc[0][self.Fields.MAX_BED_COUNT]
 
         return None

--- a/libs/datasets/data_version.py
+++ b/libs/datasets/data_version.py
@@ -1,0 +1,102 @@
+import click
+from contextlib import contextmanager
+from datetime import datetime
+import git
+import json
+import logging
+import os
+import pytz
+from typing import Optional
+
+from .dataset_utils import LOCAL_PUBLIC_DATA_PATH
+
+
+_logger = logging.getLogger(__name__)
+
+class DataVersion(object):
+    '''
+    Encapsulates some state about the source data with the
+    intention of using this information to make results
+    reproducible or comparable against new methods acting on
+    consistent data snapshots.
+    '''
+    def __init__(self, git_hash: str, is_dirty: bool):
+        self.git_hash = git_hash
+        self.is_dirty = is_dirty
+        self.now = datetime.utcnow().replace(tzinfo=pytz.utc)
+
+    def write_file(self, data_type: str, output_dir: str):
+        filename = os.path.join(output_dir, f'{data_type}.version.json')
+        with open(filename, 'w') as f:
+            json.dump({
+                'when': str(self.now),
+                'gitHash': self.git_hash,
+                'dirty': self.is_dirty
+            }, f)
+
+
+@contextmanager
+def _repo_at_hash(repo: git.Repo, git_hash: str):
+    # HEAD is a symbolic reference, grab what it points to
+    previous_head = repo.head.ref
+    # Jump to a detached head referencing the commit passed in
+    repo.head.set_reference(git_hash)
+    repo.head.reset(index=True, working_tree=True)
+    # this translates to calling `git lfs fetch` directly on the repo
+    # See: https://gitpython.readthedocs.io/en/stable/tutorial.html#using-git-directly
+    repo.git.lfs('fetch')
+    yield
+    # Reset to whatever was previously checked out
+    previous_head.checkout()
+
+@contextmanager
+def public_data_hash(git_hash: Optional[str]):
+    '''
+    If given a git hash, attempts to set the local covid-data-public
+    repository to the given hash. Yields the git hash so that it can
+    be recorded along with the data generated.
+    '''
+    if git_hash is not None:
+        repo = git.Repo(LOCAL_PUBLIC_DATA_PATH)
+        if repo.is_dirty():
+            raise RuntimeError('Cannot set covid-data-public repo hash, working tree is dirty')
+        _logger.info(f'Using git hash {git_hash}')
+        with _repo_at_hash(repo, git_hash):
+            yield git_hash
+    else:
+        yield git_hash
+
+@contextmanager
+def data_version(git_hash: Optional[str]):
+    # Handle legacy datasets
+    os.environ['COVID_DATA_PUBLIC'] = str(LOCAL_PUBLIC_DATA_PATH)
+    repo = git.Repo(str(LOCAL_PUBLIC_DATA_PATH))
+    is_dirty = repo.is_dirty()
+    if git_hash:
+        if is_dirty:
+            raise RuntimeError('Cannot set covid-data-public repo hash, working tree is dirty')
+        with _repo_at_hash(repo, git_hash):
+            logging.info(f'Using covid-data-public at version {git_hash}')
+            yield DataVersion(git_hash, is_dirty)
+    else:
+        git_hash = repo.head.ref.commit.hexsha
+        logging.info(f'Using covid-data-public at version {"*" if is_dirty else ""}{git_hash}')
+        yield DataVersion(git_hash, is_dirty)
+
+
+def with_git_version_click_option(func):
+    """Adds an additional git-hash option and loads the repo at the specified hash."""
+
+    @click.option(
+        '--git-hash',
+        type=str,
+        help='''
+        | Git hash of the commit in covid-data-public to use.
+        | If provided, covid-data-public must have no pending changes.
+        | If omitted, the repository will be used as-is'''
+    )
+    def run_in_context(git_hash, **kwargs):
+        with data_version(git_hash) as version:
+            return func(version=version, **kwargs)
+
+    return run_in_context

--- a/libs/datasets/dataset_utils.py
+++ b/libs/datasets/dataset_utils.py
@@ -1,10 +1,7 @@
-from contextlib import contextmanager
 import enum
-import git
 import logging
 import pathlib
 import pandas as pd
-from typing import Optional
 from libs import build_params
 
 LOCAL_PUBLIC_DATA_PATH = (
@@ -12,30 +9,6 @@ LOCAL_PUBLIC_DATA_PATH = (
 )
 
 _logger = logging.getLogger(__name__)
-
-@contextmanager
-def public_data_hash(git_hash: Optional[str]):
-    '''
-    If given a git hash, attempts to set the local covid-data-public
-    repository to the given hash. Yields the git hash so that it can
-    be recorded along with the data generated.
-    '''
-    if git_hash is not None:
-        repo = git.Repo(LOCAL_PUBLIC_DATA_PATH)
-        if repo.is_dirty():
-            raise RuntimeError('Cannot set covid-data-public repo hash, working tree is dirty')
-        _logger.info(f'Using git hash {git_hash}')
-        # HEAD is a symbolic reference, grab what it points to
-        previous_head = repo.head.ref
-        # Jump to a detached head referencing the commit passed in
-        repo.head.set_reference(git_hash)
-        repo.head.reset(index=True, working_tree=True)
-        yield git_hash
-        # Reset to whatever was previously checked out
-        previous_head.checkout()
-    else:
-        yield git_hash
-
 
 class AggregationLevel(enum.Enum):
     COUNTRY = "country"

--- a/libs/datasets/sources/dh_beds.py
+++ b/libs/datasets/sources/dh_beds.py
@@ -114,8 +114,10 @@ class DHBeds(data_source.DataSource):
         # Added in standardize data.
         AGGREGATE_LEVEL = "aggregate_level"
         FIPS = "fips"
+        COUNTRY = "country"
 
     BEDS_FIELD_MAP = {
+        BedsDataset.Fields.COUNTRY: Fields.COUNTRY,
         BedsDataset.Fields.STATE: Fields.STATE,
         BedsDataset.Fields.FIPS: Fields.FIPS,
         BedsDataset.Fields.STAFFED_BEDS: Fields.STAFFED_BEDS,
@@ -132,6 +134,8 @@ class DHBeds(data_source.DataSource):
     def standardize_data(cls, data: pd.DataFrame) -> pd.DataFrame:
         # All DH data is aggregated at the county level
         data[cls.Fields.AGGREGATE_LEVEL] = "county"
+
+        data[cls.Fields.COUNTRY] = "USA"
 
         # Backfilling FIPS data based on county names.
         # TODO: Fix all missing cases

--- a/run.py
+++ b/run.py
@@ -16,7 +16,8 @@ from libs.build_params import OUTPUT_DIR, get_interventions
 from libs.datasets import JHUDataset
 from libs.datasets import FIPSPopulation
 from libs.datasets import DHBeds
-from libs.datasets.dataset_utils import AggregationLevel, public_data_hash
+from libs.datasets.dataset_utils import AggregationLevel
+from libs.datasets.data_version import public_data_hash
 
 _logger = logging.getLogger(__name__)
 

--- a/run_model.py
+++ b/run_model.py
@@ -4,10 +4,13 @@ import datetime
 import logging
 import click
 from libs import build_params
+from libs.datasets import data_version
+from libs.datasets import dataset_utils
 import run
-print(run)
+
 WEB_DEPLOY_PATH = "../covid-projections/public/data"
 
+_logger = logging.getLogger(__name__)
 
 @click.group()
 def main():
@@ -26,7 +29,8 @@ def main():
     is_flag=True,
     help="Only runs the county summary if true.",
 )
-def run_county(state=None, deploy=False, summary_only=False):
+@data_version.with_git_version_click_option
+def run_county(version: data_version.DataVersion, state=None, deploy=False, summary_only=False):
     """Run county level model."""
     min_date = datetime.datetime(2020, 3, 7)
     max_date = datetime.datetime(2020, 7, 6)
@@ -40,6 +44,11 @@ def run_county(state=None, deploy=False, summary_only=False):
             min_date, max_date, country="USA", state=state, output_dir=output_dir
         )
     run.build_county_summary(min_date, state=state, output_dir=output_dir)
+    # only write the version if we saved everything
+    if state is None and not summary_only:
+        version.write_file('counties', output_dir)
+    else:
+        _logger.info('Skip version file because this is not a full run')
 
 
 @main.command("state")
@@ -49,7 +58,8 @@ def run_county(state=None, deploy=False, summary_only=False):
     is_flag=True,
     help="Output data files to public data directory in local covid-projections.",
 )
-def run_state(state=None, deploy=False):
+@data_version.with_git_version_click_option
+def run_state(version: data_version.DataVersion, state=None, deploy=False):
     """Run State level model."""
     min_date = datetime.datetime(2020, 3, 7)
     max_date = datetime.datetime(2020, 7, 6)
@@ -61,6 +71,12 @@ def run_state(state=None, deploy=False):
     run.run_state_level_forecast(
         min_date, max_date, country="USA", state=state, output_dir=output_dir
     )
+    _logger.info(f'Wrote output to {output_dir}')
+    # only write the version if we saved everything
+    if state is None :
+        version.write_file('states', output_dir)
+    else:
+        _logger.info('Skip version file because this is not a full run')
 
 
 if __name__ == "__main__":

--- a/test/beds_dataset_test.py
+++ b/test/beds_dataset_test.py
@@ -12,8 +12,9 @@ def generate_state_bed_row(**updates):
         "aggregate_level": "state",
         "source": "DH",
         "generated": True,
-        "model_input_beds": 21480,
+        "max_bed_count": 21480,
         "county": None,
+        "country": "USA",
     }
     record.update(**updates)
     return record
@@ -29,8 +30,9 @@ def generate_county_bed_row(**updates):
         "aggregate_level": "county",
         "source": "DH",
         "generated": False,
-        "model_input_beds": 4474,
+        "max_bed_count": 4474,
         "county": "Middlesex County",
+        "country": "USA",
     }
     record.update(**updates)
     return record
@@ -45,8 +47,8 @@ def test_get_county_level_beds():
     fips = "25015"
     county = "County in Mass"
     rows = [
-        generate_county_bed_row(fips="25016", county=county, model_input_beds=3000),
-        generate_county_bed_row(fips=fips, model_input_beds=1000),
+        generate_county_bed_row(fips="25016", county=county, max_bed_count=3000),
+        generate_county_bed_row(fips=fips, max_bed_count=1000),
         generate_state_bed_row(),
     ]
     beds_dataset = build_beds_dataset(rows)
@@ -63,9 +65,9 @@ def test_get_county_level_beds():
 
 def test_get_state_level_beds():
     rows = [
-        generate_county_bed_row(model_input_beds=2000),
-        generate_state_bed_row(model_input_beds=1000),
-        generate_state_bed_row(state="CA", model_input_beds=2000),
+        generate_county_bed_row(max_bed_count=2000),
+        generate_state_bed_row(max_bed_count=1000),
+        generate_state_bed_row(state="CA", max_bed_count=2000),
     ]
     beds_dataset = build_beds_dataset(rows)
 

--- a/test/beds_dataset_test.py
+++ b/test/beds_dataset_test.py
@@ -1,0 +1,75 @@
+import pandas as pd
+from libs.datasets import beds
+
+
+def generate_state_bed_row(**updates):
+    record = {
+        "fips": None,
+        "state": "MA",
+        "staffed_beds": 21374,
+        "licensed_beds": 18280,
+        "icu_beds": 1223,
+        "aggregate_level": "state",
+        "source": "DH",
+        "generated": True,
+        "model_input_beds": 21480,
+        "county": None,
+    }
+    record.update(**updates)
+    return record
+
+
+def generate_county_bed_row(**updates):
+    record = {
+        "fips": "25017",
+        "state": "MA",
+        "staffed_beds": 4474,
+        "licensed_beds": 3756,
+        "icu_beds": 206,
+        "aggregate_level": "county",
+        "source": "DH",
+        "generated": False,
+        "model_input_beds": 4474,
+        "county": "Middlesex County",
+    }
+    record.update(**updates)
+    return record
+
+
+def build_beds_dataset(rows):
+    data = pd.DataFrame(rows)
+    return beds.BedsDataset(data)
+
+
+def test_get_county_level_beds():
+    fips = "25015"
+    county = "County in Mass"
+    rows = [
+        generate_county_bed_row(fips="25016", county=county, model_input_beds=3000),
+        generate_county_bed_row(fips=fips, model_input_beds=1000),
+        generate_state_bed_row(),
+    ]
+    beds_dataset = build_beds_dataset(rows)
+
+    county_beds = beds_dataset.get_county_level("MA", county=county)
+    assert county_beds == 3000
+
+    county_beds = beds_dataset.get_county_level("MA", fips=fips)
+    assert county_beds == 1000
+
+    county_beds = beds_dataset.get_county_level("MA", fips="random")
+    assert not county_beds
+
+
+def test_get_state_level_beds():
+    rows = [
+        generate_county_bed_row(model_input_beds=2000),
+        generate_state_bed_row(model_input_beds=1000),
+        generate_state_bed_row(state="CA", model_input_beds=2000),
+    ]
+    beds_dataset = build_beds_dataset(rows)
+
+    state_beds = beds_dataset.get_state_level("MA")
+    assert state_beds == 1000
+
+    assert not beds_dataset.get_state_level("DC")


### PR DESCRIPTION
Moved the logic for choosing a bed count from querying functions to the initial data initialization.

Did this to:
 * make it easier to join on other datasets and not have to work to come up with the correct beds number.
 * Reduce touch points for the max calculation.

Also adds in the ability to quickly query just state or county level data. 