### PR TITLE
Small fixes to run.py - removing archiving folder

### DIFF
--- a/run.py
+++ b/run.py
@@ -341,11 +341,6 @@ def run_county_level_forecast(
 
     output_dir = pathlib.Path(output_dir) / "county"
     _logger.info(f"Outputting to {output_dir}")
-    # Dont want to replace when just running the states
-    if output_dir.exists() and not state:
-        backup = output_dir.name + "." + str(int(time.time()))
-        output_dir.rename(output_dir.parent / backup)
-
     output_dir.mkdir(parents=True, exist_ok=True)
 
     counties_by_state = defaultdict(list)
@@ -387,11 +382,7 @@ def run_state_level_forecast(
     timeseries = timeseries.get_subset(
         AggregationLevel.STATE, after=min_date, country=country, state=state
     )
-    output_dir = pathlib.Path(OUTPUT_DIR)
-    if output_dir.exists() and not state:
-        backup = output_dir.name + "." + str(int(time.time()))
-        output_dir.rename(output_dir.parent / backup)
-
+    output_dir = pathlib.Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
     pool = get_pool()

--- a/run_model.py
+++ b/run_model.py
@@ -5,12 +5,12 @@ import logging
 import click
 from libs import build_params
 from libs.datasets import data_version
-from libs.datasets import dataset_utils
 import run
 
 WEB_DEPLOY_PATH = "../covid-projections/public/data"
 
 _logger = logging.getLogger(__name__)
+
 
 @click.group()
 def main():
@@ -45,7 +45,7 @@ def run_county(version: data_version.DataVersion, state=None, deploy=False, summ
         )
     run.build_county_summary(min_date, state=state, output_dir=output_dir)
     # only write the version if we saved everything
-    if state is None and not summary_only:
+    if not state and not summary_only:
         version.write_file('counties', output_dir)
     else:
         _logger.info('Skip version file because this is not a full run')
@@ -73,7 +73,7 @@ def run_state(version: data_version.DataVersion, state=None, deploy=False):
     )
     _logger.info(f'Wrote output to {output_dir}')
     # only write the version if we saved everything
-    if state is None :
+    if not state:
         version.write_file('states', output_dir)
     else:
         _logger.info('Skip version file because this is not a full run')


### PR DESCRIPTION
Small changes:

 * removes the logic that "archives" the existing directories by renaming outputs.  It caused more confusion that intended.
 * fixes the output dir for state to point at the output directory passed in rather than the constant.
 * using the implicit false (recommendation per [gsg](https://google.github.io/styleguide/pyguide.html#214-truefalse-evaluations))




