### PR TITLE
Unify env vars in deploy workflow.

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -15,15 +15,30 @@ on:
   repository_dispatch:
     types: publish-api
 
+env:
+  # !!! Change this to your BRANCH if you want to test it
+  COVID_DATA_MODEL_REF: 'master'
+
+  # To pin to an old data sets, put the branch/tag/commit here:
+  COVID_DATA_PUBLIC_REF: 'master'
+
+  # S3 Bucket (used by s3-sync-action tasks) to store final API snapshot.
+  AWS_S3_BUCKET: 'data.covidactnow.org'
+
+  # The snapshot ID that identifies all of the API artifacts we're generating and ends
+  # up in the final /snapshot/{id}/ URL.
+  SNAPSHOT_ID: ${{github.run_number}}
+
+  # Used by execute-model (for now) to optimize parallelization on self-hosted
+  # runner.
+  COVID_MODEL_CORES: 96
+
+  # Used by python code that reports errors to sentry.
+  SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+
 jobs:
   execute-model:
     runs-on: self-hosted
-    env:
-      # To pin to an old data set or model code, put the branch/tag/commit here:
-      COVID_DATA_PUBLIC_REF: 'master'
-      # !!! Change this to your BRANCH if you want to test it
-      COVID_DATA_MODEL_REF: 'master'
-      SNAPSHOT_ID: ${{github.run_number}}
     steps:
     - name: Checkout covid-data-model
       uses: actions/checkout@v2
@@ -60,9 +75,6 @@ jobs:
     #     mkdir -p /data/api-results-${{env.SNAPSHOT_ID}}
     #     touch /data/api-results-${{env.SNAPSHOT_ID}}/deleteme
     - name: Build Model Results (run.sh .. .. execute_model)
-      env:
-        COVID_MODEL_CORES: 96
-        SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       run: ./covid-data-model/run.sh ./covid-data-public /data/api-results-${{env.SNAPSHOT_ID}} execute_model
     - name: Zip Model Results (run.sh .. .. execute_zip_folder)
       run: ./covid-data-model/run.sh ./covid-data-public /data/api-results-${{env.SNAPSHOT_ID}} execute_zip_folder
@@ -75,12 +87,6 @@ jobs:
   execute-summaries:
     runs-on: self-hosted
     needs: execute-model
-    env:
-      # To pin to an old data set or model code, put the branch/tag/commit here:
-      COVID_DATA_PUBLIC_REF: 'master'
-      # !!! Change this to your BRANCH if you want to test it
-      COVID_DATA_MODEL_REF: 'master'
-      SNAPSHOT_ID: ${{github.run_number}}
     steps:
     - name: Checkout covid-data-model
       uses: actions/checkout@v2
@@ -117,9 +123,6 @@ jobs:
     #     name: model-results
     #     path: ./api-results
     - name: Build Summaries (run.sh .. .. execute_summaries)
-      env:
-        COVID_MODEL_CORES: 96
-        SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       run: ./covid-data-model/run.sh ./covid-data-public /data/api-results-${{env.SNAPSHOT_ID}} execute_summaries
     # - name: Upload Summaries with Model Results
     #   uses: actions/upload-artifact@v1
@@ -130,12 +133,6 @@ jobs:
   execute-dod:
     runs-on: self-hosted
     needs: execute-model
-    env:
-      # To pin to an old data set or model code, put the branch/tag/commit here:
-      COVID_DATA_PUBLIC_REF: 'master'
-      # !!! Change this to your BRANCH if you want to test it
-      COVID_DATA_MODEL_REF: 'master'
-      SNAPSHOT_ID: ${{github.run_number}}
     steps:
     - name: Checkout covid-data-model
       uses: actions/checkout@v2
@@ -172,9 +169,6 @@ jobs:
     #     name: model-results
     #     path: ./api-results
     - name: Build DoD (run.sh .. .. execute_summaries)
-      env:
-        COVID_MODEL_CORES: 96
-        SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       run: ./covid-data-model/run.sh ./covid-data-public /data/api-results-${{env.SNAPSHOT_ID}} execute_dod
     # - name: Upload DoD with Model Results
     #   uses: actions/upload-artifact@v1
@@ -185,12 +179,6 @@ jobs:
   execute-api:
     runs-on: self-hosted
     needs: execute-model
-    env:
-      # To pin to an old data set or model code, put the branch/tag/commit here:
-      COVID_DATA_PUBLIC_REF: 'master'
-      # !!! Change this to your BRANCH if you want to test it
-      COVID_DATA_MODEL_REF: 'master'
-      SNAPSHOT_ID: ${{github.run_number}}
     steps:
     - name: Checkout covid-data-model
       uses: actions/checkout@v2
@@ -227,9 +215,6 @@ jobs:
     #     name: model-results
     #     path: ./api-results
     - name: Build API (run.sh .. .. execute_api)
-      env:
-        COVID_MODEL_CORES: 96
-        SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       run: ./covid-data-model/run.sh ./covid-data-public /data/api-results-${{env.SNAPSHOT_ID}} execute_api
     # - name: Upload API with Model Results
     #   uses: actions/upload-artifact@v1
@@ -244,13 +229,6 @@ jobs:
       - execute-api
       - execute-dod
       - execute-summaries
-    env:
-      # To pin to an old data set or model code, put the branch/tag/commit here:
-      COVID_DATA_PUBLIC_REF: 'master'
-      # !!! Change this to your BRANCH if you want to test it
-      COVID_DATA_MODEL_REF: 'master'
-      SNAPSHOT_ID: ${{github.run_number}}
-      AWS_S3_BUCKET: 'data.covidactnow.org'
 
     steps:
     - name: make and copy to local tmp directory


### PR DESCRIPTION
I mostly just wanted a single place where I can update the covid-data-model
branch that's being run against (I almost messed this up when trying to do a
test yesterday). But I took the opportunity to unify all the env vars that are
used repeatedly and/or are important enough to be top-level constants.