### PR TITLE
Add workflow for labelling snapshots and tools/label-api.sh helper for invoking.

### DIFF
--- a/.github/workflows/label_api_snapshot.yml
+++ b/.github/workflows/label_api_snapshot.yml
@@ -1,0 +1,44 @@
+# To debug, it's recommended you modify / use the version in the test-actions repo:
+# https://github.com/covid-projections/test-actions/blob/master/.github/workflows/label_api_snapshot.yml
+
+# Used to assign a label (like /snapshot/latest or /v0) to a published API
+# snapshot (like /snapshot/123).
+#
+name: Label API Snapshot.
+
+on:
+  # Hook to trigger a manual run.
+  # See: https://goobar.io/2019/12/07/manually-trigger-a-github-actions-workflow/
+  repository_dispatch:
+    types: label-api-snapshot
+
+jobs:
+  label-api-snapshot:
+    runs-on: ubuntu-latest
+
+    env:
+      AWS_S3_BUCKET: 'data.covidactnow.org'
+      LABEL: '${{ github.event.client_payload.label }}'
+      SNAPSHOT_ID: '${{ github.event.client_payload.snapshot_id }}'
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+    - name: Verify Label provided
+      if: ${{ !env.LABEL }}
+      run: 'echo "Missing client_payload parameter: label" ; exit 1'
+    - name: Verify Snapshot ID provided
+      if: ${{ !env.SNAPSHOT_ID }}
+      run: 'echo "Missing client_payload parameter: snapshot_id" ; exit 1'
+
+    # TODO: We want to replace this with a "symlink" of some kind, perhaps implemented at
+    # the CloudFront layer.
+    - name: Create Label (Copy files from /snapshot/${{env.SNAPSHOT_ID}}/ to /${{env.LABEL}}/)
+      uses: jakejarvis/s3-sync-action@master
+      with:
+        args: --acl public-read --follow-symlinks --delete
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        SOURCE_DIR: 's3://${{env.AWS_S3_BUCKET}}/snapshot/${{env.SNAPSHOT_ID}}/'
+        DEST_DIR: '${{env.LABEL}}/'

--- a/README.md
+++ b/README.md
@@ -24,23 +24,23 @@ See [covid-data-public](https://github.com/covid-projections/covid-data-public) 
 
 ## [Setup](./SETUP.md)
 
-# Running
+# API Snapshots
 
-To run a formalized job, kick it off with github actions.  Set your local token.
+We build & publish an API snapshot (e.g. https://data.covidactnow.org/snapshot/123/) twice a day via a [github action](./.github/workflows/deploy_api.yml).
+To manually kick off a new snapshot, get a
+[perosnal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line),
+and run:
 
 ```bash
 export GITHUB_TOKEN=<YOUR PERSONAL GITHUB TOKEN>
+./tools/publish-api.sh
 ```
 
-Then simply trigger the publish job with:
+Once a snapshot has been vetted, you can "label" it with a friendly name, e.g. pointing https://data.covidactnow.org/v0/ at https://data.covidactnow.org/snapshot/123/ with:
 ```bash
-curl -H "Accept: application/vnd.github.everest-preview+json" \
-    -H "Authorization: token $GITHUB_TOKEN" \
-    --request POST \
-    --data '{"event_type": "publish-api"}' \
-    https://api.github.com/repos/covid-projections/covid-data-model/dispatches
+export GITHUB_TOKEN=<YOUR PERSONAL GITHUB TOKEN>
+./tools/label-api.sh v0 123
 ```
-
 
 # Development
 

--- a/README.md
+++ b/README.md
@@ -26,14 +26,15 @@ See [covid-data-public](https://github.com/covid-projections/covid-data-public) 
 
 # API Snapshots
 
-We build & publish an API snapshot (e.g. https://data.covidactnow.org/snapshot/123/) twice a day via a [github action](./.github/workflows/deploy_api.yml).
-To manually kick off a new snapshot, get a
-[perosnal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line),
+We automatically build & publish an API snapshot (e.g. https://data.covidactnow.org/snapshot/123/) 
+twice a day via a [github action](./.github/workflows/deploy_api.yml).  To manually kick off a new
+snapshot, get a
+[personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line),
 and run:
 
 ```bash
 export GITHUB_TOKEN=<YOUR PERSONAL GITHUB TOKEN>
-./tools/publish-api.sh
+./tools/push-api.sh
 ```
 
 Once a snapshot has been vetted, you can "label" it with a friendly name, e.g. pointing https://data.covidactnow.org/v0/ at https://data.covidactnow.org/snapshot/123/ with:

--- a/tools/label-api.sh
+++ b/tools/label-api.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# label-api.sh - Assigns a label (e.g. 'v0') to a published API snapshot (e.g '15')
+
+set -o nounset
+set -o errexit
+
+CMD=$0
+
+# Checks command-line arguments, sets variables, etc.
+prepare () {
+  # Parse args if specified.
+  if [ $# -ne 2 ]; then
+    exit_with_usage
+  else
+    LABEL=$1
+    SNAPSHOT_ID=$2
+  fi
+
+  if ! [[ $SNAPSHOT_ID =~ ^[0-9]+$ ]] ; then
+    echo "Error: Specified Snapshot ID ($SNAPSHOT_ID) should be a plain number."
+    echo
+    exit_with_usage
+  fi
+
+  if [[ $LABEL =~ ^/ ]] ; then
+    echo "Error: Specified Label ($LABEL) should not start with a '/'."
+    echo
+    exit_with_usage
+  fi
+
+  if [[ -z ${GITHUB_TOKEN:-} ]]; then
+    echo "Error: GITHUB_TOKEN must be set to a personal access token. See:"
+    echo "https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line"
+    exit 1
+  fi
+}
+
+exit_with_usage () {
+  echo "Usage: $CMD <label> <snapshot-id>"
+  echo
+  echo "Examples:"
+  echo "$CMD v0 15                # Points /v0 at /snapshot/15"
+  echo "$CMD snapshot/latest 15   # Points /snapshot/latest at /snapshot/15"
+  exit 1
+}
+
+execute () {
+  curl -H "Authorization: token $GITHUB_TOKEN" \
+      --request POST \
+      --data "{\"event_type\": \"label-api-snapshot\", \"client_payload\": { \"label\": \"${LABEL}\", \"snapshot_id\": \"${SNAPSHOT_ID}\" } }" \
+      https://api.github.com/repos/covid-projections/covid-data-model/dispatches
+
+  echo "Label requested. Go to https://github.com/covid-projections/covid-data-model/actions to monitor progress."
+}
+
+prepare "$@"
+execute

--- a/tools/publish-api.sh
+++ b/tools/publish-api.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# publish-api.sh - Builds and publishes a new API snapshot (e.g.
+# https://data.covidactnow.org/snapshot/123/).
+
+set -o nounset
+set -o errexit
+
+CMD=$0
+
+# Checks command-line arguments, sets variables, etc.
+prepare () {
+  # Parse args if specified.
+  if [ $# -ne 0 ]; then
+    exit_with_usage
+  fi
+
+  if [[ -z ${GITHUB_TOKEN:-} ]]; then
+    echo "Error: GITHUB_TOKEN must be set to a personal access token. See:"
+    echo "https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line"
+    exit 1
+  fi
+}
+
+exit_with_usage () {
+  echo "Usage: $CMD"
+  exit 1
+}
+
+execute () {
+  curl -H "Authorization: token $GITHUB_TOKEN" \
+      --request POST \
+      --data "{\"event_type\": \"publish-api\", }" \
+      https://api.github.com/repos/covid-projections/covid-data-model/dispatches
+
+  echo "Publish requested. Go to https://github.com/covid-projections/covid-data-model/actions to monitor progress."
+}
+
+prepare "$@"
+execute

--- a/tools/push-api.sh
+++ b/tools/push-api.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# publish-api.sh - Builds and publishes a new API snapshot (e.g.
+# push-api.sh - Builds and publishes a new API snapshot (e.g.
 # https://data.covidactnow.org/snapshot/123/).
 
 set -o nounset


### PR DESCRIPTION
Add Github Action Workflow for labeling snapshots.
* Triggers off of a repository dispatch with event type 'label-api-snapshot'.
* Requires 'label' and 'snapshot_id' in the payload.
* For now just copies the files, but we'd like a symlink or similar in the future.

Also added `tools/publish-api.sh` and `tools/label-api.sh` helpers for invoking
workflows manually, and added to README.md.

This PR helps address issue #126.

### Please Check
- [ ] Will the *current* schema in [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.md) be updated with this PR?
- [ ] Are tests passing?
