### PR TITLE
Add sentry and a basic catch all exception tracker

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -62,6 +62,7 @@ jobs:
     - name: Build Model Results (run.sh .. .. execute_model)
       env:
         COVID_MODEL_CORES: 96
+        SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       run: ./covid-data-model/run.sh ./covid-data-public /data/api-results-${{env.SNAPSHOT_ID}} execute_model
     - name: Zip Model Results (run.sh .. .. execute_zip_folder)
       run: ./covid-data-model/run.sh ./covid-data-public /data/api-results-${{env.SNAPSHOT_ID}} execute_zip_folder
@@ -118,6 +119,7 @@ jobs:
     - name: Build Summaries (run.sh .. .. execute_summaries)
       env:
         COVID_MODEL_CORES: 96
+        SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       run: ./covid-data-model/run.sh ./covid-data-public /data/api-results-${{env.SNAPSHOT_ID}} execute_summaries
     # - name: Upload Summaries with Model Results
     #   uses: actions/upload-artifact@v1
@@ -172,6 +174,7 @@ jobs:
     - name: Build DoD (run.sh .. .. execute_summaries)
       env:
         COVID_MODEL_CORES: 96
+        SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       run: ./covid-data-model/run.sh ./covid-data-public /data/api-results-${{env.SNAPSHOT_ID}} execute_dod
     # - name: Upload DoD with Model Results
     #   uses: actions/upload-artifact@v1
@@ -226,6 +229,7 @@ jobs:
     - name: Build API (run.sh .. .. execute_api)
       env:
         COVID_MODEL_CORES: 96
+        SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       run: ./covid-data-model/run.sh ./covid-data-public /data/api-results-${{env.SNAPSHOT_ID}} execute_api
     # - name: Upload API with Model Results
     #   uses: actions/upload-artifact@v1

--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ python deploy_dod_dataset.py
 BUCKET_NAME=<bucket name> python deploy_dod_dataset.py
 ```
 
+# Sentry
+In order to have sentry run locally and report errors to the dev sentry instance, add the following to your .env
+```
+export SENTRY_DSN=https://<GET_SENTRY_DSN_FOR_DEV_INSTANCE>.ingest.sentry.io/<DEV_INSTANCE>
+```
+
+The gitub action pulls the sentry_dsn for the prod instance from a secrets stored within github. 
 
 # [NEW 4/7] PySEIR Setup
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ simplejson==3.17.0
 boto3==1.12.28
 seaborn==0.10.0
 click==7.1.1
+sentry-sdk==0.14.3
 scikit-learn
 pip
 iminuit

--- a/run.py
+++ b/run.py
@@ -3,8 +3,10 @@
 Entry point for covid-data-model CLI.
 
 """
+import os
 import logging
 import click
+import sentry_sdk
 from cli import run_data
 from cli import run_model
 from cli import run_dod_dataset
@@ -30,5 +32,11 @@ entry_point.add_command(run_states_api.deploy_states_api)
 entry_point.add_command(api.main)
 
 if __name__ == "__main__":
+    sentry_sdk.init(os.getenv("SENTRY_DSN"))
     logging.basicConfig(level=logging.INFO)
-    entry_point()
+    try: 
+        entry_point()
+    except Exception as e: 
+        # blanket catch excpetions at the entry point and send them to sentry
+        sentry_sdk.capture_exception(e)
+        raise e


### PR DESCRIPTION
We need to add SENTRY_DSN into the github secrets, but this will add exception logging to slack so that we can more easily start seeing errors! 

This PR addresses issue https://github.com/covid-projections/covid-data-model/issues/< >


### Please Check
- [ ] Will the *current* schema in [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.md) be updated with this PR?
- [ ] Are tests passing?
