### PR TITLE
Fix #258: Support Inference Output for counties

### DIFF
--- a/cli/run_counties_api.py
+++ b/cli/run_counties_api.py
@@ -43,26 +43,32 @@ def deploy_counties_api(disable_validation, input_dir, output, summary_output):
             raise NotADirectoryError(directory)
 
     for intervention in list(Intervention):
-        # TODO(issues/#258): remove check once counties support inferrence
-        if intervention in Intervention.county_supported_interventions():
-            county_result = api_pipeline.run_projections(
-                input_dir,
-                AggregationLevel.COUNTY,
-                intervention,
-                run_validation=not disable_validation,
-            )
-            county_summaries, county_timeseries = api_pipeline.generate_api(
-                county_result, input_dir
-            )
-            api_pipeline.deploy_results([*county_summaries, *county_timeseries], output)
+        county_result = api_pipeline.run_projections(
+            input_dir,
+            AggregationLevel.COUNTY,
+            intervention,
+            run_validation=not disable_validation,
+        )
+        county_summaries, county_timeseries = api_pipeline.generate_api(
+            county_result, input_dir
+        )
+        api_pipeline.deploy_results([*county_summaries, *county_timeseries], output)
 
-            counties_summary = api_pipeline.build_counties_summary(county_summaries, intervention)
-            counties_timeseries = api_pipeline.build_counties_timeseries(county_timeseries, intervention)
-            summarized_timeseries = api_pipeline.build_prediction_header_timeseries_data(counties_timeseries)
-            api_pipeline.deploy_prediction_timeseries_csvs(summarized_timeseries, summary_output)
+        counties_summary = api_pipeline.build_counties_summary(
+            county_summaries, intervention
+        )
+        counties_timeseries = api_pipeline.build_counties_timeseries(
+            county_timeseries, intervention
+        )
+        summarized_timeseries = api_pipeline.build_prediction_header_timeseries_data(
+            counties_timeseries
+        )
+        api_pipeline.deploy_prediction_timeseries_csvs(
+            summarized_timeseries, summary_output
+        )
 
-            api_pipeline.deploy_results([counties_summary], summary_output, write_csv=True)
-            api_pipeline.deploy_results([counties_timeseries], summary_output)
+        api_pipeline.deploy_results([counties_summary], summary_output, write_csv=True)
+        api_pipeline.deploy_results([counties_timeseries], summary_output)
 
         logger.info("finished top counties job")
 

--- a/libs/datasets/results_schema.py
+++ b/libs/datasets/results_schema.py
@@ -101,3 +101,17 @@ EXPECTED_MISSING_STATES = set([
 EXPECTED_MISSING_STATES_FROM_COUNTES = set([
     'District of Columbia'
 ])
+
+# Many counties don't have inference results, including all counties in a few states.
+EXPECTED_MISSING_STATES_FROM_COUNTIES_OBSERVED_INTERVENTION = set(
+    [
+        "Rhode Island",
+        "South Dakota",
+        "Montana",
+        "North Dakota",
+        "Hawaii",
+        "Wyoming",
+        "Alaska",
+        "West Virginia",
+    ]
+)

--- a/libs/pipelines/api_pipeline.py
+++ b/libs/pipelines/api_pipeline.py
@@ -99,7 +99,9 @@ def run_projections(
             input_file, intervention.value
         )
         if run_validation:
-            validate_results.validate_counties_df(counties_key_name, counties_df)
+            validate_results.validate_counties_df(
+                counties_key_name, counties_df, intervention
+            )
 
         county_results = APIPipelineProjectionResult(
             intervention, AggregationLevel.COUNTY, counties_df

--- a/libs/pipelines/dod_pipeline.py
+++ b/libs/pipelines/dod_pipeline.py
@@ -51,7 +51,9 @@ def run_projections(
         county_input_file, intervention.value
     )
     if run_validation:
-        validate_results.validate_counties_df(counties_key_name, counties_df)
+        validate_results.validate_counties_df(
+            counties_key_name, counties_df, intervention
+        )
 
     (
         counties_shp,

--- a/libs/pipelines/top_counties_pipeline.py
+++ b/libs/pipelines/top_counties_pipeline.py
@@ -41,7 +41,9 @@ def run_projections(
         input_file, intervention.value
     )
     if run_validation:
-        validate_results.validate_counties_df(counties_key_name, counties_df)
+        validate_results.validate_counties_df(
+            counties_key_name, counties_df, intervention
+        )
 
     county_results = TopCountiesPipelineProjectionResult(counties_df)
 

--- a/libs/validate_results.py
+++ b/libs/validate_results.py
@@ -2,6 +2,7 @@ import csv
 import sys
 
 from libs.datasets import CommonFields
+from libs.enums import Intervention
 from libs.us_state_abbrev import US_STATE_ABBREV
 from libs.datasets.results_schema import (
     RESULT_DATA_COLUMNS_STATES,
@@ -67,7 +68,7 @@ def validate_states_df(key, states_df):
         )
 
 
-def validate_counties_df(key, counties_df):
+def validate_counties_df(key, counties_df, intervention):
     # assert the headers are what we expect
     _raise_error_if_incorrect_headers(key, RESULT_DATA_COLUMNS_COUNTIES, counties_df)
 
@@ -75,7 +76,8 @@ def validate_counties_df(key, counties_df):
     expected_missing = EXPECTED_MISSING_STATES.union(
         EXPECTED_MISSING_STATES_FROM_COUNTES
     )
-    if key == "counties.OBSERVED_INTERVENTION":
+    is_observed = intervention is Intervention.OBSERVED_INTERVENTION
+    if is_observed:
         expected_missing = expected_missing.union(
             EXPECTED_MISSING_STATES_FROM_COUNTIES_OBSERVED_INTERVENTION
         )
@@ -94,7 +96,7 @@ def validate_counties_df(key, counties_df):
 
     # assert that the csv is a certain length
     # Note that most counties don't have inference (observed) projections yet.
-    min_length = 1800 if key != "counties.OBSERVED_INTERVENTION" else 250
+    min_length = 250 if is_observed else 1800
     if len(counties_df["County"]) < min_length:
         raise DataExportException(
             key,


### PR DESCRIPTION
This enables generating OBSERVED_INTERVENTION files in the API for inference projections.

This required tweaking our validation in several places, since we expect many
counties not to have inference results.

This PR addresses issue #258.

### Please Check
- [n/a] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [n/a] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [X] Are tests passing?
