### PR TITLE
Update fit_results lookup by fips

### DIFF
--- a/pyseir/deployment/webui_data_adaptor_v1.py
+++ b/pyseir/deployment/webui_data_adaptor_v1.py
@@ -123,13 +123,18 @@ class WebUIDataAdaptorV1:
         all_hospitalized_today = None
         try:
             fit_results = load_inference_result(fips)
-        except ValueError:
+        except (KeyError, ValueError):
             fit_results = None
-            logging.error(f'Fit result not found for {fips}: Skipping inference elements')
+            logging.warning(f'Fit result not found for {fips}: Skipping inference elements')
 
         for i_policy, suppression_policy in enumerate(policies):
             if suppression_policy == 'suppression_policy__full_containment':  # No longer shipping this.
                 continue
+            if suppression_policy == 'suppression_policy__inferred' \
+                    and len(fips) == 5 \
+                    and fips not in self.df_whitelist.fips.values:
+                continue
+
             output_for_policy = pyseir_outputs[suppression_policy]
             output_model = pd.DataFrame()
 

--- a/pyseir/inference/fit_results.py
+++ b/pyseir/inference/fit_results.py
@@ -41,7 +41,11 @@ def load_inference_result(fips):
         Dictionary of fit result information.
     """
     output_file = get_run_artifact_path(fips, RunArtifact.MLE_FIT_RESULT)
-    return pd.read_json(output_file).iloc[0].to_dict()
+    df = pd.read_json(output_file, dtype={'fips': 'str'})
+    if len(fips) == 2:
+        return df.iloc[0].to_dict()
+    else:
+        return df.set_index('fips').loc[fips].to_dict()
 
 
 def load_Rt_result(fips):


### PR DESCRIPTION
This PR addresses 2 issues

1. incorrect county R_t shipping. Previously, state lookup codes were being used incorrectly resulting in the "first" county's R_t being used for subsequent fips in a state.
2. Whitelist filtering was previously being checked after also checking for valid fit results, which if not existing, went down an alternate code path.

Acceptance tests performed:
- Verified that correct county R_t are being shipped and differ across the state.
- Verified that the number of output/web_ui/county/*.2.json == 291 == whitelist length == number of MLE reports.



### Please Check
- [ ] Will the *current* schema in [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.md) be updated with this PR?
- [ ] Are tests passing?
