### PR TITLE
Fix deploy subdirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ See [covid-data-public](https://github.com/covid-projections/covid-data-public) 
 ## Running
 
 ### Run website data deploy
+
+This will run all model and data needed for the webiste, outputting to ``../covid-projections/public/data``.
 ```bash
 ./deploy.sh
 ```

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ See [covid-data-public](https://github.com/covid-projections/covid-data-public) 
 
 ## Running
 
-### Create JSON for UI
+### Run website data deploy
 ```bash
-python run.py
+./deploy.sh
 ```
 
 ### Create JSON for API

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
-# Run State and County level models
-./run_model.py state --deploy
-./run_model.py county --deploy
+PUBLIC_DATA_PATH=../covid-projections/public/data
 
+
+# Run State and County level models
+./run_model.py state -o ${PUBLIC_DATA_PATH}
+./run_model.py county -o ${PUBLIC_DATA_PATH}/county
+./run_model.py county-summary -o ${PUBLIC_DATA_PATH}/county_summaries
 # Generate the latest state case summary data.
-./run_data.py latest --deploy
+./run_data.py latest -o ${PUBLIC_DATA_PATH}/case_summary

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Run State and County level models
+./run_model.py state --deploy
+./run_model.py county --deploy
+
+# Generate the latest state case summary data.
+./run_data.py latest --deploy

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,10 +2,12 @@
 
 PUBLIC_DATA_PATH=../covid-projections/public/data
 
-
 # Run State and County level models
 ./run_model.py state -o ${PUBLIC_DATA_PATH}
 ./run_model.py county -o ${PUBLIC_DATA_PATH}/county
 ./run_model.py county-summary -o ${PUBLIC_DATA_PATH}/county_summaries
 # Generate the latest state case summary data.
 ./run_data.py latest -o ${PUBLIC_DATA_PATH}/case_summary
+
+mkdir dod_results
+./deploy_dod_dataset.py -i ${PUBLIC_DATA_PATH} -o dod_results

--- a/deploy_dod_dataset.py
+++ b/deploy_dod_dataset.py
@@ -1,5 +1,7 @@
+#!/usr/bin/env python
 from io import BytesIO
 import boto3
+import click
 import os
 
 from libs.build_dod_dataset import get_usa_by_county_df, get_usa_by_states_df, get_usa_county_shapefile, get_usa_state_shapefile
@@ -7,13 +9,14 @@ from libs.build_dod_dataset import get_usa_by_county_with_projection_df
 
 class DatasetDeployer():
 
-    def __init__(self, key='filename.csv', body='a random data'):
+    def __init__(self, key='filename.csv', body='a random data', output_dir='.'):
         self.s3 = boto3.client('s3')
         # Supplied by ENV on AWS
         # BUCKET_NAME format is s3://{BUCKET_NAME}
         self.bucket_name = os.environ.get('BUCKET_NAME')
         self.key = key
         self.body = body
+        self.output_dir = output_dir
 
     def _persist_to_s3(self):
         """Persists specific data onto an s3 bucket.
@@ -33,7 +36,7 @@ class DatasetDeployer():
         """
         print('persisting {} to local'.format(self.key))
 
-        with open(self.key, 'wb') as f:
+        with open(os.path.join(self.output_dir, self.key), 'wb') as f:
             # hack to allow the local writer to take either bytes or a string
             # note this assumes that all strings are given in utf-8 and not,
             # like, ASCII
@@ -48,40 +51,40 @@ class DatasetDeployer():
             self._persist_to_local()
         return
 
-
-def deploy():
+@click.command()
+@click.option('--input', '-i', default='results', help='Input directory of state/county projections')
+@click.option('--output', '-o', default='', help='Output directory for artifacts')
+def deploy(input, output):
     """The entry function for invokation
 
     """
-    states_blob = {
-        'key': 'states.csv',
-        'body': get_usa_by_states_df().to_csv()
-        }
-    statesObj = DatasetDeployer(**states_blob)
-    statesObj.persist()
+    DatasetDeployer(
+        key='states.csv',
+        body=get_usa_by_states_df(input).to_csv(),
+        output_dir=output
+    ).persist()
 
-    counties_blob = {
-        'key': 'counties.csv',
-        'body': get_usa_by_county_with_projection_df().to_csv()
-        }
-    countiesObj = DatasetDeployer(**counties_blob)
-    countiesObj.persist()
+    DatasetDeployer(
+        key='counties.csv',
+        body=get_usa_by_county_with_projection_df(input).to_csv(),
+        output_dir=output
+    ).persist()
 
     states_shp = BytesIO()
     states_shx = BytesIO()
     states_dbf = BytesIO()
-    get_usa_state_shapefile(states_shp, states_shx, states_dbf)
-    DatasetDeployer(key='states.shp', body=states_shp.getvalue()).persist()
-    DatasetDeployer(key='states.shx', body=states_shx.getvalue()).persist()
-    DatasetDeployer(key='states.dbf', body=states_dbf.getvalue()).persist()
+    get_usa_state_shapefile(input, states_shp, states_shx, states_dbf)
+    DatasetDeployer(key='states.shp', body=states_shp.getvalue(), output_dir=output).persist()
+    DatasetDeployer(key='states.shx', body=states_shx.getvalue(), output_dir=output).persist()
+    DatasetDeployer(key='states.dbf', body=states_dbf.getvalue(), output_dir=output).persist()
 
     counties_shp = BytesIO()
     counties_shx = BytesIO()
     counties_dbf = BytesIO()
-    get_usa_county_shapefile(counties_shp, counties_shx, counties_dbf)
-    DatasetDeployer(key='counties.shp', body=counties_shp.getvalue()).persist()
-    DatasetDeployer(key='counties.shx', body=counties_shx.getvalue()).persist()
-    DatasetDeployer(key='counties.dbf', body=counties_dbf.getvalue()).persist()
+    get_usa_county_shapefile(input, counties_shp, counties_shx, counties_dbf)
+    DatasetDeployer(key='counties.shp', body=counties_shp.getvalue(), output_dir=output).persist()
+    DatasetDeployer(key='counties.shx', body=counties_shx.getvalue(), output_dir=output).persist()
+    DatasetDeployer(key='counties.dbf', body=counties_dbf.getvalue(), output_dir=output).persist()
 
     print('finished dod job')
 
@@ -96,4 +99,5 @@ if __name__ == "__main__":
     python deploy_dod_dataset.py
     """
 
+    # pylint: disable=no-value-for-parameter
     deploy()

--- a/libs/build_dod_dataset.py
+++ b/libs/build_dod_dataset.py
@@ -181,7 +181,7 @@ def get_county_projections():
         state = fips_row['state']
         fips = fips_row['fips']
         file_name = f"{state}.{fips}.{intervention_type}.json"
-        path = os.path.join(OUTPUT_DIR_COUNTIES, file_name)
+        path = os.path.join(str(OUTPUT_DIR_COUNTIES), file_name)
         # if the file exists in that directory then process
         if os.path.exists(path):
             df = read_json_as_df(path)

--- a/libs/build_params.py
+++ b/libs/build_params.py
@@ -32,6 +32,7 @@ def get_interventions(start_date=datetime.now().date()):
 
 
 OUTPUT_DIR = 'results/test'
+OUTPUT_DIR_COUNTIES = 'results/county'
 
 # Relative directory to where all output data is deployed to for the website
 WEB_DEPLOY_PATH = pathlib.Path("../covid-projections/public/data")

--- a/libs/build_params.py
+++ b/libs/build_params.py
@@ -3,6 +3,7 @@ Constants to use for a build. In a separate file to avoid
 auto-importing a dataset when we don't necessarily need to.
 '''
 
+import pathlib
 from datetime import datetime, timedelta, date
 
 
@@ -29,11 +30,27 @@ def get_interventions(start_date=datetime.now().date()):
         },
     ]
 
+
 OUTPUT_DIR = 'results/test'
-OUTPUT_DIR_COUNTIES = 'results/county'
+COUNTY_SUBDIR = 'county'
+COUNTY_SUMMARY_SUBDIR = 'county_summaries'
+# Output directory for latest case data by state
+STATE_SUMMARY_SUBDIR = "case_summary"
+
+# pathlib version of output_dir.
+OUTPUT_PATH = pathlib.Path(OUTPUT_DIR)
+
+# For now state output directory is just the root of the folder
+OUTPUT_DIR_STATES = OUTPUT_PATH
+OUTPUT_DIR_COUNTIES = OUTPUT_PATH / COUNTY_SUBDIR
+OUTPUT_DIR_COUNTY_SUMMARY = OUTPUT_PATH / COUNTY_SUMMARY_SUBDIR
+
+# Relative directory to where all output data is deployed to for the website
+WEB_DEPLOY_PATH = pathlib.Path("../covid-projections/public/data")
+
 
 # Dict to transform longhand state names to abbreviations
-US_STATE_ABBREV =  {
+US_STATE_ABBREV = {
     'Alabama': 'AL',
     'Alaska': 'AK',
     'American Samoa': 'AS',

--- a/libs/build_params.py
+++ b/libs/build_params.py
@@ -3,7 +3,6 @@ Constants to use for a build. In a separate file to avoid
 auto-importing a dataset when we don't necessarily need to.
 '''
 
-import pathlib
 from datetime import datetime, timedelta, date
 
 
@@ -33,9 +32,6 @@ def get_interventions(start_date=datetime.now().date()):
 
 OUTPUT_DIR = 'results/test'
 OUTPUT_DIR_COUNTIES = 'results/county'
-
-# Relative directory to where all output data is deployed to for the website
-WEB_DEPLOY_PATH = pathlib.Path("../covid-projections/public/data")
 
 
 # Dict to transform longhand state names to abbreviations

--- a/libs/build_params.py
+++ b/libs/build_params.py
@@ -32,18 +32,6 @@ def get_interventions(start_date=datetime.now().date()):
 
 
 OUTPUT_DIR = 'results/test'
-COUNTY_SUBDIR = 'county'
-COUNTY_SUMMARY_SUBDIR = 'county_summaries'
-# Output directory for latest case data by state
-STATE_SUMMARY_SUBDIR = "case_summary"
-
-# pathlib version of output_dir.
-OUTPUT_PATH = pathlib.Path(OUTPUT_DIR)
-
-# For now state output directory is just the root of the folder
-OUTPUT_DIR_STATES = OUTPUT_PATH
-OUTPUT_DIR_COUNTIES = OUTPUT_PATH / COUNTY_SUBDIR
-OUTPUT_DIR_COUNTY_SUMMARY = OUTPUT_PATH / COUNTY_SUMMARY_SUBDIR
 
 # Relative directory to where all output data is deployed to for the website
 WEB_DEPLOY_PATH = pathlib.Path("../covid-projections/public/data")

--- a/run.py
+++ b/run.py
@@ -463,3 +463,10 @@ def run_state_level_forecast(
 
     pool.close()
     pool.join()
+
+
+if __name__ == "__main__":
+    _logger.warning(
+        "Models are no longer ran from run.py. Please see README.md for the most up to date "
+        "way to run models."
+    )

--- a/run.py
+++ b/run.py
@@ -231,9 +231,9 @@ def model_state(timeseries, starting_beds, population, interventions=None):
 
 def build_county_summary(
     min_date: datetime.datetime,
+    output_dir: pathlib.Path,
     country: str = "USA",
     state: str = None,
-    output_dir: pathlib.Path = build_params.OUTPUT_DIR_COUNTY_SUMMARY
 ):
     """Builds county summary json files."""
     beds_data = DHBeds.local().beds()
@@ -383,9 +383,9 @@ def forecast_each_county(
 def run_county_level_forecast(
     min_date: datetime.datetime,
     max_date: datetime.datetime,
+    output_dir: pathlib.Path,
     country: str = "USA",
     state: str = None,
-    output_dir: pathlib.Path = build_params.OUTPUT_DIR_COUNTIES
 ):
     beds_data = DHBeds.local().beds()
     population_data = FIPSPopulation.local().population()
@@ -430,7 +430,7 @@ def run_county_level_forecast(
 
 
 def run_state_level_forecast(
-    min_date, max_date, country="USA", state=None, output_dir=build_params.OUTPUT_DIR
+    min_date, max_date, output_dir, country="USA", state=None,
 ):
     # DH Beds dataset does not have all counties, so using the legacy state
     # level bed data.

--- a/run_data.py
+++ b/run_data.py
@@ -4,16 +4,12 @@ CLI Functionality to generate reports and summaries of data sources.
 
 To generate model output, see ./run_model.py
 """
-import pathlib
 import json
 import logging
 import click
 from libs import build_params
 from libs.datasets import JHUDataset
 from libs.datasets import dataset_export
-
-WEB_DEPLOY_PATH = pathlib.Path("../covid-projections/public/data")
-
 
 _logger = logging.getLogger(__name__)
 
@@ -31,11 +27,11 @@ def main():
 )
 def run_latest(deploy=False):
     """Get latest case values from JHU dataset."""
-    output_dir = pathlib.Path(build_params.OUTPUT_DIR)
+    output_base = build_params.OUTPUT_PATH
     if deploy:
-        output_dir = WEB_DEPLOY_PATH
+        output_base = build_params.WEB_DEPLOY_PATH
 
-    output_folder = output_dir / "case_summary"
+    output_folder = output_base / build_params.STATE_SUMMARY_SUBDIR
     output_folder.mkdir(exist_ok=True)
     timeseries = JHUDataset.local().timeseries()
     state_summaries = dataset_export.latest_case_summaries_by_state(timeseries)

--- a/run_data.py
+++ b/run_data.py
@@ -41,10 +41,7 @@ def run_latest(version: data_version.DataVersion, output: pathlib.Path):
             _logger.info(f"Writing latest data for {state}")
             json.dump(state_summary, f)
 
-    if not state:
-        version.write_file("case_summary", output)
-    else:
-        _logger.info("Skip version file because this is not a full run")
+    version.write_file("case_summary", output)
 
 
 if __name__ == "__main__":

--- a/run_data.py
+++ b/run_data.py
@@ -29,7 +29,7 @@ def main():
     default=pathlib.Path("results/case_summaries"),
 )
 @data_version.with_git_version_click_option
-def run_latest(version: data_version.Version, output: pathlib.Path):
+def run_latest(version: data_version.DataVersion, output: pathlib.Path):
     """Get latest case values from JHU dataset."""
     output.mkdir(exist_ok=True)
     timeseries = JHUDataset.local().timeseries()

--- a/run_model.py
+++ b/run_model.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python
-
+import os
 import datetime
 import logging
 import click
 from libs import build_params
 from libs.datasets import data_version
 import run
-
-WEB_DEPLOY_PATH = "../covid-projections/public/data"
 
 _logger = logging.getLogger(__name__)
 
@@ -35,14 +33,17 @@ def run_county(version: data_version.DataVersion, state=None, deploy=False, summ
     min_date = datetime.datetime(2020, 3, 7)
     max_date = datetime.datetime(2020, 7, 6)
 
-    output_dir = build_params.OUTPUT_DIR
+    output_base = build_params.OUTPUT_PATH
     if deploy:
-        output_dir = WEB_DEPLOY_PATH
+        output_base = build_params.WEB_DEPLOY_PATH
+    output_dir = output_base / build_params.COUNTY_SUBDIR
 
     if not summary_only:
         run.run_county_level_forecast(
             min_date, max_date, country="USA", state=state, output_dir=output_dir
         )
+
+    output_dir = output_base / build_params.COUNTY_SUMMARY_SUBDIR
     run.build_county_summary(min_date, state=state, output_dir=output_dir)
     # only write the version if we saved everything
     if not state and not summary_only:
@@ -66,7 +67,7 @@ def run_state(version: data_version.DataVersion, state=None, deploy=False):
 
     output_dir = build_params.OUTPUT_DIR
     if deploy:
-        output_dir = WEB_DEPLOY_PATH
+        output_dir = build_params.WEB_DEPLOY_PATH
 
     run.run_state_level_forecast(
         min_date, max_date, country="USA", state=state, output_dir=output_dir

--- a/run_model.py
+++ b/run_model.py
@@ -23,12 +23,9 @@ def main():
     type=pathlib.Path,
     default=pathlib.Path("results/county"),
 )
-@click.option(
-    "--summary-only", is_flag=True, help="Only runs the county summary if true.",
-)
 @data_version.with_git_version_click_option
 def run_county(
-    version: data_version.DataVersion, output, state=None, summary_only=False
+    version: data_version.DataVersion, output, state=None
 ):
     """Run county level model."""
     min_date = datetime.datetime(2020, 3, 7)
@@ -72,7 +69,7 @@ def run_county_summary(version: data_version.DataVersion, output, state=None):
     "-o",
     help="Output directory",
     type=pathlib.Path,
-    default=pathlib.Path("results/county_summaries"),
+    default=pathlib.Path("results/state"),
 )
 @data_version.with_git_version_click_option
 def run_state(version: data_version.DataVersion, output, state=None):

--- a/run_model.py
+++ b/run_model.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
-import os
+import pathlib
 import datetime
 import logging
 import click
-from libs import build_params
 from libs.datasets import data_version
 import run
 
@@ -18,66 +17,76 @@ def main():
 @main.command("county")
 @click.option("--state", "-s")
 @click.option(
-    "--deploy",
-    is_flag=True,
-    help="Output data files to public data directory in local covid-projections.",
+    "--output",
+    "-o",
+    help="Output directory",
+    type=pathlib.Path,
+    default=pathlib.Path("results/county"),
 )
 @click.option(
-    "--summary-only",
-    is_flag=True,
-    help="Only runs the county summary if true.",
+    "--summary-only", is_flag=True, help="Only runs the county summary if true.",
 )
 @data_version.with_git_version_click_option
-def run_county(version: data_version.DataVersion, state=None, deploy=False, summary_only=False):
+def run_county(
+    version: data_version.DataVersion, output, state=None, summary_only=False
+):
     """Run county level model."""
     min_date = datetime.datetime(2020, 3, 7)
     max_date = datetime.datetime(2020, 7, 6)
 
-    output_base = build_params.OUTPUT_PATH
-    if deploy:
-        output_base = build_params.WEB_DEPLOY_PATH
-    output_dir = output_base / build_params.COUNTY_SUBDIR
-
-    if not summary_only:
-        run.run_county_level_forecast(
-            min_date, max_date, country="USA", state=state, output_dir=output_dir
-        )
-
-    output_dir = output_base / build_params.COUNTY_SUMMARY_SUBDIR
-    run.build_county_summary(min_date, state=state, output_dir=output_dir)
-    # only write the version if we saved everything
-    if not state and not summary_only:
-        version.write_file('counties', output_dir)
+    run.run_county_level_forecast(
+        min_date, max_date, output, country="USA", state=state
+    )
+    if not state:
+        version.write_file("county", output)
     else:
-        _logger.info('Skip version file because this is not a full run')
+        _logger.info("Skip version file because this is not a full run")
+
+
+@main.command("county-summary")
+@click.option("--state", "-s")
+@click.option(
+    "--output",
+    "-o",
+    help="Output directory",
+    type=pathlib.Path,
+    default=pathlib.Path("results/county_summaries"),
+)
+@data_version.with_git_version_click_option
+def run_county_summary(version: data_version.DataVersion, output, state=None):
+    """Run county level model."""
+    min_date = datetime.datetime(2020, 3, 7)
+    run.build_county_summary(min_date, output, state=state)
+
+    # only write the version if we saved everything
+    if not state:
+        version.write_file("county_summary", output)
+    else:
+        _logger.info("Skip version file because this is not a full run")
 
 
 @main.command("state")
 @click.option("--state", "-s")
 @click.option(
-    "--deploy",
-    is_flag=True,
-    help="Output data files to public data directory in local covid-projections.",
+    "--output",
+    "-o",
+    help="Output directory",
+    type=pathlib.Path,
+    default=pathlib.Path("results/county_summaries"),
 )
 @data_version.with_git_version_click_option
-def run_state(version: data_version.DataVersion, state=None, deploy=False):
+def run_state(version: data_version.DataVersion, output, state=None):
     """Run State level model."""
     min_date = datetime.datetime(2020, 3, 7)
     max_date = datetime.datetime(2020, 7, 6)
 
-    output_dir = build_params.OUTPUT_DIR
-    if deploy:
-        output_dir = build_params.WEB_DEPLOY_PATH
-
-    run.run_state_level_forecast(
-        min_date, max_date, country="USA", state=state, output_dir=output_dir
-    )
-    _logger.info(f'Wrote output to {output_dir}')
+    run.run_state_level_forecast(min_date, max_date, output, country="USA", state=state)
+    _logger.info(f"Wrote output to {output}")
     # only write the version if we saved everything
     if not state:
-        version.write_file('states', output_dir)
+        version.write_file("states", output)
     else:
-        _logger.info('Skip version file because this is not a full run')
+        _logger.info("Skip version file because this is not a full run")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Changing the deploy directory wasn't quite working properly, so this standardizes a bit of that.

Also, added a `deploy.sh` file to illustrate how to deploy the data to the website.  It doesn't quite cover #123 , but I think it's a start and at least documents the current process.

I named it `deploy.sh` rather than `run.sh` because it's pretty specific to what you need to do to actually deploy to the website, rather than just run the models for testing