### PR TITLE
Model/optimize pyseir integration

### DIFF
--- a/pyseir/models/seir_model.py
+++ b/pyseir/models/seir_model.py
@@ -172,7 +172,7 @@ class SEIRModel:
                  mortality_rate_no_ICU_beds=1.,
                  mortality_rate_from_ICUVent=1.0,
                  mortality_rate_no_general_beds=0.0,
-                 initial_hospital_bed_utilization=0.6):
+                 initial_hospital_bed_utilization=0.6,):
 
         self.N = N
         self.suppression_policy = suppression_policy

--- a/pyseir/models/seir_model_age.py
+++ b/pyseir/models/seir_model_age.py
@@ -636,7 +636,7 @@ class SEIRModelAge:
         R, D, D_no_hgen, D_no_icu, HAdmissions_general, HAdmissions_ICU, TotalAllInfections = result_time_series[-7:]
 
         if self.approximate_R0:
-            Rt = self.suppression_policy(self.t_list)
+            Rt = self.R0 * self.suppression_policy(self.t_list)
         else:
             S_fracs_within_age_group = S / S.sum(axis=0)
             if self.suppression_policy is not None:

--- a/pyseir/models/seir_model_age.py
+++ b/pyseir/models/seir_model_age.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.integrate import odeint, solve_ivp
+from scipy.integrate import solve_ivp
 import matplotlib.pyplot as plt
 
 

--- a/pyseir/models/suppression_policies.py
+++ b/pyseir/models/suppression_policies.py
@@ -154,7 +154,7 @@ def generate_covidactnow_scenarios(t_list, R0, t0, scenario):
         else:
             raise ValueError(f'Invalid scenario {scenario}')
 
-    return interp1d(t_list, rho, fill_value='extrapolate')
+    return lambda x: np.interp(x, t_list, rho)
 
 
 def generate_two_step_policy(t_list, eps, t_break, transition_time=14):
@@ -177,10 +177,11 @@ def generate_two_step_policy(t_list, eps, t_break, transition_time=14):
     suppression_model: callable
         suppression_model(t) returns the current suppression model at time t.
     """
-    return interp1d(
-        x=[0, t_break, t_break + transition_time, 100000],
-        y=[1, 1, eps, eps],
-        fill_value='extrapolate')
+    return lambda x: np.interp(
+        x,
+        [0, t_break, t_break + transition_time, 100000],
+        [1, 1, eps, eps]
+    )
 
 
 def generate_empirical_distancing_policy(t_list, fips, future_suppression,
@@ -263,7 +264,7 @@ def generate_empirical_distancing_policy(t_list, fips, future_suppression,
 
     t_list_since_reference_date = t_list + (pd.to_datetime(t0) - pd.to_datetime(reference_start_date)).days
 
-    return interp1d(t_list_since_reference_date, rho, fill_value='extrapolate')
+    return lambda x: np.interp(x, t_list_since_reference_date, rho)
 
 
 def generate_empirical_distancing_policy_by_state(t_list, state, future_suppression, reference_start_date=None):
@@ -312,7 +313,7 @@ def generate_empirical_distancing_policy_by_state(t_list, state, future_suppress
         results.append(suppression_policy(t_list).clip(max=1, min=0))
     results_for_state = (np.vstack(results).T * weight).sum(axis=1)
 
-    return interp1d(t_list, results_for_state, fill_value='extrapolate')
+    return lambda x: np.interp(x, t_list, results_for_state)
 
 
 def piecewise_parametric_policy(x, t_list):


### PR DESCRIPTION
Age structure dynamics add substantial matrix calculations to the SEIR model which produced a 50x runtime hit per simulation.  The additional variable tracking required also introduces expensive jacobian computation for the standard ODEINT solver. Switching to a Runge-Kutta method provides much faster integration.  Low level optimizations have also been made to interpolation, array insertion, and array splitting.

Deep optimization of age structured dynamics.  Takes runtime from about 500ms per sim -> 35ms per sim with no loss to accuracy for 18 age bins.