### PR TITLE
Fixing duplicate county data in beds

### DIFF
--- a/.github/workflows/python_unit_tests.yml
+++ b/.github/workflows/python_unit_tests.yml
@@ -4,6 +4,8 @@ on: [push]
 
 jobs:
   build:
+    env:
+      COVID_DATA_PUBLIC_REF: 'master'
 
     runs-on: ubuntu-latest
     strategy:
@@ -11,6 +13,13 @@ jobs:
         python-version: [3.7]
 
     steps:
+    - name: Checkout covid-data-public
+      uses: actions/checkout@v2
+      with:
+        repository: covid-projections/covid-data-public
+        path: covid-data-public
+        lfs: true
+        ref: '${{env.COVID_DATA_PUBLIC_REF}}'
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1

--- a/.github/workflows/python_unit_tests.yml
+++ b/.github/workflows/python_unit_tests.yml
@@ -20,7 +20,11 @@ jobs:
         path: covid-data-public
         lfs: true
         ref: '${{env.COVID_DATA_PUBLIC_REF}}'
-    - uses: actions/checkout@v2
+    - name: Checkout covid-data-model
+      uses: actions/checkout@v2
+      with:
+        repository: covid-projections/covid-data-model
+        path: covid-data-model
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
@@ -29,6 +33,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt -r requirements_test.txt
+      working-directory: ./covid-data-model
     - name: Test with pytest
       run: |
         make test
+      working-directory: ./covid-data-model

--- a/libs/datasets/dataset_utils.py
+++ b/libs/datasets/dataset_utils.py
@@ -198,7 +198,7 @@ def add_county_using_fips(data, fips_data):
     is_county = data.aggregate_level == AggregationLevel.COUNTY.value
     # Only want to add county names to county level data, so we'll slice out the county
     # data and combine it back at the end.
-    not_county = data[~is_county]
+    not_county_df = data[~is_county]
     data = data[is_county]
     fips_data = fips_data[fips_data.aggregate_level == AggregationLevel.COUNTY.value]
 
@@ -225,7 +225,7 @@ def add_county_using_fips(data, fips_data):
     if "county_r" in data.columns:
         data = data.drop(columns="county").rename({"county_r": "county"}, axis=1)
 
-    return pd.concat([data, not_county])
+    return pd.concat([data, not_county_df])
 
 
 def assert_counties_have_fips(data, county_key='county', fips_key='fips'):

--- a/libs/datasets/dataset_utils.py
+++ b/libs/datasets/dataset_utils.py
@@ -195,6 +195,13 @@ def build_fips_data_frame():
 
 
 def add_county_using_fips(data, fips_data):
+    is_county = data.aggregate_level == AggregationLevel.COUNTY.value
+    # Only want to add county names to county level data, so we'll slice out the county
+    # data and combine it back at the end.
+    not_county = data[~is_county]
+    data = data[is_county]
+    fips_data = fips_data[fips_data.aggregate_level == AggregationLevel.COUNTY.value]
+
     data = data.set_index(["fips", "state"])
     fips_data = fips_data.set_index(["fips", "state"])
     data = data.join(fips_data[["county"]], on=["fips", "state"], rsuffix="_r").reset_index()
@@ -216,8 +223,9 @@ def add_county_using_fips(data, fips_data):
         _logger.warning(f"{unique_fips}")
 
     if "county_r" in data.columns:
-        return data.drop("county").rename({"count_r": "county"}, axis=1)
-    return data
+        data = data.drop(columns="county").rename({"county_r": "county"}, axis=1)
+
+    return pd.concat([data, not_county])
 
 
 def assert_counties_have_fips(data, county_key='county', fips_key='fips'):

--- a/test/beds_dataset_test.py
+++ b/test/beds_dataset_test.py
@@ -1,6 +1,7 @@
 import pytest
 import pandas as pd
 from libs.datasets import beds
+from libs.datasets import DHBeds
 from libs.datasets import dataset_utils
 
 
@@ -94,3 +95,8 @@ def test_duplicate_index_fails(is_county):
 
     with pytest.raises(dataset_utils.DuplicateValuesForIndex):
         build_beds_dataset(rows)
+
+
+def test_dh_beds_loading():
+    beds_data = DHBeds.local().beds()
+    assert beds_data


### PR DESCRIPTION
This PR addresses issue https://github.com/covid-projections/covid-data-model/issues/201

It also pulls down the covid-data-public repo so that we can write tests on the actual data sources we have.  I think in the ideal world I would rather have smaller unit test coverage, but this will at least give us an opportunity to make sure PRs aren't breaking existing behavior.

### Please Check
- [ ] Will the *current* schema in [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.md) be updated with this PR?
- [x] Are tests passing?
