### PR TITLE
Fixing PR processing for beds data

### DIFF
--- a/libs/datasets/data_version.py
+++ b/libs/datasets/data_version.py
@@ -13,6 +13,7 @@ from .dataset_utils import LOCAL_PUBLIC_DATA_PATH
 
 _logger = logging.getLogger(__name__)
 
+
 class DataVersion(object):
     '''
     Encapsulates some state about the source data with the

--- a/libs/datasets/sources/dh_beds.py
+++ b/libs/datasets/sources/dh_beds.py
@@ -1,6 +1,6 @@
 import logging
 from collections import defaultdict
-import numpy
+from libs import enums
 import pandas as pd
 from libs.datasets.beds import BedsDataset
 from libs.datasets import dataset_utils
@@ -21,6 +21,9 @@ def match_county_to_fips(data, fips_data, county_key="county", state_key="state"
             .replace("'", "")
             .replace("-", " ")
             .replace("ó", "o")
+            .replace("í", "i")
+            .replace("é", "e")
+            .replace("á", "a")
             .replace(".", "")
             .replace("ñ", ""),
         ): fips
@@ -34,6 +37,9 @@ def match_county_to_fips(data, fips_data, county_key="county", state_key="state"
             .replace("'", "")
             .replace("-", " ")
             .replace("ó", "o")
+            .replace("é", "e")
+            .replace("í", "i")
+            .replace("á", "a")
             .replace(".", "")
             .replace("ñ", "")
         )
@@ -59,8 +65,6 @@ def match_county_to_fips(data, fips_data, county_key="county", state_key="state"
         "de kalb": "dekalb",
     }
     for state, county in county_combos:
-        if state == "PR":
-            continue
         key = state, county
         county = county.lower()
         county = replacements.get(county, county)
@@ -85,7 +89,9 @@ def match_county_to_fips(data, fips_data, county_key="county", state_key="state"
                 match = True
                 break
 
-        if not match:
+        if not match and state == 'VI':
+            matched[key] = enums.UNKNOWN_FIPS
+        elif not match:
             _logger.warning(f"Could not match {key}")
             if not counties_by_state[state]:
                 continue
@@ -138,10 +144,13 @@ class DHBeds(data_source.DataSource):
         data[cls.Fields.COUNTRY] = "USA"
 
         # Backfilling FIPS data based on county names.
-        # TODO: Fix all missing cases
         fips_data = dataset_utils.build_fips_data_frame()
         data = match_county_to_fips(data, fips_data)
-        return data
+
+        # The virgin islands do not currently have associated fips codes.
+        # if VI is supported in the future, this should be removed.
+        is_virgin_islands = data[cls.Fields.STATE] == 'VI'
+        return data[~is_virgin_islands]
 
     @classmethod
     def local(cls) -> "DHBeds":

--- a/libs/datasets/sources/fips_population.py
+++ b/libs/datasets/sources/fips_population.py
@@ -52,6 +52,7 @@ class FIPSPopulation(data_source.DataSource):
     def standardize_data(cls, data: pd.DataFrame) -> pd.DataFrame:
         # Add Missing
         unknown_fips = []
+
         for state in data.state.unique():
             row = {
                 cls.Fields.STATE: state,
@@ -61,6 +62,7 @@ class FIPSPopulation(data_source.DataSource):
                 cls.Fields.COUNTY: 'Unknown'
             }
             unknown_fips.append(row)
+
         data = data.append(unknown_fips)
         # All DH data is aggregated at the county level
         data[cls.Fields.AGGREGATE_LEVEL] = "county"


### PR DESCRIPTION
For better or for worse, the DH beds data was broken because we check for duplicate indexes and the PR bed data wasn't being processed properly.

This fixes that. 

Also, drops all Virgin islands data as we have no fips or population data on it right now.