### PR TITLE
Parallelize Run Model 3x

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -18,10 +18,10 @@ on:
 jobs:
   execute-model:
     runs-on: self-hosted
-    strategy:
-      max-parallel: 25
-      matrix:
-        us-states: ['Alabama', 'Alaska', 'Arizona', 'Arkansas', 'California', 'Colorado', 'Connecticut', 'Delaware', 'District of Columbia', 'Florida', 'Georgia', 'Hawaii', 'Idaho', 'Illinois', 'Indiana', 'Iowa', 'Kansas', 'Kentucky', 'Louisiana', 'Maine', 'Maryland', 'Massachusetts', 'Michigan', 'Minnesota', 'Mississippi', 'Missouri', 'Montana', 'Nebraska', 'Nevada', 'New Hampshire', 'New Jersey', 'New Mexico', 'New York', 'North Carolina', 'North Dakota', 'Ohio', 'Oklahoma', 'Oregon', 'Pennsylvania', 'Rhode Island', 'South Carolina', 'South Dakota', 'Tennessee', 'Texas', 'Utah', 'Vermont', 'Virginia', 'Washington', 'West Virginia', 'Wisconsin', 'Wyoming']
+    # strategy:
+    #   max-parallel: 25
+    #   matrix:
+    #     us-states: ['Alabama', 'Alaska', 'Arizona', 'Arkansas', 'California', 'Colorado', 'Connecticut', 'Delaware', 'District of Columbia', 'Florida', 'Georgia', 'Hawaii', 'Idaho', 'Illinois', 'Indiana', 'Iowa', 'Kansas', 'Kentucky', 'Louisiana', 'Maine', 'Maryland', 'Massachusetts', 'Michigan', 'Minnesota', 'Mississippi', 'Missouri', 'Montana', 'Nebraska', 'Nevada', 'New Hampshire', 'New Jersey', 'New Mexico', 'New York', 'North Carolina', 'North Dakota', 'Ohio', 'Oklahoma', 'Oregon', 'Pennsylvania', 'Rhode Island', 'South Carolina', 'South Dakota', 'Tennessee', 'Texas', 'Utah', 'Vermont', 'Virginia', 'Washington', 'West Virginia', 'Wisconsin', 'Wyoming']
 
     env:
       # To pin to an old data set or model code, put the branch/tag/commit here:
@@ -29,7 +29,7 @@ jobs:
       # !!! Change this to your BRANCH if you want to test it
       COVID_DATA_MODEL_REF: 'fridiculous/parallelize-via-github'
       SNAPSHOT_ID: ${{github.run_number}}
-      FOR_US_STATE: ${{ matrix.us-states }}
+      # FOR_US_STATE: ${{ matrix.us-states }}
     steps:
     - name: Checkout covid-data-model
       uses: actions/checkout@v2
@@ -76,7 +76,8 @@ jobs:
       uses: actions/upload-artifact@v2-preview
       with:
         name: model-results-${{env.SNAPSHOT_ID}}
-        path: /data/api-results-${{env.SNAPSHOT_ID}}/api-results-${{env.FOR_US_STATE}}.zip
+        path: /data/api-results-${{env.SNAPSHOT_ID}}/api-results.zip
+        # path: /data/api-results-${{env.SNAPSHOT_ID}}/api-results-${{env.FOR_US_STATE}}.zip
 
   execute-summaries:
     runs-on: self-hosted

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -9,7 +9,7 @@ on:
   schedule:
    - cron: '30 0,12 * * *'
 
-  # push:
+  push:
   # Hook to trigger a manual run.
   # See: https://goobar.io/2019/12/07/manually-trigger-a-github-actions-workflow/
   repository_dispatch:
@@ -27,7 +27,7 @@ jobs:
       # To pin to an old data set or model code, put the branch/tag/commit here:
       COVID_DATA_PUBLIC_REF: 'master'
       # !!! Change this to your BRANCH if you want to test it
-      COVID_DATA_MODEL_REF: 'master'
+      COVID_DATA_MODEL_REF: 'fridiculous/parallelize-via-github'
       SNAPSHOT_ID: ${{github.run_number}}
       FOR_STATE: ${{ matrix.us-states }}
     steps:
@@ -76,7 +76,7 @@ jobs:
       uses: actions/upload-artifact@v2-preview
       with:
         name: model-results-${{env.SNAPSHOT_ID}}
-        path: /data/api-results-${{env.SNAPSHOT_ID}}/api-results.zip
+        path: /data/api-results-${{env.SNAPSHOT_ID}}/api-results-${{env.FOR_STATE}}.zip
 
   execute-summaries:
     runs-on: self-hosted
@@ -118,20 +118,11 @@ jobs:
       working-directory: ./covid-data-model
       run: pip install -r requirements.txt
 
-    # - uses: actions/download-artifact@v1
-    #   with:
-    #     name: model-results
-    #     path: ./api-results
     - name: Build Summaries (run.sh .. .. execute_summaries)
       env:
         COVID_MODEL_CORES: 96
         SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       run: ./covid-data-model/run.sh ./covid-data-public /data/api-results-${{env.SNAPSHOT_ID}} execute_summaries
-    # - name: Upload Summaries with Model Results
-    #   uses: actions/upload-artifact@v1
-    #   with:
-    #     name: model-results-with-summaries
-    #     path: ./api-results
 
   execute-dod:
     runs-on: self-hosted
@@ -173,20 +164,11 @@ jobs:
       working-directory: ./covid-data-model
       run: pip install -r requirements.txt
 
-    # - uses: actions/download-artifact@v1
-    #   with:
-    #     name: model-results
-    #     path: ./api-results
     - name: Build DoD (run.sh .. .. execute_summaries)
       env:
         COVID_MODEL_CORES: 96
         SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       run: ./covid-data-model/run.sh ./covid-data-public /data/api-results-${{env.SNAPSHOT_ID}} execute_dod
-    # - name: Upload DoD with Model Results
-    #   uses: actions/upload-artifact@v1
-    #   with:
-    #     name: model-results-with-dod
-    #     path: ./api-results
 
   execute-api:
     runs-on: self-hosted
@@ -228,20 +210,11 @@ jobs:
       working-directory: ./covid-data-model
       run: pip install -r requirements.txt
 
-    # - uses: actions/download-artifact@v1
-    #   with:
-    #     name: model-results
-    #     path: ./api-results
     - name: Build API (run.sh .. .. execute_api)
       env:
         COVID_MODEL_CORES: 96
         SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       run: ./covid-data-model/run.sh ./covid-data-public /data/api-results-${{env.SNAPSHOT_ID}} execute_api
-    # - name: Upload API with Model Results
-    #   uses: actions/upload-artifact@v1
-    #   with:
-    #     name: model-results-with-api
-    #     path: ./api-results
 
   # push-snapshot-to-s3:
   #   runs-on: self-hosted

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -18,12 +18,18 @@ on:
 jobs:
   execute-model:
     runs-on: self-hosted
+    strategy:
+      max-parallel: 25
+      matrix:
+        us-states: ['Alabama', 'Alaska', 'Arizona', 'Arkansas', 'California', 'Colorado', 'Connecticut', 'Delaware', 'District of Columbia', 'Florida', 'Georgia', 'Hawaii', 'Idaho', 'Illinois', 'Indiana', 'Iowa', 'Kansas', 'Kentucky', 'Louisiana', 'Maine', 'Maryland', 'Massachusetts', 'Michigan', 'Minnesota', 'Mississippi', 'Missouri', 'Montana', 'Nebraska', 'Nevada', 'New Hampshire', 'New Jersey', 'New Mexico', 'New York', 'North Carolina', 'North Dakota', 'Ohio', 'Oklahoma', 'Oregon', 'Pennsylvania', 'Rhode Island', 'South Carolina', 'South Dakota', 'Tennessee', 'Texas', 'Utah', 'Vermont', 'Virginia', 'Washington', 'West Virginia', 'Wisconsin', 'Wyoming']
+
     env:
       # To pin to an old data set or model code, put the branch/tag/commit here:
       COVID_DATA_PUBLIC_REF: 'master'
       # !!! Change this to your BRANCH if you want to test it
       COVID_DATA_MODEL_REF: 'master'
       SNAPSHOT_ID: ${{github.run_number}}
+      FOR_STATE: ${{ matrix.us-states }}
     steps:
     - name: Checkout covid-data-model
       uses: actions/checkout@v2
@@ -237,39 +243,38 @@ jobs:
     #     name: model-results-with-api
     #     path: ./api-results
 
-  push-snapshot-to-s3:
-    runs-on: self-hosted
-    needs:
-      - execute-model
-      - execute-api
-      - execute-dod
-      - execute-summaries
-    env:
-      # To pin to an old data set or model code, put the branch/tag/commit here:
-      COVID_DATA_PUBLIC_REF: 'master'
-      # !!! Change this to your BRANCH if you want to test it
-      COVID_DATA_MODEL_REF: 'master'
-      SNAPSHOT_ID: ${{github.run_number}}
-      AWS_S3_BUCKET: 'data.covidactnow.org'
+  # push-snapshot-to-s3:
+  #   runs-on: self-hosted
+  #   needs:
+  #     - execute-model
+  #     - execute-api
+  #     - execute-dod
+  #     - execute-summaries
+  #   env:
+  #     # To pin to an old data set or model code, put the branch/tag/commit here:
+  #     COVID_DATA_PUBLIC_REF: 'master'
+  #     # !!! Change this to your BRANCH if you want to test it
+  #     COVID_DATA_MODEL_REF: 'master'
+  #     SNAPSHOT_ID: ${{github.run_number}}
+  #     AWS_S3_BUCKET: 'data.covidactnow.org'
 
-    steps:
-    - name: make and copy to local tmp directory
-      run: |
-        mkdir -p ./tmp/data/
-        cp -r /data/api-results-${{env.SNAPSHOT_ID}}/ ./tmp/data/
+    # steps:
+    # - name: make and copy to local tmp directory
+    #   run: |
+    #     mkdir -p ./tmp/data/
+    #     cp -r /data/api-results-${{env.SNAPSHOT_ID}}/ ./tmp/data/
 
-    - name: Deploy Artifacts to S3 (https://data.covidactnow.org/snapshot/${{env.SNAPSHOT_ID}}/).
-      uses: jakejarvis/s3-sync-action@master
-      with:
-        args: --acl public-read --follow-symlinks --delete
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        SOURCE_DIR: './tmp/data/api-results-${{env.SNAPSHOT_ID}}/'
-        DEST_DIR: 'snapshot/${{env.SNAPSHOT_ID}}/'
-    
-    - name: remove local tmp directory
-      run: |
-        rm -rf ./tmp/data/
+    # - name: Deploy Artifacts to S3 (https://data.covidactnow.org/snapshot/${{env.SNAPSHOT_ID}}/).
+    #   uses: jakejarvis/s3-sync-action@master
+    #   with:
+    #     args: --acl public-read --follow-symlinks --delete
+    #   env:
+    #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    #     SOURCE_DIR: './tmp/data/api-results-${{env.SNAPSHOT_ID}}/'
+    #     DEST_DIR: 'snapshot/${{env.SNAPSHOT_ID}}/'
 
-      # TODO: Upload RedirectRules to AWS to make snapshot/latest pointer work.
+    # - name: remove local tmp directory
+    #   run: |
+    #     rm -rf ./tmp/data/
+

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -29,7 +29,7 @@ jobs:
       # !!! Change this to your BRANCH if you want to test it
       COVID_DATA_MODEL_REF: 'fridiculous/parallelize-via-github'
       SNAPSHOT_ID: ${{github.run_number}}
-      FOR_STATE: ${{ matrix.us-states }}
+      FOR_US_STATE: ${{ matrix.us-states }}
     steps:
     - name: Checkout covid-data-model
       uses: actions/checkout@v2
@@ -76,7 +76,7 @@ jobs:
       uses: actions/upload-artifact@v2-preview
       with:
         name: model-results-${{env.SNAPSHOT_ID}}
-        path: /data/api-results-${{env.SNAPSHOT_ID}}/api-results-${{env.FOR_STATE}}.zip
+        path: /data/api-results-${{env.SNAPSHOT_ID}}/api-results-${{env.FOR_US_STATE}}.zip
 
   execute-summaries:
     runs-on: self-hosted

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -9,7 +9,7 @@ on:
   schedule:
    - cron: '30 0,12 * * *'
 
-  push:
+  # push:
   # Hook to trigger a manual run.
   # See: https://goobar.io/2019/12/07/manually-trigger-a-github-actions-workflow/
   repository_dispatch:
@@ -18,6 +18,7 @@ on:
 jobs:
   execute-model:
     runs-on: self-hosted
+    # to parallelize jobs by state
     # strategy:
     #   max-parallel: 25
     #   matrix:
@@ -27,8 +28,9 @@ jobs:
       # To pin to an old data set or model code, put the branch/tag/commit here:
       COVID_DATA_PUBLIC_REF: 'master'
       # !!! Change this to your BRANCH if you want to test it
-      COVID_DATA_MODEL_REF: 'fridiculous/parallelize-via-github'
+      COVID_DATA_MODEL_REF: 'master'
       SNAPSHOT_ID: ${{github.run_number}}
+      # if parallelized jobs by state
       # FOR_US_STATE: ${{ matrix.us-states }}
     steps:
     - name: Checkout covid-data-model
@@ -61,10 +63,6 @@ jobs:
       working-directory: ./covid-data-model
       run: pip install -r requirements.txt
 
-    # - name: create temp file
-    #   run: |
-    #     mkdir -p /data/api-results-${{env.SNAPSHOT_ID}}
-    #     touch /data/api-results-${{env.SNAPSHOT_ID}}/deleteme
     - name: Build Model Results (run.sh .. .. execute_model)
       env:
         COVID_MODEL_CORES: 96
@@ -77,6 +75,7 @@ jobs:
       with:
         name: model-results-${{env.SNAPSHOT_ID}}
         path: /data/api-results-${{env.SNAPSHOT_ID}}/api-results.zip
+        # if parallelized jobs by state
         # path: /data/api-results-${{env.SNAPSHOT_ID}}/api-results-${{env.FOR_US_STATE}}.zip
     - name: County number of counties
       run: ls -hal /data/api-results-${{env.SNAPSHOT_ID}}/county | wc -l
@@ -219,38 +218,38 @@ jobs:
         SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       run: ./covid-data-model/run.sh ./covid-data-public /data/api-results-${{env.SNAPSHOT_ID}} execute_api
 
-  # push-snapshot-to-s3:
-  #   runs-on: self-hosted
-  #   needs:
-  #     - execute-model
-  #     - execute-api
-  #     - execute-dod
-  #     - execute-summaries
-  #   env:
-  #     # To pin to an old data set or model code, put the branch/tag/commit here:
-  #     COVID_DATA_PUBLIC_REF: 'master'
-  #     # !!! Change this to your BRANCH if you want to test it
-  #     COVID_DATA_MODEL_REF: 'master'
-  #     SNAPSHOT_ID: ${{github.run_number}}
-  #     AWS_S3_BUCKET: 'data.covidactnow.org'
+  push-snapshot-to-s3:
+    runs-on: self-hosted
+    needs:
+      - execute-model
+      - execute-api
+      - execute-dod
+      - execute-summaries
+    env:
+      # To pin to an old data set or model code, put the branch/tag/commit here:
+      COVID_DATA_PUBLIC_REF: 'master'
+      # !!! Change this to your BRANCH if you want to test it
+      COVID_DATA_MODEL_REF: 'master'
+      SNAPSHOT_ID: ${{github.run_number}}
+      AWS_S3_BUCKET: 'data.covidactnow.org'
 
-    # steps:
-    # - name: make and copy to local tmp directory
-    #   run: |
-    #     mkdir -p ./tmp/data/
-    #     cp -r /data/api-results-${{env.SNAPSHOT_ID}}/ ./tmp/data/
+    steps:
+    - name: make and copy to local tmp directory
+      run: |
+        mkdir -p ./tmp/data/
+        cp -r /data/api-results-${{env.SNAPSHOT_ID}}/ ./tmp/data/
 
-    # - name: Deploy Artifacts to S3 (https://data.covidactnow.org/snapshot/${{env.SNAPSHOT_ID}}/).
-    #   uses: jakejarvis/s3-sync-action@master
-    #   with:
-    #     args: --acl public-read --follow-symlinks --delete
-    #   env:
-    #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-    #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    #     SOURCE_DIR: './tmp/data/api-results-${{env.SNAPSHOT_ID}}/'
-    #     DEST_DIR: 'snapshot/${{env.SNAPSHOT_ID}}/'
+    - name: Deploy Artifacts to S3 (https://data.covidactnow.org/snapshot/${{env.SNAPSHOT_ID}}/).
+      uses: jakejarvis/s3-sync-action@master
+      with:
+        args: --acl public-read --follow-symlinks --delete
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        SOURCE_DIR: './tmp/data/api-results-${{env.SNAPSHOT_ID}}/'
+        DEST_DIR: 'snapshot/${{env.SNAPSHOT_ID}}/'
 
-    # - name: remove local tmp directory
-    #   run: |
-    #     rm -rf ./tmp/data/
+    - name: remove local tmp directory
+      run: |
+        rm -rf ./tmp/data/
 

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -78,6 +78,8 @@ jobs:
         name: model-results-${{env.SNAPSHOT_ID}}
         path: /data/api-results-${{env.SNAPSHOT_ID}}/api-results.zip
         # path: /data/api-results-${{env.SNAPSHOT_ID}}/api-results-${{env.FOR_US_STATE}}.zip
+    - name: County number of counties
+      run: ls -hal /data/api-results-${{env.SNAPSHOT_ID}}/county | wc -l
 
   execute-summaries:
     runs-on: self-hosted

--- a/README.md
+++ b/README.md
@@ -41,10 +41,6 @@ Once a snapshot has been vetted, you can "label" it with a friendly name, e.g. p
 ```bash
 export GITHUB_TOKEN=<YOUR PERSONAL GITHUB TOKEN>
 ./tools/label-api.sh v0 123
-
-
-curl -v -L -u octocat:$token -o Rails.zip /
-"https://api.github.com/repos/octo-org/octo-repo/actions/artifacts/30209828/zip"
 ```
 
 # Development

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ See [covid-data-public](https://github.com/covid-projections/covid-data-public) 
 
 # API Snapshots
 
-We automatically build & publish an API snapshot (e.g. https://data.covidactnow.org/snapshot/123/) 
+We automatically build & publish an API snapshot (e.g. https://data.covidactnow.org/snapshot/123/)
 twice a day via a [github action](./.github/workflows/deploy_api.yml).  To manually kick off a new
 snapshot, get a
 [personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line),
@@ -41,6 +41,10 @@ Once a snapshot has been vetted, you can "label" it with a friendly name, e.g. p
 ```bash
 export GITHUB_TOKEN=<YOUR PERSONAL GITHUB TOKEN>
 ./tools/label-api.sh v0 123
+
+
+curl -v -L -u octocat:$token -o Rails.zip /
+"https://api.github.com/repos/octo-org/octo-repo/actions/artifacts/30209828/zip"
 ```
 
 # Development
@@ -100,6 +104,6 @@ Change to into the county_covid_seir_models directory
 Example here. You can remove the `--state` flag to run everything. To run only states, add `--states-only`.
 `pyseir run-all --run-mode='can-before-hospitalization-new-params' --output-interval-days=4 --state="California"`
 
-`pyseir --help ` and `pyseir <subcommand> --help` also provide specific flags. 
+`pyseir --help ` and `pyseir <subcommand> --help` also provide specific flags.
 
 Check the `output/` folder for results.

--- a/pyseir/cli.py
+++ b/pyseir/cli.py
@@ -28,6 +28,8 @@ cds_dataset = None
 DEFAULT_RUN_MODE = 'can-before-hospitalization-new-params'
 ALL_STATES = [state_obj.name for state_obj in us.STATES]
 
+API_OUTPUT_DIR=os.getenv('API_OUTPUT_DIR')
+
 
 def _cache_global_datasets():
     global nyt_dataset, cds_dataset
@@ -203,7 +205,7 @@ def map_outputs(state, output_interval_days, run_mode, states_only):
 @click.option('--generate-reports', default=False, type=bool, is_flag=True, help='If False, skip pdf report generation.')
 @click.option('--output-interval-days', default=4, type=int, help='Number of days between outputs for the WebUI payload.')
 @click.option('--skip-download', default=False, is_flag=True, type=bool, help='Skip the download phase.')
-@click.option('--output-dir', default=None, type=str, help='Directory to deploy webui output.')
+@click.option('--output-dir', default=API_OUTPUT_DIR, type=str, help='Directory to deploy webui output.')
 @click.option('--states-only', default=False, is_flag=True, type=bool, help='Only model states')
 def run_all(state, run_mode, generate_reports, output_interval_days, skip_download, output_dir, states_only):
     _run_all(state, run_mode, generate_reports, output_interval_days, skip_download=skip_download,

--- a/pyseir/cli.py
+++ b/pyseir/cli.py
@@ -27,8 +27,7 @@ cds_dataset = None
 
 DEFAULT_RUN_MODE = 'can-before-hospitalization-new-params'
 ALL_STATES = [state_obj.name for state_obj in us.STATES]
-
-API_OUTPUT_DIR=os.getenv('API_OUTPUT_DIR')
+API_OUTPUT_DIR = os.getenv('API_OUTPUT_DIR')
 
 
 def _cache_global_datasets():

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ numpy==1.18.2
 pandas==1.0.3
 plotly==4.5.4
 pyshp==2.1.0
-pymc3
+pymc3==3.8
 requests==2.23.0
 jupyter==1.0.0
 simplejson==3.17.0
@@ -22,11 +22,11 @@ boto3==1.12.28
 seaborn==0.10.0
 click==7.1.1
 sentry-sdk==0.14.3
-scikit-learn
+scikit-learn==0.22.2.post1
 pip
-iminuit
-fastparquet
-us
-adtk
+iminuit==1.3.10
+fastparquet==0.3.3
+us==1.0.0
+adtk==0.6.0
 -e .
 pydantic==1.4

--- a/run.sh
+++ b/run.sh
@@ -60,14 +60,17 @@ execute_model() {
   cd "$(dirname "$0")"
 
   # TODO(#148): We need to clean up the output of these scripts!
-  if [ -z "$FOR_US_STATE" ];
-  then
-    echo ">>> Generating state and county models to ${API_OUTPUT_DIR}"
-    pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" > /dev/null
-  else
-    echo ">>> Generating $FOR_US_STATE's state and county models to ${API_OUTPUT_DIR}"
-    pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="$FOR_US_STATE" > /dev/null
-  fi
+  # if [ -z "$FOR_US_STATE" ];
+  # then
+  #   echo ">>> Generating state and county models to ${API_OUTPUT_DIR}"
+  #   pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" > /dev/null
+  # else
+  #   echo ">>> Generating $FOR_US_STATE's state and county models to ${API_OUTPUT_DIR}"
+  #   pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="$FOR_US_STATE" > /dev/null
+  # fi
+
+  echo ">>> Generating state and county models to ${API_OUTPUT_DIR}"
+  cat states.txt | parallel -j 20 pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state ${1}  > /dev/null
 
   # Move state output to the expected location.
   mkdir -p ${API_OUTPUT_DIR}/
@@ -78,6 +81,7 @@ execute_model() {
   cp -r ${API_OUTPUT_DIR}/web_ui/county/* ${API_OUTPUT_DIR}/county
 
   # Clean up original output directories.
+  # will need to isolated, in jobs are done in parallel
   rmdir ${API_OUTPUT_DIR}/web_ui/state/
   rmdir ${API_OUTPUT_DIR}/web_ui/
 

--- a/run.sh
+++ b/run.sh
@@ -70,7 +70,7 @@ execute_model() {
   # fi
 
   echo ">>> Generating state and county models to ${API_OUTPUT_DIR}"
-  parallel --eta -j 5 -a state_commands.txt && echo OK
+  parallel --eta -j 3 -a state_commands.txt && echo OK
 
   # Move state output to the expected location.
   mkdir -p ${API_OUTPUT_DIR}/

--- a/run.sh
+++ b/run.sh
@@ -70,7 +70,7 @@ execute_model() {
   # fi
 
   echo ">>> Generating state and county models to ${API_OUTPUT_DIR}"
-  cat states.txt | parallel -j 20 pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state ${1}  > /dev/null
+  cat states.txt | parallel -j 20 pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="${1}"  > /dev/null
 
   # Move state output to the expected location.
   mkdir -p ${API_OUTPUT_DIR}/

--- a/run.sh
+++ b/run.sh
@@ -59,7 +59,7 @@ execute_model() {
   # Go to repo root (where run.sh lives).
   cd "$(dirname "$0")"
 
-  # TODO(#148): We need to clean up the output of these scripts!
+  # TODO(#parallelize by job)
   # if [ -z "$FOR_US_STATE" ];
   # then
   #   echo ">>> Generating state and county models to ${API_OUTPUT_DIR}"
@@ -69,6 +69,7 @@ execute_model() {
   #   pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="$FOR_US_STATE" > /dev/null
   # fi
 
+  # TODO(#148): We need to clean up the output of these scripts!
   echo ">>> Generating state and county models to ${API_OUTPUT_DIR}"
   parallel --eta -j 3 -a state_commands.txt && echo OK
 

--- a/run.sh
+++ b/run.sh
@@ -75,7 +75,7 @@ execute_model() {
 
   # Move county output to the expected location.
   mkdir -p ${API_OUTPUT_DIR}/county
-  mv ${API_OUTPUT_DIR}/web_ui/county ${API_OUTPUT_DIR}/
+  mv ${API_OUTPUT_DIR}/web_ui/county/* ${API_OUTPUT_DIR}/county
 
   # Clean up original output directories.
   rmdir ${API_OUTPUT_DIR}/web_ui/state/

--- a/run.sh
+++ b/run.sh
@@ -70,7 +70,7 @@ execute_model() {
   # fi
 
   echo ">>> Generating state and county models to ${API_OUTPUT_DIR}"
-  parallel --eta -j 10 -a state_commands.txt && echo OK > /dev/null
+  parallel --eta -j 10 -a state_commands.txt && echo OK
 
   # Move state output to the expected location.
   mkdir -p ${API_OUTPUT_DIR}/

--- a/run.sh
+++ b/run.sh
@@ -19,8 +19,8 @@ prepare () {
     echo "Example: $0 ../covid-data-public/ ./api-results/ execute_api"
     exit 1
   else
-    DATA_SOURCES_DIR="$(abs_path $1)"
-    API_OUTPUT_DIR="$(abs_path $2)"
+    export DATA_SOURCES_DIR="$(abs_path $1)"
+    export API_OUTPUT_DIR="$(abs_path $2)"
   fi
 
   if [ $# -eq 2 ]; then

--- a/run.sh
+++ b/run.sh
@@ -74,11 +74,11 @@ execute_model() {
 
   # Move state output to the expected location.
   mkdir -p ${API_OUTPUT_DIR}/
-  cp -r ${API_OUTPUT_DIR}/web_ui/state/* ${API_OUTPUT_DIR}/
+  mv ${API_OUTPUT_DIR}/web_ui/state/* ${API_OUTPUT_DIR}/
 
   # Move county output to the expected location.
   mkdir -p ${API_OUTPUT_DIR}/county
-  cp -r ${API_OUTPUT_DIR}/web_ui/county/* ${API_OUTPUT_DIR}/county
+  mv ${API_OUTPUT_DIR}/web_ui/county ${API_OUTPUT_DIR}/
 
   # Clean up original output directories.
   # will need to isolated, in jobs are done in parallel

--- a/run.sh
+++ b/run.sh
@@ -70,7 +70,7 @@ execute_model() {
   # fi
 
   echo ">>> Generating state and county models to ${API_OUTPUT_DIR}"
-  parallel -a state.txt --eta -j 20 pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state={1}  > /dev/null
+  parallel -a states.txt --eta -j 20 pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state={1}  > /dev/null
 
   # Move state output to the expected location.
   mkdir -p ${API_OUTPUT_DIR}/

--- a/run.sh
+++ b/run.sh
@@ -70,7 +70,7 @@ execute_model() {
   # fi
 
   echo ">>> Generating state and county models to ${API_OUTPUT_DIR}"
-  parallel --eta -j 10 -a state_commands.txt && echo OK
+  parallel --eta -j 5 -a state_commands.txt && echo OK
 
   # Move state output to the expected location.
   mkdir -p ${API_OUTPUT_DIR}/

--- a/run.sh
+++ b/run.sh
@@ -70,7 +70,7 @@ execute_model() {
   # fi
 
   echo ">>> Generating state and county models to ${API_OUTPUT_DIR}"
-  parallel -a states.txt --eta -j 20 pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state={1}  > /dev/null
+  parallel --eta -j 10 -a state_commands.txt && echo OK > /dev/null
 
   # Move state output to the expected location.
   mkdir -p ${API_OUTPUT_DIR}/

--- a/run.sh
+++ b/run.sh
@@ -71,11 +71,11 @@ execute_model() {
 
   # Move state output to the expected location.
   mkdir -p ${API_OUTPUT_DIR}/
-  mv ${API_OUTPUT_DIR}/web_ui/state/* ${API_OUTPUT_DIR}/
+  cp -r ${API_OUTPUT_DIR}/web_ui/state/* ${API_OUTPUT_DIR}/
 
   # Move county output to the expected location.
   mkdir -p ${API_OUTPUT_DIR}/county
-  mv ${API_OUTPUT_DIR}/web_ui/county/* ${API_OUTPUT_DIR}/county
+  cp -r ${API_OUTPUT_DIR}/web_ui/county/* ${API_OUTPUT_DIR}/county
 
   # Clean up original output directories.
   rmdir ${API_OUTPUT_DIR}/web_ui/state/

--- a/run.sh
+++ b/run.sh
@@ -59,9 +59,15 @@ execute_model() {
   # Go to repo root (where run.sh lives).
   cd "$(dirname "$0")"
 
-  echo ">>> Generating state and county models to ${API_OUTPUT_DIR}"
   # TODO(#148): We need to clean up the output of these scripts!
-  pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" > /dev/null
+  if [ -z "$FOR_US_STATE" ];
+  then
+    echo ">>> Generating state and county models to ${API_OUTPUT_DIR}"
+    pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" > /dev/null
+  else
+    echo ">>> Generating $FOR_US_STATE's state and county models to ${API_OUTPUT_DIR}"
+    pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="$FOR_US_STATE" > /dev/null
+  fi
 
   # Move state output to the expected location.
   mkdir -p ${API_OUTPUT_DIR}/

--- a/run.sh
+++ b/run.sh
@@ -70,7 +70,7 @@ execute_model() {
   # fi
 
   echo ">>> Generating state and county models to ${API_OUTPUT_DIR}"
-  cat states.txt | parallel -j 20 pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="${1}"  > /dev/null
+  parallel -a state.txt --eta -j 20 pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state={1}  > /dev/null
 
   # Move state output to the expected location.
   mkdir -p ${API_OUTPUT_DIR}/

--- a/state_commands.txt
+++ b/state_commands.txt
@@ -1,51 +1,51 @@
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Alabama
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Alaska
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Arizona
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Arkansas
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=California
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Colorado
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Connecticut
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Delaware
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=District of Columbia
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Florida
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Georgia
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Hawaii
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Idaho
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Illinois
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Indiana
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Iowa
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Kansas
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Kentucky
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Louisiana
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Maine
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Maryland
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Massachusetts
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Michigan
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Minnesota
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Mississippi
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Missouri
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Montana
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Nebraska
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Nevada
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=New Hampshire
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=New Jersey
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=New Mexico
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=New York
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=North Carolina
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=North Dakota
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Ohio
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Oklahoma
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Oregon
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Pennsylvania
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Rhode Island
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=South Carolina
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=South Dakota
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Tennessee
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Texas
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Utah
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Vermont
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Virginia
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Washington
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=West Virginia
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Wisconsin
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Wyoming
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Alabama" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Alaska" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Arizona" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Arkansas" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="California" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Colorado" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Connecticut" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Delaware" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="District of Columbia" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Florida" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Georgia" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Hawaii" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Idaho" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Illinois" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Indiana" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Iowa" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Kansas" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Kentucky" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Louisiana" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Maine" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Maryland" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Massachusetts" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Michigan" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Minnesota" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Mississippi" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Missouri" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Montana" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Nebraska" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Nevada" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="New Hampshire" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="New Jersey" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="New Mexico" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="New York" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="North Carolina" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="North Dakota" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Ohio" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Oklahoma" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Oregon" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Pennsylvania" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Rhode Island" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="South Carolina" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="South Dakota" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Tennessee" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Texas" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Utah" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Vermont" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Virginia" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Washington" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="West Virginia" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Wisconsin" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Wyoming" > /dev/null

--- a/state_commands.txt
+++ b/state_commands.txt
@@ -1,0 +1,51 @@
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Alabama
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Alaska
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Arizona
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Arkansas
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=California
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Colorado
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Connecticut
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Delaware
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=District of Columbia
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Florida
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Georgia
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Hawaii
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Idaho
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Illinois
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Indiana
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Iowa
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Kansas
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Kentucky
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Louisiana
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Maine
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Maryland
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Massachusetts
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Michigan
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Minnesota
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Mississippi
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Missouri
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Montana
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Nebraska
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Nevada
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=New Hampshire
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=New Jersey
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=New Mexico
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=New York
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=North Carolina
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=North Dakota
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Ohio
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Oklahoma
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Oregon
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Pennsylvania
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Rhode Island
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=South Carolina
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=South Dakota
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Tennessee
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Texas
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Utah
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Vermont
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Virginia
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Washington
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=West Virginia
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Wisconsin
+pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state=Wyoming

--- a/state_commands.txt
+++ b/state_commands.txt
@@ -1,51 +1,51 @@
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Alabama" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Alaska" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Arizona" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Arkansas" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="California" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Colorado" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Connecticut" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Delaware" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="District of Columbia" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Florida" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Georgia" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Hawaii" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Idaho" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Illinois" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Indiana" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Iowa" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Kansas" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Kentucky" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Louisiana" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Maine" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Maryland" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Massachusetts" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Michigan" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Minnesota" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Mississippi" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Missouri" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Montana" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Nebraska" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Nevada" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="New Hampshire" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="New Jersey" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="New Mexico" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="New York" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="North Carolina" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="North Dakota" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Ohio" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Oklahoma" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Oregon" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Pennsylvania" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Rhode Island" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="South Carolina" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="South Dakota" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Tennessee" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Texas" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Utah" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Vermont" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Virginia" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Washington" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="West Virginia" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Wisconsin" > /dev/null
-pyseir run-all --run-mode=can-before-hospitalization-new-params --output-dir="${API_OUTPUT_DIR}" --state="Wyoming" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Alabama" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Alaska" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Arizona" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Arkansas" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="California" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Colorado" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Connecticut" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Delaware" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="District of Columbia" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Florida" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Georgia" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Hawaii" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Idaho" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Illinois" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Indiana" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Iowa" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Kansas" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Kentucky" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Louisiana" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Maine" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Maryland" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Massachusetts" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Michigan" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Minnesota" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Mississippi" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Missouri" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Montana" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Nebraska" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Nevada" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="New Hampshire" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="New Jersey" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="New Mexico" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="New York" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="North Carolina" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="North Dakota" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Ohio" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Oklahoma" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Oregon" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Pennsylvania" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Rhode Island" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="South Carolina" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="South Dakota" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Tennessee" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Texas" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Utah" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Vermont" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Virginia" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Washington" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="West Virginia" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Wisconsin" > /dev/null
+pyseir run-all --run-mode=can-before-hospitalization-new-params --state="Wyoming" > /dev/null

--- a/states.txt
+++ b/states.txt
@@ -1,0 +1,51 @@
+Alabama
+Alaska
+Arizona
+Arkansas
+California
+Colorado
+Connecticut
+Delaware
+District of Columbia
+Florida
+Georgia
+Hawaii
+Idaho
+Illinois
+Indiana
+Iowa
+Kansas
+Kentucky
+Louisiana
+Maine
+Maryland
+Massachusetts
+Michigan
+Minnesota
+Mississippi
+Missouri
+Montana
+Nebraska
+Nevada
+New Hampshire
+New Jersey
+New Mexico
+New York
+North Carolina
+North Dakota
+Ohio
+Oklahoma
+Oregon
+Pennsylvania
+Rhode Island
+South Carolina
+South Dakota
+Tennessee
+Texas
+Utah
+Vermont
+Virginia
+Washington
+West Virginia
+Wisconsin
+Wyoming


### PR DESCRIPTION
`execute_model` now runs in parallel in 3x.

Original benchmark was 50 min for execute_model
Now execute_model runs in 20 min.

20x, 10x and 5x were also tried, however, the reliability of the runs was unsuccessful.  Overall, CPU utilization improved, however, there is still a lot on table.  Perfectly efficient CPU would result <10 min per run.