### PR TITLE
20x Api Speed.  Remove Unneeded Computation, Refactor & Parallelize

### DIFF
--- a/libs/dataset_deployer.py
+++ b/libs/dataset_deployer.py
@@ -1,41 +1,21 @@
 import os
 import io
 import logging
-import boto3
 
 _logger = logging.getLogger(__name__)
 
 
 class DatasetDeployer(object):
-    """Common deploy operations for persisting files to s3 or local folder.
+    """Common deploy operations for persisting files to a local folder.
 
-    Deploys to S3 if the BUCKET_NAME environment variable is set.
     """
 
     def __init__(self, key="filename.csv", body="a random data", output_dir="."):
-        self.s3 = boto3.client("s3")
-        # Supplied by ENV on AWS
-        # BUCKET_NAME format is s3://{BUCKET_NAME}
-        self.bucket_name = os.environ.get("BUCKET_NAME")
         self.key = key
         self.body = body
         self.output_dir = output_dir
 
-    def _persist_to_s3(self):
-        """Persists specific data onto an s3 bucket.
-        This method assumes versioned is handled on the bucket itself.
-        """
-        _logger.info(f"persisting {self.key} to s3")
-
-        response = self.s3.put_object(
-            Bucket=self.bucket_name, Key=self.key, Body=self.body, ACL="public-read"
-        )
-        return response
-
     def _persist_to_local(self):
-        """Persists specific data onto an s3 bucket.
-        This method assumes versioned is handled on the bucket itself.
-        """
         _logger.info(f"persisting {self.key} to local")
 
         with open(os.path.join(self.output_dir, self.key), "wb") as f:
@@ -46,14 +26,8 @@ class DatasetDeployer(object):
                 self.body.encode("UTF-8") if isinstance(self.body, str) else self.body
             )
 
-        pass
-
     def persist(self):
-        if self.bucket_name:
-            self._persist_to_s3()
-        else:
-            self._persist_to_local()
-        return
+        self._persist_to_local()
 
 
 def upload_csv(key_name: str, csv: str, output_dir: str):
@@ -67,7 +41,7 @@ def upload_csv(key_name: str, csv: str, output_dir: str):
     _logger.info(f"Generated csv for {key_name}")
 
 
-def upload_json(key_name, json: str, output_dir: str): 
+def upload_json(key_name, json: str, output_dir: str):
     DatasetDeployer(f"{key_name}.json", json, output_dir).persist()
     _logger.info(f"Generated json for {key_name}")
 

--- a/libs/functions/calculate_projections.py
+++ b/libs/functions/calculate_projections.py
@@ -40,7 +40,7 @@ def _read_json_as_df(path):
         exclude=CAN_MODEL_OUTPUT_SCHEMA_EXCLUDED_COLUMNS,
     )
 
-    df["date"] = pd.to_datetime(df.date)
+    df["date"] = pd.to_datetime(df.date, format='%m/%d/%y')
     df["all_hospitalized"] = df["all_hospitalized"].astype("int")
     df["beds"] = df["beds"].astype("int")
     df["dead"] = df["dead"].astype("int")

--- a/libs/functions/get_can_projection.py
+++ b/libs/functions/get_can_projection.py
@@ -5,13 +5,22 @@ import requests
 from libs.enums import Intervention
 from libs.datasets.dataset_utils import AggregationLevel
 from libs.datasets.can_model_output_schema import CAN_MODEL_OUTPUT_SCHEMA
+import functools
+
+
+@functools.lru_cache(None)
+def get_interventions():
+    interventions_url = "https://raw.githubusercontent.com/covid-projections/covid-projections/master/src/assets/data/interventions.json"
+    interventions = requests.get(interventions_url).json()
+    return interventions
 
 
 def get_intervention_for_state(state):
+    return Intervention.from_str(get_interventions()[state])
     # TODO: read this from a dataset class
-    interventions_url = "https://raw.githubusercontent.com/covid-projections/covid-projections/master/src/assets/data/interventions.json"
-    interventions = requests.get(interventions_url).json()
-    return Intervention.from_str(interventions[state])
+    # interventions_url = "https://raw.githubusercontent.com/covid-projections/covid-projections/master/src/assets/data/interventions.json"
+    # interventions = requests.get(interventions_url).json()
+    # return Intervention.from_str(interventions[state])
 
 
 def _get_intervention(intervention, state):

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ boto3==1.12.28
 seaborn==0.10.0
 click==7.1.1
 sentry-sdk==0.14.3
+pandarallel==1.4.8
 scikit-learn
 pip
 iminuit


### PR DESCRIPTION
New results. 1 min, 50 seconds locally
Previous result:  >> 40 min locally, (25+ min on Github actions)

Change made:
* Cache intervention.json network request happening from covid-public 
* remove unused boto session that's done over and over again
* Use known date format for faster date conversions
* refactor iterrows to use pandas native map functions
* use pandas apply to parallelize per county manipulations


## The Result
```bash
run.sh ../covid-data-public/ ../data/api-results-118/ execute_api  440.69s user 26.94s system 423% cpu 1:50.30 total
```


### Please Check
- [ ] Will the *current* schema in [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.md) be updated with this PR?
- [ ] Are tests passing?
