### PR TITLE
Fixing fips aggregation

### DIFF
--- a/libs/datasets/dataset_utils.py
+++ b/libs/datasets/dataset_utils.py
@@ -10,6 +10,7 @@ LOCAL_PUBLIC_DATA_PATH = (
 
 _logger = logging.getLogger(__name__)
 
+
 class AggregationLevel(enum.Enum):
     COUNTRY = "country"
     STATE = "state"
@@ -86,6 +87,9 @@ def check_index_values_are_unique(data):
     duplicates = duplicates_results[duplicates_results == True]
     if len(duplicates):
         _logger.warning(f"Found {len(duplicates)} results.")
+        return data[duplicates_results]
+
+    return None
 
 
 def compare_datasets(
@@ -166,9 +170,9 @@ def build_fips_data_frame():
 
 
 def add_county_using_fips(data, fips_data):
-    data = data.set_index("fips")
-    fips_data = fips_data.set_index("fips")
-    data = data.join(fips_data[["county"]], on="fips", rsuffix="_r").reset_index()
+    data = data.set_index(["fips", "state"])
+    fips_data = fips_data.set_index(["fips", "state"])
+    data = data.join(fips_data[["county"]], on=["fips", "state"], rsuffix="_r").reset_index()
     is_missing_county = data.county.isnull() & data.fips.notnull()
 
     data.loc[is_missing_county, 'county'] = (

--- a/libs/datasets/dataset_utils.py
+++ b/libs/datasets/dataset_utils.py
@@ -205,10 +205,14 @@ def assert_counties_have_fips(data, county_key='county', fips_key='fips'):
 def add_fips_using_county(data, fips_data) -> pd.Series:
     """Gets FIPS code from a data frame with a county."""
     data = data.set_index(["county", "state"])
+    original_rows = len(data)
     fips_data = fips_data.set_index(["county", "state"])
     data = data.join(
         fips_data[["fips"]], how="left", on=["county", "state"], rsuffix="_r"
     ).reset_index()
+
+    if len(data) != original_rows:
+        raise Exception("Non-unique join, check for duplicate fips data.")
 
     non_matching = data[data.county.notnull() & data.fips.isnull()]
 

--- a/libs/datasets/sources/fips_population.py
+++ b/libs/datasets/sources/fips_population.py
@@ -5,7 +5,7 @@ from libs.datasets.population import PopulationDataset
 from libs.datasets import dataset_utils
 from libs.datasets import data_source
 from libs.build_params import US_STATE_ABBREV
-
+from libs import enums
 CURRENT_FOLDER = pathlib.Path(__file__).parent
 
 
@@ -55,7 +55,7 @@ class FIPSPopulation(data_source.DataSource):
             row = {
                 cls.Fields.STATE: state,
                 # TODO(chris): Possibly separate fips out by state prefix
-                cls.Fields.FIPS: '99999',
+                cls.Fields.FIPS: enums.UNKNOWN_FIPS,
                 cls.Fields.POPULATION: None,
                 cls.Fields.COUNTY: 'Unknown'
             }

--- a/libs/datasets/sources/jhu_dataset.py
+++ b/libs/datasets/sources/jhu_dataset.py
@@ -5,7 +5,7 @@ from libs.datasets.timeseries import TimeseriesDataset
 from libs.datasets import dataset_utils
 from libs.datasets import data_source
 from libs.datasets.dataset_utils import AggregationLevel
-
+from libs import enums
 _logger = logging.getLogger(__name__)
 
 
@@ -32,6 +32,7 @@ class JHUDataset(data_source.DataSource):
         RECOVERED = "Recovered"
         ACTIVE = "Active"
         COMBINED_KEY = "Combined_Key"
+
         # Added manually in init.
         DATE = "date"
         AGGREGATE_LEVEL = "aggregate_level"
@@ -96,17 +97,20 @@ class JHUDataset(data_source.DataSource):
         )
         data[cls.Fields.STATE] = states
         data = cls._fill_incomplete_county_data(data)
-        state_only = data[cls.Fields.FIPS].isnull() & data[cls.Fields.COUNTY].isnull()
 
+        state_only = data[cls.Fields.FIPS].isnull() & data[cls.Fields.COUNTY].isnull()
         # Pad fips values to 5 spots
         data[cls.Fields.FIPS] = data[cls.Fields.FIPS].apply(
             lambda x: f"{x.zfill(5)}" if type(x) == str else x
         )
+
         data[cls.Fields.AGGREGATE_LEVEL] = numpy.where(state_only, "state", "county")
+        data = cls._aggregate_fips_data(data)
 
         dataset_utils.assert_counties_have_fips(
             data, county_key=cls.Fields.COUNTY, fips_key=cls.Fields.FIPS
         )
+
         return data
 
     @classmethod
@@ -117,7 +121,8 @@ class JHUDataset(data_source.DataSource):
         We probably need to either give each state its own fake FIP, or spread this
         out over the existing counties for the state.
         """
-        unknown_fips = '99999'
+        has_county = data[cls.Fields.COUNTY].notnull()
+        rows_to_replace = has_county & data[cls.Fields.FIPS].isnull()
         overrides = {
             # Assigning nantucket county to dukes and nantucket
             ('MA', 'Dukes and Nantucket'): '25019'
@@ -127,9 +132,32 @@ class JHUDataset(data_source.DataSource):
             matches_county = data[cls.Fields.COUNTY] == county
             data.loc[matches_state & matches_county, cls.Fields.FIPS] = fips
 
-        has_county = data[cls.Fields.COUNTY].notnull()
-        data.loc[has_county & data.FIPS.isnull(), cls.Fields.FIPS] = unknown_fips
+        data.loc[rows_to_replace, cls.Fields.FIPS] = enums.UNKNOWN_FIPS
         return data
+
+    @classmethod
+    def _aggregate_fips_data(cls, data):
+        is_county_level = data[cls.Fields.AGGREGATE_LEVEL] == AggregationLevel.COUNTY.value
+        has_fips = data[cls.Fields.FIPS].notnull()
+        county_data = data[is_county_level & has_fips]
+
+        # This key aggregates county level data based on the fips code.
+        # note that we are not using county name to aggregate. There are some rows in the
+        # JHU data that have multiple different county names per fips code.
+        # Right now, we are just combining that data, it may be more appropriate to take the max.
+        group_key = [
+            cls.Fields.DATE,
+            cls.Fields.AGGREGATE_LEVEL,
+            cls.Fields.FIPS,
+            cls.Fields.STATE,
+            cls.Fields.COUNTRY,
+        ]
+        result = county_data.groupby(group_key).sum().reset_index()
+
+        return pd.concat([
+            data[~(is_county_level & has_fips)],
+            result
+        ])
 
     @classmethod
     def local(cls) -> "JHUTimeseriesData":

--- a/libs/datasets/sources/jhu_dataset.py
+++ b/libs/datasets/sources/jhu_dataset.py
@@ -121,8 +121,6 @@ class JHUDataset(data_source.DataSource):
         We probably need to either give each state its own fake FIP, or spread this
         out over the existing counties for the state.
         """
-        has_county = data[cls.Fields.COUNTY].notnull()
-        rows_to_replace = has_county & data[cls.Fields.FIPS].isnull()
         overrides = {
             # Assigning nantucket county to dukes and nantucket
             ('MA', 'Dukes and Nantucket'): '25019'
@@ -132,6 +130,8 @@ class JHUDataset(data_source.DataSource):
             matches_county = data[cls.Fields.COUNTY] == county
             data.loc[matches_state & matches_county, cls.Fields.FIPS] = fips
 
+        has_county = data[cls.Fields.COUNTY].notnull()
+        rows_to_replace = has_county & data[cls.Fields.FIPS].isnull()
         data.loc[rows_to_replace, cls.Fields.FIPS] = enums.UNKNOWN_FIPS
         return data
 

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -41,6 +41,14 @@ class TimeseriesDataset(object):
     def states(self) -> List:
         return self.data[self.Fields.STATE].dropna().unique().tolist()
 
+    @property
+    def state_data(self) -> pd.DataFrame:
+        return self.get_subset(AggregationLevel.STATE).data
+
+    @property
+    def county_data(self) -> pd.DataFrame:
+        return self.get_subset(AggregationLevel.COUNTY).data
+
     def county_keys(self) -> List:
         """Returns a list of all (country, state, county) combinations."""
         # Check to make sure all values are county values

--- a/libs/enums.py
+++ b/libs/enums.py
@@ -1,0 +1,4 @@
+
+# Fips code chosen for all unknown fips values.
+# TODO: This should maybe be unique per state.
+UNKNOWN_FIPS = "99999"

--- a/run.py
+++ b/run.py
@@ -129,8 +129,12 @@ def prepare_data_for_website(
     relevant_date_index = pd.to_datetime(website_ordering.date).isin(historicals_df.date)
     extract_real_date_index = historicals_df.date.isin(pd.to_datetime(website_ordering.date))
 
-    website_ordering.loc[relevant_date_index, 'all_infected'] = historicals_df[extract_real_date_index]['estimated_infected'].values
-    website_ordering.loc[relevant_date_index, 'all_hospitalized'] = historicals_df[extract_real_date_index]['estimated_hospitalized'].values
+    website_ordering.loc[relevant_date_index, 'all_infected'] = (
+        historicals_df[extract_real_date_index]['estimated_infected'].values
+    )
+    website_ordering.loc[relevant_date_index, 'all_hospitalized'] = (
+        historicals_df[extract_real_date_index]['estimated_hospitalized'].values
+    )
 
     return website_ordering
 


### PR DESCRIPTION
Okay - so found an annoying bug in the fips data. Basically there are duplicate rows for some counties.

here's an example, notice on 4/23 how there are two different rows for that fips: 
![image](https://user-images.githubusercontent.com/1422280/78507045-d8b1b980-774b-11ea-9fe2-40e5fc7925a9.png)

Also fixes a bug on the county replacement to make sure that counties aren't adding additional unknown data by joining on more than fips.

I would like to figure out a way to standardize this missing data.  this is a quick fix, but I think there's a larger ticket that needs to be done so that we're not handling this differently for every case.

