### PR TITLE
Enable COVID_DATA_PUBLIC env var again.

### DIFF
--- a/libs/datasets/dataset_utils.py
+++ b/libs/datasets/dataset_utils.py
@@ -1,12 +1,16 @@
+import os
 import enum
 import logging
 import pathlib
 import pandas as pd
 from libs import build_params
 
-LOCAL_PUBLIC_DATA_PATH = (
-    pathlib.Path(__file__).parent.parent / ".." / ".." / "covid-data-public"
-)
+if os.getenv("COVID_DATA_PUBLIC"):
+    LOCAL_PUBLIC_DATA_PATH = pathlib.Path(os.getenv("COVID_DATA_PUBLIC"))
+else:
+    LOCAL_PUBLIC_DATA_PATH = (
+        pathlib.Path(__file__).parent.parent / ".." / ".." / "covid-data-public"
+    )
 
 _logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This restores the capability of using COVID_DATA_PUBLIC env var to specify where to find that repo.  

I'm not opposed to changing the way this works (e.g. using CLI arguments), but if/when we do, we should add a legacy check for COVID_DATA_PUBLIC and tell people to use the command-line arg instead. 