### PR TITLE
Generate pyseir_state_summaries.zip as part of execute_model

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -75,6 +75,11 @@ execute_model() {
   rmdir ${API_OUTPUT_DIR}/web_ui/state/
   rmdir ${API_OUTPUT_DIR}/web_ui/
 
+  echo ">>> Generating pyseir_state_summaries.zip from output/pyseir/state_summaries."
+  pushd output/pyseir
+  zip -r "${API_OUTPUT_DIR}/pyseir_state_summaries.zip" state_summaries/*
+  popd
+
   # Previous method for invoking the original Python SEIR model follows.
   #./run.py model state -o "${API_OUTPUT_DIR}" > /dev/null
   #./run.py model county -o "${COUNTIES_DIR}" > /dev/null
@@ -123,11 +128,6 @@ execute_api() {
 
   echo ">>> Generating API for counties to ${API_OUTPUT_COUNTIES}/{FIPS}.{INTERVENTION}.json"
   ./run.py deploy-counties-api -i "${API_OUTPUT_DIR}/county" -o "${API_OUTPUT_COUNTIES}"
-
-  echo ">>> Generating pyseir_state_summaries.zip from output/pyseir/state_summaries."
-  pushd output/pyseir
-  zip -r "${API_OUTPUT_DIR}/pyseir_state_summaries.zip" state_summaries/*
-  popd
 
   echo ">>> All API Artifacts written to ${API_OUTPUT_DIR}"
 }


### PR DESCRIPTION
https://github.com/covid-projections/covid-data-model/actions/runs/80995224 failed with:

> Generating pyseir_state_summaries.zip from output/pyseir/state_summaries.
> ./covid-data-model/run.sh: line 128: pushd: output/pyseir: No such file or directory

I suspect this will fix it (though it's untested).