### PR TITLE
Add deploy-api Github Action workflow.

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -1,0 +1,75 @@
+# To debug, it's recommended you modify / use the version in the test-actions repo:
+# https://github.com/covid-projections/test-actions/blob/master/.github/workflows/deploy_api.yml
+
+name: Build / Publish API artifacts to data.covidactnow.org
+
+on:
+  # JHU posts new data at 11:30 (UTC).
+  # covid-data-public fetches it at 12:00 (UTC).
+  # So we rebuild / publish the API at 12:30 (UTC).
+  schedule:
+   - cron: '30 12 * * *'
+
+  # Hook to trigger a manual run.
+  # See: https://goobar.io/2019/12/07/manually-trigger-a-github-actions-workflow/
+  repository_dispatch:
+    types: publish-api
+
+jobs:
+  publish-api:
+    runs-on: ubuntu-latest
+
+    env:
+      AWS_S3_BUCKET: 'data.covidactnow.org'
+      # To pin to an old data set or model code, put the branch/tag/commit here:
+      COVID_DATA_PUBLIC_REF: 'master'
+      COVID_DATA_MODEL_REF: 'master'
+      SNAPSHOT_ID: ${{github.run_number}}
+
+    steps:
+    - name: Checkout covid-data-model
+      uses: actions/checkout@v2
+      with:
+        repository: covid-projections/covid-data-model
+        path: covid-data-model
+        ref: '${{env.COVID_DATA_MODEL_REF}}'
+    - name: Checkout covid-data-public
+      uses: actions/checkout@v2
+      with:
+        repository: covid-projections/covid-data-public
+        path: covid-data-public
+        lfs: true
+        ref: '${{env.COVID_DATA_PUBLIC_REF}}'
+
+    - name: Setup Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.7.6'
+        architecture: 'x64'
+    - name: Cache Pip
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+          ${{ runner.os }}-
+    - name: Install Dependencies
+      run: pip install -r covid-data-model/requirements.txt
+
+    - name: Build API Artifacts (run.sh)
+      env:
+        COVID_MODEL_CORES: 2
+      run: ./covid-data-model/run.sh ./covid-data-public ./api_results
+
+    - name: Deploy Artifacts to S3 (https://data.covidactnow.org/snapshot/${{env.SNAPSHOT_ID}}/).
+      uses: jakejarvis/s3-sync-action@master
+      with:
+        args: --acl public-read --follow-symlinks --delete
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        SOURCE_DIR: './api_results/'
+        DEST_DIR: 'snapshot/${{env.SNAPSHOT_ID}}'
+
+      # TODO: Upload RedirectRules to AWS to make snapshot/latest pointer work.

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -1,7 +1,7 @@
 # To debug, it's recommended you modify / use the version in the test-actions repo:
 # https://github.com/covid-projections/test-actions/blob/master/.github/workflows/deploy_api.yml
 
-name: Build / Publish API artifacts to data.covidactnow.org
+name: Build & Publish API artifacts to data.covidactnow.org
 
 on:
   # JHU posts new data at 11:30 (UTC).


### PR DESCRIPTION
* Runs run.sh and publishes the results to data.covidactnow.org/snapshot/<run-id>
* Scheduled for 12:30 daily, which should be after the relevant covid-data-public
  update.

@fridiculous Before we merge this we need to add the AWS secrets for the data bucket to github (as AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY).  Can you do that?