### PR TITLE
moving datset deployer out of deploy_dod_dataset

### DIFF
--- a/deploy_dod_dataset.py
+++ b/deploy_dod_dataset.py
@@ -9,63 +9,9 @@ from libs.enums import Intervention
 from libs.validate_results import validate_states_df, validate_counties_df, validate_states_shapefile, validate_counties_shapefile
 from libs.build_dod_dataset import get_usa_by_county_with_projection_df, get_usa_by_states_df
 from libs.functions.generate_shapefiles import get_usa_county_shapefile, get_usa_state_shapefile
-
+from libs import dataset_deployer
 logger = logging.getLogger(__name__)
 PROD_BUCKET = "data.covidactnow.org"
-
-class DatasetDeployer():
-
-    def __init__(self, key='filename.csv', body='a random data', output_dir='.'):
-        self.s3 = boto3.client('s3')
-        # Supplied by ENV on AWS
-        # BUCKET_NAME format is s3://{BUCKET_NAME}
-        self.bucket_name = os.environ.get('BUCKET_NAME')
-        self.key = key
-        self.body = body
-        self.output_dir = output_dir
-
-    def _persist_to_s3(self):
-        """Persists specific data onto an s3 bucket.
-        This method assumes versioned is handled on the bucket itself.
-        """
-        print('persisting {} to s3'.format(self.key))
-
-        response = self.s3.put_object(Bucket=self.bucket_name,
-                                      Key=self.key,
-                                      Body=self.body,
-                                      ACL='public-read')
-        return response
-
-    def _persist_to_local(self):
-        """Persists specific data onto an s3 bucket.
-        This method assumes versioned is handled on the bucket itself.
-        """
-        print('persisting {} to local'.format(self.key))
-
-        with open(os.path.join(self.output_dir, self.key), 'wb') as f:
-            # hack to allow the local writer to take either bytes or a string
-            # note this assumes that all strings are given in utf-8 and not,
-            # like, ASCII
-            f.write(self.body.encode('UTF-8') if isinstance(self.body, str) else self.body)
-
-        pass
-
-    def persist(self):
-        if self.bucket_name:
-            self._persist_to_s3()
-        else:
-            self._persist_to_local()
-        return
-
-def upload_csv(key_name, csv, output_dir): 
-    blob = {
-        'key': f'{key_name}.csv',
-        'body': csv,
-        'output_dir': output_dir,
-        }
-    obj = DatasetDeployer(**blob)
-    obj.persist()
-    logger.info(f"Generated csv for {key_name}")
 
 
 @click.command()
@@ -75,41 +21,37 @@ def upload_csv(key_name, csv, output_dir):
 def deploy(run_validation, input, output):
     """The entry function for invocation"""
 
-    for intervention_enum in list(Intervention): 
+    for intervention_enum in list(Intervention):
         logger.info(f"Starting to generate files for {intervention_enum.name}.")
 
         states_key_name = f'states.{intervention_enum.name}'
         states_df = get_usa_by_states_df(input, intervention_enum.value)
-        if run_validation: 
+        if run_validation:
             validate_states_df(states_key_name, states_df)
-        upload_csv(states_key_name, states_df.to_csv(), output)
+        dataset_deployer.upload_csv(states_key_name, states_df.to_csv(), output)
 
         states_shp = BytesIO()
         states_shx = BytesIO()
         states_dbf = BytesIO()
         get_usa_state_shapefile(states_df, states_shp, states_shx, states_dbf)
-        if run_validation: 
+        if run_validation:
             validate_states_shapefile(states_key_name, states_shp, states_shx, states_dbf)
-        DatasetDeployer(key=f'{states_key_name}.shp', body=states_shp.getvalue(), output_dir=output).persist()
-        DatasetDeployer(key=f'{states_key_name}.shx', body=states_shx.getvalue(), output_dir=output).persist()
-        DatasetDeployer(key=f'{states_key_name}.dbf', body=states_dbf.getvalue(), output_dir=output).persist()
+        dataset_deployer.deploy_shape_files(output, states_key_name, states_shp, states_shx, states_dbf)
         logger.info(f"Generated state shape files for {intervention_enum.name}")
 
         counties_key_name = f'counties.{intervention_enum.name}'
         counties_df = get_usa_by_county_with_projection_df(input, intervention_enum.value)
-        if run_validation: 
+        if run_validation:
             validate_counties_df(counties_key_name, counties_df)
-        upload_csv(counties_key_name, counties_df.to_csv(), output)
+        dataset_deployer.upload_csv(counties_key_name, counties_df.to_csv(), output)
 
         counties_shp = BytesIO()
         counties_shx = BytesIO()
         counties_dbf = BytesIO()
         get_usa_county_shapefile(counties_df, counties_shp, counties_shx, counties_dbf)
-        if run_validation: 
+        if run_validation:
             validate_counties_shapefile(counties_key_name, counties_shp, counties_shx, counties_dbf)
-        DatasetDeployer(key=f'{counties_key_name}.shp', body=counties_shp.getvalue(), output_dir=output).persist()
-        DatasetDeployer(key=f'{counties_key_name}.shx', body=counties_shx.getvalue(), output_dir=output).persist()
-        DatasetDeployer(key=f'{counties_key_name}.dbf', body=counties_dbf.getvalue(), output_dir=output).persist()
+        dataset_deployer.deploy_shape_files(output, counties_key_name, counties_shp, counties_shx, counties_dbf)
         logger.info(f"Generated counties shape files for {intervention_enum.name}")
 
     print('finished dod job')

--- a/libs/dataset_deployer.py
+++ b/libs/dataset_deployer.py
@@ -1,0 +1,94 @@
+import os
+import io
+import logging
+import boto3
+
+_logger = logging.getLogger(__name__)
+
+
+class DatasetDeployer(object):
+    """Common deploy operations for persisting files to s3 or local folder.
+
+    Deploys to S3 if the BUCKET_NAME environment variable is set.
+    """
+
+    def __init__(self, key="filename.csv", body="a random data", output_dir="."):
+        self.s3 = boto3.client("s3")
+        # Supplied by ENV on AWS
+        # BUCKET_NAME format is s3://{BUCKET_NAME}
+        self.bucket_name = os.environ.get("BUCKET_NAME")
+        self.key = key
+        self.body = body
+        self.output_dir = output_dir
+
+    def _persist_to_s3(self):
+        """Persists specific data onto an s3 bucket.
+        This method assumes versioned is handled on the bucket itself.
+        """
+        _logger.info(f"persisting {self.key} to s3")
+
+        response = self.s3.put_object(
+            Bucket=self.bucket_name, Key=self.key, Body=self.body, ACL="public-read"
+        )
+        return response
+
+    def _persist_to_local(self):
+        """Persists specific data onto an s3 bucket.
+        This method assumes versioned is handled on the bucket itself.
+        """
+        _logger.info(f"persisting {self.key} to local")
+
+        with open(os.path.join(self.output_dir, self.key), "wb") as f:
+            # hack to allow the local writer to take either bytes or a string
+            # note this assumes that all strings are given in utf-8 and not,
+            # like, ASCII
+            f.write(
+                self.body.encode("UTF-8") if isinstance(self.body, str) else self.body
+            )
+
+        pass
+
+    def persist(self):
+        if self.bucket_name:
+            self._persist_to_s3()
+        else:
+            self._persist_to_local()
+        return
+
+
+def upload_csv(key_name: str, csv: str, output_dir: str):
+    blob = {
+        "key": f"{key_name}.csv",
+        "body": csv,
+        "output_dir": output_dir,
+    }
+    obj = DatasetDeployer(**blob)
+    obj.persist()
+    _logger.info(f"Generated csv for {key_name}")
+
+
+def deploy_shape_files(
+    output_dir: str,
+    key: str,
+    shp_bytes: io.BytesIO,
+    shx_bytes: io.BytesIO,
+    dbf_bytes: io.BytesIO,
+):
+    """Deploys shape files to specified output dir.
+
+    Args:
+        output_dir: Output directory to save shapefiles to.
+        key: stem of filename to save shapefiles to.
+        shp_bytes:
+        shx_bytes:
+        dbf_bytes:
+    """
+    DatasetDeployer(
+        key=f"{key}.shp", body=shp_bytes.getvalue(), output_dir=output_dir
+    ).persist()
+    DatasetDeployer(
+        key=f"{key}.shx", body=shx_bytes.getvalue(), output_dir=output_dir
+    ).persist()
+    DatasetDeployer(
+        key=f"{key}.dbf", body=dbf_bytes.getvalue(), output_dir=output_dir
+    ).persist()


### PR DESCRIPTION
More work on 145 https://github.com/covid-projections/covid-data-model/issues/145

Moves logic out of deploy_dod_dataset + adds a helper function to deploy all shapefiles


### Please Check
- [ ] Will the *current* schema in [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.md) be updated with this PR?
- [ ] Are tests passing?
