### PR TITLE
Add git hash support to run_model.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ results/*.csv
 results/*.json
 results/test/*.csv
 results/test/*.json
-results/test.*/county
+results/test.*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/libs/datasets/data_version.py
+++ b/libs/datasets/data_version.py
@@ -1,0 +1,102 @@
+import click
+from contextlib import contextmanager
+from datetime import datetime
+import git
+import json
+import logging
+import os
+import pytz
+from typing import Optional
+
+from .dataset_utils import LOCAL_PUBLIC_DATA_PATH
+
+
+_logger = logging.getLogger(__name__)
+
+class DataVersion(object):
+    '''
+    Encapsulates some state about the source data with the
+    intention of using this information to make results
+    reproducible or comparable against new methods acting on
+    consistent data snapshots.
+    '''
+    def __init__(self, git_hash: str, is_dirty: bool):
+        self.git_hash = git_hash
+        self.is_dirty = is_dirty
+        self.now = datetime.utcnow().replace(tzinfo=pytz.utc)
+
+    def write_file(self, data_type: str, output_dir: str):
+        filename = os.path.join(output_dir, f'{data_type}.version.json')
+        with open(filename, 'w') as f:
+            json.dump({
+                'when': str(self.now),
+                'gitHash': self.git_hash,
+                'dirty': self.is_dirty
+            }, f)
+
+
+@contextmanager
+def _repo_at_hash(repo: git.Repo, git_hash: str):
+    # HEAD is a symbolic reference, grab what it points to
+    previous_head = repo.head.ref
+    # Jump to a detached head referencing the commit passed in
+    repo.head.set_reference(git_hash)
+    repo.head.reset(index=True, working_tree=True)
+    # this translates to calling `git lfs fetch` directly on the repo
+    # See: https://gitpython.readthedocs.io/en/stable/tutorial.html#using-git-directly
+    repo.git.lfs('fetch')
+    yield
+    # Reset to whatever was previously checked out
+    previous_head.checkout()
+
+@contextmanager
+def public_data_hash(git_hash: Optional[str]):
+    '''
+    If given a git hash, attempts to set the local covid-data-public
+    repository to the given hash. Yields the git hash so that it can
+    be recorded along with the data generated.
+    '''
+    if git_hash is not None:
+        repo = git.Repo(LOCAL_PUBLIC_DATA_PATH)
+        if repo.is_dirty():
+            raise RuntimeError('Cannot set covid-data-public repo hash, working tree is dirty')
+        _logger.info(f'Using git hash {git_hash}')
+        with _repo_at_hash(repo, git_hash):
+            yield git_hash
+    else:
+        yield git_hash
+
+@contextmanager
+def data_version(git_hash: Optional[str]):
+    # Handle legacy datasets
+    os.environ['COVID_DATA_PUBLIC'] = str(LOCAL_PUBLIC_DATA_PATH)
+    repo = git.Repo(str(LOCAL_PUBLIC_DATA_PATH))
+    is_dirty = repo.is_dirty()
+    if git_hash:
+        if is_dirty:
+            raise RuntimeError('Cannot set covid-data-public repo hash, working tree is dirty')
+        with _repo_at_hash(repo, git_hash):
+            logging.info(f'Using covid-data-public at version {git_hash}')
+            yield DataVersion(git_hash, is_dirty)
+    else:
+        git_hash = repo.head.ref.commit.hexsha
+        logging.info(f'Using covid-data-public at version {"*" if is_dirty else ""}{git_hash}')
+        yield DataVersion(git_hash, is_dirty)
+
+
+def with_git_version_click_option(func):
+    """Adds an additional git-hash option and loads the repo at the specified hash."""
+
+    @click.option(
+        '--git-hash',
+        type=str,
+        help='''
+        | Git hash of the commit in covid-data-public to use.
+        | If provided, covid-data-public must have no pending changes.
+        | If omitted, the repository will be used as-is'''
+    )
+    def run_in_context(git_hash, **kwargs):
+        with data_version(git_hash) as version:
+            return func(version=version, **kwargs)
+
+    return run_in_context

--- a/libs/datasets/dataset_utils.py
+++ b/libs/datasets/dataset_utils.py
@@ -1,9 +1,13 @@
 from contextlib import contextmanager
+from datetime import datetime
 import enum
 import git
+import json
 import logging
+import os
 import pathlib
 import pandas as pd
+import pytz
 from typing import Optional
 from libs import build_params
 
@@ -12,6 +16,42 @@ LOCAL_PUBLIC_DATA_PATH = (
 )
 
 _logger = logging.getLogger(__name__)
+
+class DataVersion(object):
+    '''
+    Encapsulates some state about the source data with the
+    intention of using this information to make results
+    reproducible or comparable against new methods acting on
+    consistent data snapshots.
+    '''
+    def __init__(self, git_hash: str, is_dirty: bool):
+        self.git_hash = git_hash
+        self.is_dirty = is_dirty
+        self.now = datetime.utcnow().replace(tzinfo=pytz.utc)
+
+    def write_file(self, data_type: str, output_dir: str):
+        filename = os.path.join(output_dir, f'{data_type}.version.json')
+        with open(filename, 'w') as f:
+            json.dump({
+                'when': str(self.now),
+                'gitHash': self.git_hash,
+                'dirty': self.is_dirty
+            }, f)
+
+
+@contextmanager
+def _repo_at_hash(repo: git.Repo, git_hash: str):
+    # HEAD is a symbolic reference, grab what it points to
+    previous_head = repo.head.ref
+    # Jump to a detached head referencing the commit passed in
+    repo.head.set_reference(git_hash)
+    repo.head.reset(index=True, working_tree=True)
+    # this translates to calling `git lfs fetch` directly on the repo
+    # See: https://gitpython.readthedocs.io/en/stable/tutorial.html#using-git-directly
+    repo.git.lfs('fetch')
+    yield
+    # Reset to whatever was previously checked out
+    previous_head.checkout()
 
 @contextmanager
 def public_data_hash(git_hash: Optional[str]):
@@ -25,17 +65,27 @@ def public_data_hash(git_hash: Optional[str]):
         if repo.is_dirty():
             raise RuntimeError('Cannot set covid-data-public repo hash, working tree is dirty')
         _logger.info(f'Using git hash {git_hash}')
-        # HEAD is a symbolic reference, grab what it points to
-        previous_head = repo.head.ref
-        # Jump to a detached head referencing the commit passed in
-        repo.head.set_reference(git_hash)
-        repo.head.reset(index=True, working_tree=True)
-        yield git_hash
-        # Reset to whatever was previously checked out
-        previous_head.checkout()
+        with _repo_at_hash(repo, git_hash):
+            yield git_hash
     else:
         yield git_hash
 
+@contextmanager
+def data_version(git_hash: Optional[str]):
+    # Handle legacy datasets
+    os.environ['COVID_DATA_PUBLIC'] = str(LOCAL_PUBLIC_DATA_PATH)
+    repo = git.Repo(str(LOCAL_PUBLIC_DATA_PATH))
+    is_dirty = repo.is_dirty()
+    if git_hash:
+        if is_dirty:
+            raise RuntimeError('Cannot set covid-data-public repo hash, working tree is dirty')
+        with _repo_at_hash(repo, git_hash):
+            logging.info(f'Using covid-data-public at version {git_hash}')
+            yield DataVersion(git_hash, is_dirty)
+    else:
+        git_hash = repo.head.ref.commit.hexsha
+        logging.info(f'Using covid-data-public at version {"*" if is_dirty else ""}{git_hash}')
+        yield DataVersion(git_hash, is_dirty)
 
 class AggregationLevel(enum.Enum):
     COUNTRY = "country"

--- a/libs/datasets/dataset_utils.py
+++ b/libs/datasets/dataset_utils.py
@@ -1,15 +1,7 @@
-from contextlib import contextmanager
-from datetime import datetime
-import click
 import enum
-import git
-import json
 import logging
-import os
 import pathlib
 import pandas as pd
-import pytz
-from typing import Optional
 from libs import build_params
 
 LOCAL_PUBLIC_DATA_PATH = (
@@ -17,96 +9,6 @@ LOCAL_PUBLIC_DATA_PATH = (
 )
 
 _logger = logging.getLogger(__name__)
-
-
-class DataVersion(object):
-    '''
-    Encapsulates some state about the source data with the
-    intention of using this information to make results
-    reproducible or comparable against new methods acting on
-    consistent data snapshots.
-    '''
-    def __init__(self, git_hash: str, is_dirty: bool):
-        self.git_hash = git_hash
-        self.is_dirty = is_dirty
-        self.now = datetime.utcnow().replace(tzinfo=pytz.utc)
-
-    def write_file(self, data_type: str, output_dir: str):
-        filename = os.path.join(output_dir, f'{data_type}.version.json')
-        with open(filename, 'w') as f:
-            json.dump({
-                'when': str(self.now),
-                'gitHash': self.git_hash,
-                'dirty': self.is_dirty
-            }, f)
-
-
-@contextmanager
-def _repo_at_hash(repo: git.Repo, git_hash: str):
-    # HEAD is a symbolic reference, grab what it points to
-    previous_head = repo.head.ref
-    # Jump to a detached head referencing the commit passed in
-    repo.head.set_reference(git_hash)
-    repo.head.reset(index=True, working_tree=True)
-    # this translates to calling `git lfs fetch` directly on the repo
-    # See: https://gitpython.readthedocs.io/en/stable/tutorial.html#using-git-directly
-    repo.git.lfs('fetch')
-    yield
-    # Reset to whatever was previously checked out
-    previous_head.checkout()
-
-@contextmanager
-def public_data_hash(git_hash: Optional[str]):
-    '''
-    If given a git hash, attempts to set the local covid-data-public
-    repository to the given hash. Yields the git hash so that it can
-    be recorded along with the data generated.
-    '''
-    if git_hash is not None:
-        repo = git.Repo(LOCAL_PUBLIC_DATA_PATH)
-        if repo.is_dirty():
-            raise RuntimeError('Cannot set covid-data-public repo hash, working tree is dirty')
-        _logger.info(f'Using git hash {git_hash}')
-        with _repo_at_hash(repo, git_hash):
-            yield git_hash
-    else:
-        yield git_hash
-
-@contextmanager
-def data_version(git_hash: Optional[str]):
-    # Handle legacy datasets
-    os.environ['COVID_DATA_PUBLIC'] = str(LOCAL_PUBLIC_DATA_PATH)
-    repo = git.Repo(str(LOCAL_PUBLIC_DATA_PATH))
-    is_dirty = repo.is_dirty()
-    if git_hash:
-        if is_dirty:
-            raise RuntimeError('Cannot set covid-data-public repo hash, working tree is dirty')
-        with _repo_at_hash(repo, git_hash):
-            logging.info(f'Using covid-data-public at version {git_hash}')
-            yield DataVersion(git_hash, is_dirty)
-    else:
-        git_hash = repo.head.ref.commit.hexsha
-        logging.info(f'Using covid-data-public at version {"*" if is_dirty else ""}{git_hash}')
-        yield DataVersion(git_hash, is_dirty)
-
-
-def with_git_version_click_option(func):
-    """Adds an additional git-hash option and loads the repo at the specified hash."""
-
-    @click.option(
-        '--git-hash',
-        type=str,
-        help='''
-        | Git hash of the commit in covid-data-public to use.
-        | If provided, covid-data-public must have no pending changes.
-        | If omitted, the repository will be used as-is'''
-    )
-    def run_in_context(git_hash, **kwargs):
-        with data_version(git_hash) as version:
-            return func(version=version, **kwargs)
-
-    return run_in_context
-
 
 class AggregationLevel(enum.Enum):
     COUNTRY = "country"

--- a/run.py
+++ b/run.py
@@ -16,7 +16,8 @@ from libs.build_params import OUTPUT_DIR, get_interventions
 from libs.datasets import JHUDataset
 from libs.datasets import FIPSPopulation
 from libs.datasets import DHBeds
-from libs.datasets.dataset_utils import AggregationLevel, public_data_hash
+from libs.datasets.dataset_utils import AggregationLevel
+from libs.datasets.data_version import public_data_hash
 
 _logger = logging.getLogger(__name__)
 

--- a/run_model.py
+++ b/run_model.py
@@ -29,7 +29,7 @@ def main():
     help="Only runs the county summary if true.",
 )
 @data_version.with_git_version_click_option
-def run_county(state=None, deploy=False, summary_only=False, version=None):
+def run_county(version: data_version.DataVersion, state=None, deploy=False, summary_only=False):
     """Run county level model."""
     min_date = datetime.datetime(2020, 3, 7)
     max_date = datetime.datetime(2020, 7, 6)
@@ -58,7 +58,7 @@ def run_county(state=None, deploy=False, summary_only=False, version=None):
     help="Output data files to public data directory in local covid-projections.",
 )
 @data_version.with_git_version_click_option
-def run_state(state=None, deploy=False, version=None):
+def run_state(version: data_version.DataVersion, state=None, deploy=False):
     """Run State level model."""
     min_date = datetime.datetime(2020, 3, 7)
     max_date = datetime.datetime(2020, 7, 6)

--- a/run_model.py
+++ b/run_model.py
@@ -10,6 +10,7 @@ import run
 
 WEB_DEPLOY_PATH = "../covid-projections/public/data"
 
+_logger = logging.getLogger(__name__)
 
 @click.group()
 def main():
@@ -47,7 +48,7 @@ def run_county(version: data_version.DataVersion, state=None, deploy=False, summ
     if state is None and not summary_only:
         version.write_file('counties', output_dir)
     else:
-        logging.info('Skip version file because this is not a full run')
+        _logger.info('Skip version file because this is not a full run')
 
 
 @main.command("state")
@@ -70,12 +71,12 @@ def run_state(version: data_version.DataVersion, state=None, deploy=False):
     run.run_state_level_forecast(
         min_date, max_date, country="USA", state=state, output_dir=output_dir
     )
-    logging.info(f'Wrote output to {output_dir}')
+    _logger.info(f'Wrote output to {output_dir}')
     # only write the version if we saved everything
     if state is None :
         version.write_file('states', output_dir)
     else:
-        logging.info('Skip version file because this is not a full run')
+        _logger.info('Skip version file because this is not a full run')
 
 
 if __name__ == "__main__":

--- a/run_model.py
+++ b/run_model.py
@@ -5,6 +5,7 @@ import logging
 import click
 from libs import build_params
 from libs.datasets.dataset_utils import data_version
+from libs.datasets import dataset_utils
 import run
 
 WEB_DEPLOY_PATH = "../covid-projections/public/data"
@@ -27,34 +28,27 @@ def main():
     is_flag=True,
     help="Only runs the county summary if true.",
 )
-@click.option(
-    '--git-hash',
-    type=str,
-    help='''
-    | Git hash of the commit in covid-data-public to use.
-    | If provided, covid-data-public must have no pending changes.
-    | If omitted, the repository will be used as-is'''
-)
-def run_county(state=None, deploy=False, summary_only=False, git_hash=None):
+@dataset_utils.with_git_version_click_option
+def run_county(state=None, deploy=False, summary_only=False, version=None):
     """Run county level model."""
-    with data_version(git_hash) as version:
-        min_date = datetime.datetime(2020, 3, 7)
-        max_date = datetime.datetime(2020, 7, 6)
+    min_date = datetime.datetime(2020, 3, 7)
+    max_date = datetime.datetime(2020, 7, 6)
 
-        output_dir = build_params.OUTPUT_DIR
-        if deploy:
-            output_dir = WEB_DEPLOY_PATH
+    output_dir = build_params.OUTPUT_DIR
+    if deploy:
+        output_dir = WEB_DEPLOY_PATH
 
-        if not summary_only:
-            run.run_county_level_forecast(
-                min_date, max_date, country="USA", state=state, output_dir=output_dir
-            )
-        run.build_county_summary(min_date, state=state, output_dir=output_dir)
-        # only write the version if we saved everything
-        if state is None and not summary_only:
-            version.write_file('counties', output_dir)
-        else:
-            logging.info('Skip version file because this is not a full run')
+    if not summary_only:
+        run.run_county_level_forecast(
+            min_date, max_date, country="USA", state=state, output_dir=output_dir
+        )
+    run.build_county_summary(min_date, state=state, output_dir=output_dir)
+    # only write the version if we saved everything
+    if state is None and not summary_only:
+        version.write_file('counties', output_dir)
+    else:
+        logging.info('Skip version file because this is not a full run')
+
 
 @main.command("state")
 @click.option("--state", "-s")
@@ -63,33 +57,25 @@ def run_county(state=None, deploy=False, summary_only=False, git_hash=None):
     is_flag=True,
     help="Output data files to public data directory in local covid-projections.",
 )
-@click.option(
-    '--git-hash',
-    type=str,
-    help='''
-    | Git hash of the commit in covid-data-public to use.
-    | If provided, covid-data-public must have no pending changes.
-    | If omitted, the repository will be used as-is'''
-)
-def run_state(state=None, deploy=False, git_hash=None):
+@dataset_utils.with_git_version_click_option
+def run_state(state=None, deploy=False, version=None):
     """Run State level model."""
-    with data_version(git_hash) as version:
-        min_date = datetime.datetime(2020, 3, 7)
-        max_date = datetime.datetime(2020, 7, 6)
+    min_date = datetime.datetime(2020, 3, 7)
+    max_date = datetime.datetime(2020, 7, 6)
 
-        output_dir = build_params.OUTPUT_DIR
-        if deploy:
-            output_dir = WEB_DEPLOY_PATH
+    output_dir = build_params.OUTPUT_DIR
+    if deploy:
+        output_dir = WEB_DEPLOY_PATH
 
-        run.run_state_level_forecast(
-            min_date, max_date, country="USA", state=state, output_dir=output_dir
-        )
-        logging.info(f'Wrote output to {output_dir}')
-        # only write the version if we saved everything
-        if state is None :
-            version.write_file('states', output_dir)
-        else:
-            logging.info('Skip version file because this is not a full run')
+    run.run_state_level_forecast(
+        min_date, max_date, country="USA", state=state, output_dir=output_dir
+    )
+    logging.info(f'Wrote output to {output_dir}')
+    # only write the version if we saved everything
+    if state is None :
+        version.write_file('states', output_dir)
+    else:
+        logging.info('Skip version file because this is not a full run')
 
 
 if __name__ == "__main__":

--- a/run_model.py
+++ b/run_model.py
@@ -4,7 +4,7 @@ import datetime
 import logging
 import click
 from libs import build_params
-from libs.datasets.dataset_utils import data_version
+from libs.datasets import data_version
 from libs.datasets import dataset_utils
 import run
 
@@ -28,7 +28,7 @@ def main():
     is_flag=True,
     help="Only runs the county summary if true.",
 )
-@dataset_utils.with_git_version_click_option
+@data_version.with_git_version_click_option
 def run_county(state=None, deploy=False, summary_only=False, version=None):
     """Run county level model."""
     min_date = datetime.datetime(2020, 3, 7)
@@ -57,7 +57,7 @@ def run_county(state=None, deploy=False, summary_only=False, version=None):
     is_flag=True,
     help="Output data files to public data directory in local covid-projections.",
 )
-@dataset_utils.with_git_version_click_option
+@data_version.with_git_version_click_option
 def run_state(state=None, deploy=False, version=None):
     """Run State level model."""
     min_date = datetime.datetime(2020, 3, 7)

--- a/run_model.py
+++ b/run_model.py
@@ -4,8 +4,9 @@ import datetime
 import logging
 import click
 from libs import build_params
+from libs.datasets.dataset_utils import data_version
 import run
-print(run)
+
 WEB_DEPLOY_PATH = "../covid-projections/public/data"
 
 
@@ -26,21 +27,34 @@ def main():
     is_flag=True,
     help="Only runs the county summary if true.",
 )
-def run_county(state=None, deploy=False, summary_only=False):
+@click.option(
+    '--git-hash',
+    type=str,
+    help='''
+    | Git hash of the commit in covid-data-public to use.
+    | If provided, covid-data-public must have no pending changes.
+    | If omitted, the repository will be used as-is'''
+)
+def run_county(state=None, deploy=False, summary_only=False, git_hash=None):
     """Run county level model."""
-    min_date = datetime.datetime(2020, 3, 7)
-    max_date = datetime.datetime(2020, 7, 6)
+    with data_version(git_hash) as version:
+        min_date = datetime.datetime(2020, 3, 7)
+        max_date = datetime.datetime(2020, 7, 6)
 
-    output_dir = build_params.OUTPUT_DIR
-    if deploy:
-        output_dir = WEB_DEPLOY_PATH
+        output_dir = build_params.OUTPUT_DIR
+        if deploy:
+            output_dir = WEB_DEPLOY_PATH
 
-    if not summary_only:
-        run.run_county_level_forecast(
-            min_date, max_date, country="USA", state=state, output_dir=output_dir
-        )
-    run.build_county_summary(min_date, state=state, output_dir=output_dir)
-
+        if not summary_only:
+            run.run_county_level_forecast(
+                min_date, max_date, country="USA", state=state, output_dir=output_dir
+            )
+        run.build_county_summary(min_date, state=state, output_dir=output_dir)
+        # only write the version if we saved everything
+        if state is None and not summary_only:
+            version.write_file('counties', output_dir)
+        else:
+            logging.info('Skip version file because this is not a full run')
 
 @main.command("state")
 @click.option("--state", "-s")
@@ -49,18 +63,33 @@ def run_county(state=None, deploy=False, summary_only=False):
     is_flag=True,
     help="Output data files to public data directory in local covid-projections.",
 )
-def run_state(state=None, deploy=False):
+@click.option(
+    '--git-hash',
+    type=str,
+    help='''
+    | Git hash of the commit in covid-data-public to use.
+    | If provided, covid-data-public must have no pending changes.
+    | If omitted, the repository will be used as-is'''
+)
+def run_state(state=None, deploy=False, git_hash=None):
     """Run State level model."""
-    min_date = datetime.datetime(2020, 3, 7)
-    max_date = datetime.datetime(2020, 7, 6)
+    with data_version(git_hash) as version:
+        min_date = datetime.datetime(2020, 3, 7)
+        max_date = datetime.datetime(2020, 7, 6)
 
-    output_dir = build_params.OUTPUT_DIR
-    if deploy:
-        output_dir = WEB_DEPLOY_PATH
+        output_dir = build_params.OUTPUT_DIR
+        if deploy:
+            output_dir = WEB_DEPLOY_PATH
 
-    run.run_state_level_forecast(
-        min_date, max_date, country="USA", state=state, output_dir=output_dir
-    )
+        run.run_state_level_forecast(
+            min_date, max_date, country="USA", state=state, output_dir=output_dir
+        )
+        logging.info(f'Wrote output to {output_dir}')
+        # only write the version if we saved everything
+        if state is None :
+            version.write_file('states', output_dir)
+        else:
+            logging.info('Skip version file because this is not a full run')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Also output a version file when the model is run. Git hash support is in the form of the `--git-hash` commandline argument, as that seems to be how we are configuring these runs.