### PR TITLE
Move run py to pipelines

### DIFF
--- a/libs/pipelines/can_model_pipeline.py
+++ b/libs/pipelines/can_model_pipeline.py
@@ -470,10 +470,3 @@ def run_state_level_forecast(
 
     pool.close()
     pool.join()
-
-
-if __name__ == "__main__":
-    _logger.warning(
-        "Models are no longer ran from run.py. Please see README.md for the most up to date "
-        "way to run models."
-    )

--- a/run_model.py
+++ b/run_model.py
@@ -4,7 +4,7 @@ import datetime
 import logging
 import click
 from libs.datasets import data_version
-import run
+from libs.pipelines import can_model_pipeline
 
 _logger = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ def run_county(
     min_date = datetime.datetime(2020, 3, 7)
     max_date = datetime.datetime(2020, 7, 6)
 
-    run.run_county_level_forecast(
+    can_model_pipeline.run_county_level_forecast(
         min_date, max_date, output, country="USA", state=state
     )
     if not state:
@@ -53,7 +53,7 @@ def run_county(
 def run_county_summary(version: data_version.DataVersion, output, state=None):
     """Run county level model."""
     min_date = datetime.datetime(2020, 3, 7)
-    run.build_county_summary(min_date, output, state=state)
+    can_model_pipeline.build_county_summary(min_date, output, state=state)
 
     # only write the version if we saved everything
     if not state:
@@ -77,7 +77,7 @@ def run_state(version: data_version.DataVersion, output, state=None):
     min_date = datetime.datetime(2020, 3, 7)
     max_date = datetime.datetime(2020, 7, 6)
 
-    run.run_state_level_forecast(min_date, max_date, output, country="USA", state=state)
+    can_model_pipeline.run_state_level_forecast(min_date, max_date, output, country="USA", state=state)
     _logger.info(f"Wrote output to {output}")
     # only write the version if we saved everything
     if not state:


### PR DESCRIPTION
This PR addresses issue https://github.com/covid-projections/covid-data-model/issues/145

This just moves the functionality to run the normal model into the pipelines folder.

To be clear, nothing is actually running from run.py directly, it's only accessed from `./run_model.py`.

I'd like to improve the cli structure so that we'll have an entry point for the existing run_model.py and run_data.py files. By moving this to a pipeline, i can make a new run.py to be an actual entry point.

### Please Check
- [ ] Will the *current* schema in [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.md) be updated with this PR?
- [ ] Are tests passing?
