### PR TITLE
Move to common cli

### DIFF
--- a/cli/run_data.py
+++ b/cli/run_data.py
@@ -15,8 +15,9 @@ from libs.datasets import data_version
 _logger = logging.getLogger(__name__)
 
 
-@click.group()
+@click.group('data')
 def main():
+    """Generate reports from raw data."""
     pass
 
 

--- a/cli/run_dod_dataset.py
+++ b/cli/run_dod_dataset.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+
 import click
 import logging
 
@@ -8,12 +9,24 @@ logger = logging.getLogger(__name__)
 PROD_BUCKET = "data.covidactnow.org"
 
 
-@click.command()
+@click.command('deploy-dod')
 @click.option('--run_validation', '-r', default=True, help='Run the validation on the deploy command')
 @click.option('--input-dir', '-i', default='results', help='Input directory of state/county projections')
 @click.option('--output', '-o', default='results/dod', help='Output directory for artifacts')
-def deploy(run_validation, input_dir, output):
-    """The entry function for invocation"""
+def deploy_dod_projections(run_validation, input_dir, output):
+    """Generates and runs dod data projections from model outputs.
+
+    Used for manual trigger
+
+    # triggering persistance to s3
+    AWS_PROFILE=covidactnow BUCKET_NAME=covidactnow-deleteme python run.py deploy-dod-projections
+
+    # deploy to the data bucket
+    AWS_PROFILE=covidactnow BUCKET_NAME=data.covidactnow.org python run.py deploy-dod-projections
+
+    # triggering persistance to local
+    python run.py deploy-dod-projections
+    """
 
     for intervention in list(Intervention):
         logger.info(f"Starting to generate files for {intervention.name}.")
@@ -25,20 +38,3 @@ def deploy(run_validation, input_dir, output):
         dod_pipeline.deploy_results(county_result, output)
 
     logger.info('finished dod job')
-
-
-if __name__ == "__main__":
-    """Used for manual trigger
-
-    # triggering persistance to s3
-    AWS_PROFILE=covidactnow BUCKET_NAME=covidactnow-deleteme python deploy_dod_dataset.py
-
-    # deploy to the data bucket
-    AWS_PROFILE=covidactnow BUCKET_NAME=data.covidactnow.org python deploy_dod_dataset.py
-
-    # triggering persistance to local
-    python deploy_dod_dataset.py
-    """
-    logging.basicConfig(level=logging.INFO)
-    # pylint: disable=no-value-for-parameter
-    deploy()

--- a/cli/run_model.py
+++ b/cli/run_model.py
@@ -9,8 +9,9 @@ from libs.pipelines import can_model_pipeline
 _logger = logging.getLogger(__name__)
 
 
-@click.group()
+@click.group('model')
 def main():
+    """Run models"""
     pass
 
 

--- a/deploy_dod.sh
+++ b/deploy_dod.sh
@@ -16,8 +16,8 @@ RESULTS_DIR="results/dod_results"
 mkdir -p "${MODELS_DIR}"
 
 # Run State and County level models
-./run_model.py state -o "${MODELS_DIR}/state"
-./run_model.py county -o "${MODELS_DIR}/county"
+./run.py model state -o "${MODELS_DIR}/state"
+./run.py model county -o "${MODELS_DIR}/county"
 
 mkdir -p dod_results
-./deploy_dod_dataset.py -i "${MODELS_DIR}" -o "${RESULTS_DIR}"
+./run.py deploy-dod -i "${MODELS_DIR}" -o "${RESULTS_DIR}"

--- a/deploy_website.sh
+++ b/deploy_website.sh
@@ -14,8 +14,8 @@ if [ ! -d "${PUBLIC_DATA_PATH}" ] ; then
 fi
 
 # Run State and County level models
-./run_model.py state -o "${PUBLIC_DATA_PATH}"
-./run_model.py county -o "${PUBLIC_DATA_PATH}/county"
-./run_model.py county-summary -o "${PUBLIC_DATA_PATH}/county_summaries"
+./run.py model state -o "${PUBLIC_DATA_PATH}"
+./run.py model county -o "${PUBLIC_DATA_PATH}/county"
+./run.py model county-summary -o "${PUBLIC_DATA_PATH}/county_summaries"
 # Generate the latest state case summary data.
-./run_data.py latest -o "${PUBLIC_DATA_PATH}/case_summary"
+./run.py data latest -o "${PUBLIC_DATA_PATH}/case_summary"

--- a/run.py
+++ b/run.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+"""
+Entry point for covid-data-model CLI.
+
+"""
+import logging
+import click
+from cli import run_data
+from cli import run_model
+from cli import run_dod_dataset
+
+
+@click.group()
+def entry_point():
+    """Entry point for covid-data-model CLI."""
+    pass
+
+
+entry_point.add_command(run_data.main)
+entry_point.add_command(run_model.main)
+entry_point.add_command(run_dod_dataset.deploy_dod_projections)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    entry_point()

--- a/run.sh
+++ b/run.sh
@@ -52,23 +52,23 @@ execute() {
 
   echo ">>> Generating state models to ${STATES_DIR}"
   # TODO(#148): We need to clean up the output of these scripts!
-  ./run_model.py state -o "${API_OUTPUT_DIR}" > /dev/null
+  ./run.py model state -o "${API_OUTPUT_DIR}" > /dev/null
 
   echo ">>> Generating county models to ${COUNTIES_DIR}"
   # TODO(#148): We need to clean up the output of these scripts!
-  ./run_model.py county -o "${COUNTIES_DIR}" > /dev/null
+  ./run.py model county -o "${COUNTIES_DIR}" > /dev/null
 
   echo ">>> Generating county summaries to ${COUNTY_SUMMARIES_DIR}"
   # TODO(#148): We need to clean up the output of these scripts!
-  ./run_model.py county-summary -o "${COUNTY_SUMMARIES_DIR}" > /dev/null
+  ./run.py model county-summary -o "${COUNTY_SUMMARIES_DIR}" > /dev/null
 
   echo ">>> Generating case summaries to ${CASE_SUMMARIES_DIR}"
   # TODO(#148): We need to clean up the output of these scripts!
-  ./run_data.py latest -o "${CASE_SUMMARIES_DIR}" > /dev/null
+  ./run.py data latest -o "${CASE_SUMMARIES_DIR}" > /dev/null
 
   echo ">>> Generating DoD artifacts to ${DOD_DIR}"
   mkdir -p "${DOD_DIR}"
-  ./deploy_dod_dataset.py -i "${STATES_DIR}" -o "${DOD_DIR}"
+  ./run.py deploy-dod -i "${STATES_DIR}" -o "${DOD_DIR}"
 
   echo ">>> Generating ${API_OUTPUT_DIR}/version.json"
   generate_version_json


### PR DESCRIPTION
This PR addresses issue https://github.com/covid-projections/covid-data-model/issues/145

Okay - a bit larger change.

This just hooks in all of the various command lines into one master cli so it's easier to get around and gives a common home for all cli functionality. 

I didn't do any restructuring right now, just wanted to keep the current structure as closely as possible.

I'm running all of the deploy scripts right now to verify that everything hooks together.


```
(covid-data-model) ➜  covid-data-model git:(move-to-common-cli) ✗ ./run.py
Usage: run.py [OPTIONS] COMMAND [ARGS]...

  Entry point for covid-data-model CLI.

Options:
  --help  Show this message and exit.

Commands:
  data        Generate reports from raw data.
  deploy-dod  Generates and runs dod data projections from model outputs.
  model       Run models
```

### Please Check
- [ ] Will the *current* schema in [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.md) be updated with this PR?
- [ ] Are tests passing?
