### PR TITLE
Pyseir ensemble parameter generator cleanup

### DIFF
--- a/pyseir/ensembles/ensemble_runner.py
+++ b/pyseir/ensembles/ensemble_runner.py
@@ -73,6 +73,7 @@ class EnsembleRunner:
         self.fips = fips
         self.agg_level = AggregationLevel.COUNTY if len(fips) == 5 else AggregationLevel.STATE
 
+        # generates list of times to run model for.
         self.t_list = np.linspace(0, int(365 * n_years), int(365 * n_years))
         self.skip_plots = skip_plots
         self.run_mode = RunMode(run_mode)
@@ -311,7 +312,7 @@ class EnsembleRunner:
             else:
                 parameter_sampler = ParameterEnsembleGenerator(fips=self.fips)
                 parameter_ensemble = parameter_sampler.sample_seir_parameters(
-                    self.N_samples, override_params=self.override_params
+                    self.n_samples, override_params=self.override_params
                 )
                 model_ensemble = [
                     self._run_single_simulation(suppression_policy, parameters)

--- a/pyseir/ensembles/ensemble_runner.py
+++ b/pyseir/ensembles/ensemble_runner.py
@@ -266,7 +266,7 @@ class EnsembleRunner:
 
         elif self.run_mode is RunMode.DEFAULT:
             for suppression_policy in self.suppression_policy:
-                self.suppression_policies[f'suppression_policy__{suppression_policy}']= generate_empirical_distancing_policy(
+                self.suppression_policies[f'suppression_policy__{suppression_policy}'] = generate_empirical_distancing_policy(
                     t_list=self.t_list, fips=self.fips, future_suppression=suppression_policy)
             self.override_params = dict()
         else:
@@ -278,6 +278,8 @@ class EnsembleRunner:
 
         Parameters
         ----------
+        suppression_policy: scipy.interpolate.interpolate.interp1d
+            Suppression policy to run.
         parameter_set: dict
             Params passed to the SEIR model
 

--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -175,22 +175,20 @@ class ModelFitter:
     def get_average_seir_parameters(self):
         """
         Generate the additional fitter candidates from the ensemble generator. This
-        has the suppression policy and R0 keys removed.
+        has the R0 key removed.
 
         Returns
         -------
         SEIR_kwargs: dict
             The average ensemble params.
         """
-        SEIR_kwargs = ParameterEnsembleGenerator(
-            fips=self.fips,
-            N_samples=5000,
-            t_list=self.t_list,
-            suppression_policy=None).get_average_seir_parameters()
+        N_samples = 5000
+        ensemble_generator = ParameterEnsembleGenerator(fips=self.fips)
+        SEIR_kwargs = ensemble_generator.get_average_seir_parameters(N_samples)
 
         SEIR_kwargs = {k: v for k, v in SEIR_kwargs.items() if k not in self.fit_params}
-        del SEIR_kwargs['suppression_policy']
         del SEIR_kwargs['I_initial']
+
         return SEIR_kwargs
 
     def calculate_observation_errors(self):
@@ -302,10 +300,12 @@ class ModelFitter:
         self.SEIR_kwargs['E_initial'] = self.steady_state_exposed_to_infected_ratio * 10 ** log10_I_initial
 
         model = SEIRModel(
+            t_list=self.t_list,
             R0=R0,
             suppression_policy=suppression_policy,
             I_initial=10 ** log10_I_initial,
-            **self.SEIR_kwargs)
+            **self.SEIR_kwargs
+        )
         model.run()
         return model
 


### PR DESCRIPTION
Couple things this PR does:

 - pulls out a couple variables that were in the ensemble generator just to be passed through to the seir model.  This include `suppression_policy` and `t_list`.  In both cases, we can use the context that the SEIRModel is called from to pass through those variables. 
 - Moves `N_samples` out of the `__init__` for ensemble_generator.  The idea being that `N_samples` is less of a property of the generator itself and more of how you want to use the generator.  For instance, I would expect you to be able to call: 
```
ensemble_generator = ParameterEnsembleGenerator(fips)
ensemble_generator.sample(500)
ensemble_generator.sample(5000)
```
without having to create a new instance.

I ran the models on missouri locally and got results the were in the same ballpark as when i ran it on master.  Not sure if there are any other checks you'd like me to run to verify.