### PR TITLE
Add icu ventilator usage + fix cumulative tests

### DIFF
--- a/api/can_api_definition.py
+++ b/api/can_api_definition.py
@@ -110,9 +110,17 @@ class CANPredictionTimeseriesRow(pydantic.BaseModel):
         ...,
         description="Number of ICU beds projected to be in-use or that were actually in use (if in the past)",
     )
-    ICUBedCapacity: Optional[int] = pydantic.Field(
+    ICUBedCapacity: int = pydantic.Field(
         ...,
         description="Number of ICU beds projected to be in-use or actually in use (if in the past)",
+    )
+    VentilatorsInUse: int = pydantic.Field(
+        ...,
+        description="Number of ventilators projected to be in-use.",
+    )
+    VentilatorCapacity: int = pydantic.Field(
+        ...,
+        description="Total ventilator capacity."
     )
     cumulativeDeaths: int = pydantic.Field(..., description="Number of cumulative deaths")
     cumulativeInfected: Optional[int] = pydantic.Field(
@@ -124,6 +132,7 @@ class CANPredictionTimeseriesRow(pydantic.BaseModel):
     cumulativeNegativeTests: Optional[int] = pydantic.Field(
         ..., description="Number of negative test results to date"
     )
+
 
 class PredictionTimeseriesRowWithHeader(CANPredictionTimeseriesRow):
     countryName: str = "US"

--- a/api/can_api_definition.py
+++ b/api/can_api_definition.py
@@ -158,6 +158,7 @@ class PredictionTimeseriesRowWithHeader(CANPredictionTimeseriesRow):
 class CovidActNowStateTimeseries(CovidActNowStateSummary):
     timeseries: List[CANPredictionTimeseriesRow] = pydantic.Field(...)
 
+    # pylint: disable=no-self-argument
     @pydantic.validator('timeseries')
     def check_timeseries_have_cumulative_test_data(cls, rows, values):
         # Nebraska is missing testing data.

--- a/api/schemas/CANPredictionTimeseriesRow.json
+++ b/api/schemas/CANPredictionTimeseriesRow.json
@@ -28,6 +28,16 @@
       "description": "Number of ICU beds projected to be in-use or actually in use (if in the past)",
       "type": "integer"
     },
+    "VentilatorsInUse": {
+      "title": "Ventilatorsinuse",
+      "description": "Number of ventilators projected to be in-use.",
+      "type": "integer"
+    },
+    "VentilatorCapacity": {
+      "title": "Ventilatorcapacity",
+      "description": "Total ventilator capacity.",
+      "type": "integer"
+    },
     "cumulativeDeaths": {
       "title": "Cumulativedeaths",
       "description": "Number of cumulative deaths",
@@ -55,6 +65,8 @@
     "hospitalBedCapacity",
     "ICUBedsInUse",
     "ICUBedCapacity",
+    "VentilatorsInUse",
+    "VentilatorCapacity",
     "cumulativeDeaths",
     "cumulativeInfected",
     "cumulativePositiveTests",

--- a/api/schemas/CANPredictionTimeseriesRow.json
+++ b/api/schemas/CANPredictionTimeseriesRow.json
@@ -28,12 +28,12 @@
       "description": "Number of ICU beds projected to be in-use or actually in use (if in the past)",
       "type": "integer"
     },
-    "VentilatorsInUse": {
+    "ventilatorsInUse": {
       "title": "Ventilatorsinuse",
       "description": "Number of ventilators projected to be in-use.",
       "type": "integer"
     },
-    "VentilatorCapacity": {
+    "ventilatorCapacity": {
       "title": "Ventilatorcapacity",
       "description": "Total ventilator capacity.",
       "type": "integer"
@@ -65,8 +65,8 @@
     "hospitalBedCapacity",
     "ICUBedsInUse",
     "ICUBedCapacity",
-    "VentilatorsInUse",
-    "VentilatorCapacity",
+    "ventilatorsInUse",
+    "ventilatorCapacity",
     "cumulativeDeaths",
     "cumulativeInfected",
     "cumulativePositiveTests",

--- a/api/schemas/CovidActNowCountiesTimeseries.json
+++ b/api/schemas/CovidActNowCountiesTimeseries.json
@@ -176,12 +176,12 @@
           "description": "Number of ICU beds projected to be in-use or actually in use (if in the past)",
           "type": "integer"
         },
-        "VentilatorsInUse": {
+        "ventilatorsInUse": {
           "title": "Ventilatorsinuse",
           "description": "Number of ventilators projected to be in-use.",
           "type": "integer"
         },
-        "VentilatorCapacity": {
+        "ventilatorCapacity": {
           "title": "Ventilatorcapacity",
           "description": "Total ventilator capacity.",
           "type": "integer"
@@ -213,8 +213,8 @@
         "hospitalBedCapacity",
         "ICUBedsInUse",
         "ICUBedCapacity",
-        "VentilatorsInUse",
-        "VentilatorCapacity",
+        "ventilatorsInUse",
+        "ventilatorCapacity",
         "cumulativeDeaths",
         "cumulativeInfected",
         "cumulativePositiveTests",

--- a/api/schemas/CovidActNowCountiesTimeseries.json
+++ b/api/schemas/CovidActNowCountiesTimeseries.json
@@ -176,6 +176,16 @@
           "description": "Number of ICU beds projected to be in-use or actually in use (if in the past)",
           "type": "integer"
         },
+        "VentilatorsInUse": {
+          "title": "Ventilatorsinuse",
+          "description": "Number of ventilators projected to be in-use.",
+          "type": "integer"
+        },
+        "VentilatorCapacity": {
+          "title": "Ventilatorcapacity",
+          "description": "Total ventilator capacity.",
+          "type": "integer"
+        },
         "cumulativeDeaths": {
           "title": "Cumulativedeaths",
           "description": "Number of cumulative deaths",
@@ -203,6 +213,8 @@
         "hospitalBedCapacity",
         "ICUBedsInUse",
         "ICUBedCapacity",
+        "VentilatorsInUse",
+        "VentilatorCapacity",
         "cumulativeDeaths",
         "cumulativeInfected",
         "cumulativePositiveTests",

--- a/api/schemas/CovidActNowStatesTimeseries.json
+++ b/api/schemas/CovidActNowStatesTimeseries.json
@@ -176,12 +176,12 @@
           "description": "Number of ICU beds projected to be in-use or actually in use (if in the past)",
           "type": "integer"
         },
-        "VentilatorsInUse": {
+        "ventilatorsInUse": {
           "title": "Ventilatorsinuse",
           "description": "Number of ventilators projected to be in-use.",
           "type": "integer"
         },
-        "VentilatorCapacity": {
+        "ventilatorCapacity": {
           "title": "Ventilatorcapacity",
           "description": "Total ventilator capacity.",
           "type": "integer"
@@ -213,8 +213,8 @@
         "hospitalBedCapacity",
         "ICUBedsInUse",
         "ICUBedCapacity",
-        "VentilatorsInUse",
-        "VentilatorCapacity",
+        "ventilatorsInUse",
+        "ventilatorCapacity",
         "cumulativeDeaths",
         "cumulativeInfected",
         "cumulativePositiveTests",

--- a/api/schemas/CovidActNowStatesTimeseries.json
+++ b/api/schemas/CovidActNowStatesTimeseries.json
@@ -176,6 +176,16 @@
           "description": "Number of ICU beds projected to be in-use or actually in use (if in the past)",
           "type": "integer"
         },
+        "VentilatorsInUse": {
+          "title": "Ventilatorsinuse",
+          "description": "Number of ventilators projected to be in-use.",
+          "type": "integer"
+        },
+        "VentilatorCapacity": {
+          "title": "Ventilatorcapacity",
+          "description": "Total ventilator capacity.",
+          "type": "integer"
+        },
         "cumulativeDeaths": {
           "title": "Cumulativedeaths",
           "description": "Number of cumulative deaths",
@@ -203,6 +213,8 @@
         "hospitalBedCapacity",
         "ICUBedsInUse",
         "ICUBedCapacity",
+        "VentilatorsInUse",
+        "VentilatorCapacity",
         "cumulativeDeaths",
         "cumulativeInfected",
         "cumulativePositiveTests",

--- a/libs/datasets/can_model_output_schema.py
+++ b/libs/datasets/can_model_output_schema.py
@@ -22,6 +22,7 @@ POPULATION = "population"
 ICU_BED_CAPACITY = "icu_bed_capacity"
 VENTILATOR_CAPACITY = "ventilator_capacity"
 
+
 CAN_MODEL_OUTPUT_SCHEMA = [
     DAY_NUM,
     # ^ for index column

--- a/libs/datasets/results_schema.py
+++ b/libs/datasets/results_schema.py
@@ -1,7 +1,7 @@
 from libs.datasets import CommonFields
+from libs.datasets import can_model_output_schema
 
-
-STATE = CommonFields.STATE_FULL_NAME
+STATE_FULL_NAME = CommonFields.STATE_FULL_NAME
 COUNTRY = "Country/Region"
 LAST_UPDATED = "Last Update"
 LATITUDE = "Latitude"
@@ -27,8 +27,9 @@ POPULATION = "Population"
 RT = "Rt"
 RT_CI90 = "Rt_ci90"
 
+
 RESULT_DATA_COLUMNS_SHARED = [
-    STATE,
+    STATE_FULL_NAME,
     COUNTRY,
     LAST_UPDATED,
     LATITUDE,
@@ -52,7 +53,7 @@ RESULT_DATA_COLUMNS_SHARED = [
     PEAK_BED_CAPACITY,
     POPULATION,
     RT,
-    RT_CI90
+    RT_CI90,
 ]
 
 NON_INTEGER_FIELDS = [
@@ -61,7 +62,7 @@ NON_INTEGER_FIELDS = [
     PEAK_DEATHS,
     HOSPITAL_SHORTFALL_DATE,
     PEAK_HOSPITALIZATION_SHORTFALL,
-    STATE,
+    STATE_FULL_NAME,
     COUNTRY,
     LAST_UPDATED,
     COMBINED_KEY,

--- a/libs/functions/calculate_projections.py
+++ b/libs/functions/calculate_projections.py
@@ -6,15 +6,13 @@ import simplejson
 from libs.us_state_abbrev import US_STATE_ABBREV
 from libs.datasets import FIPSPopulation
 from libs.datasets import CommonFields
+from libs.datasets import can_model_output_schema as schema
 from libs.datasets.can_model_output_schema import (
     CAN_MODEL_OUTPUT_SCHEMA,
     CAN_MODEL_OUTPUT_SCHEMA_EXCLUDED_COLUMNS,
 )
-from libs.datasets.projections_schema import CALCULATED_PROJECTION_HEADERS_STATES
 from libs.enums import Intervention
 from libs.constants import NULL_VALUE
-
-from pandarallel import pandarallel
 
 
 def _calc_short_fall(x):
@@ -116,6 +114,7 @@ def _calculate_projection_data(state, file_path, fips=None):
     record["Population"] = population
     record["Rt"] = Rt
     record["Rt_ci90"] = Rt_ci90
+
     return pd.Series(record)
 
 

--- a/libs/functions/generate_api.py
+++ b/libs/functions/generate_api.py
@@ -159,20 +159,18 @@ def _generate_county_timeseries_row(json_data_row):
 def generate_state_timeseries(
     projection_row, intervention, input_dir
 ) -> CovidActNowStateTimeseries:
-    state_abbrev = US_STATE_ABBREV[projection_row[rc.STATE]]
+    state = US_STATE_ABBREV[projection_row[rc.STATE_FULL_NAME]]
     fips = projection_row[rc.FIPS]
     raw_dataseries = get_can_projection.get_can_raw_data(
-        input_dir, state_abbrev, fips, AggregationLevel.STATE, intervention
+        input_dir, state, fips, AggregationLevel.STATE, intervention
     )
 
     # join in state testing data onto the timeseries
     # left join '%m/%d/%y', so the left join gracefully handles missing state testing data (i.e. NE)
-    testing_df = get_testing_timeseries_by_state(projection_row[rc.STATE])
+    testing_df = get_testing_timeseries_by_state(state)
     new_df = pd.DataFrame(raw_dataseries).merge(
-        testing_df, left_on="date", right_on="date", how="left"
+        testing_df, on="date", how="left"
     )
-
-    # reformat as dict
     can_dataseries = new_df.to_dict(orient="records")
 
     timeseries = []
@@ -185,8 +183,8 @@ def generate_state_timeseries(
     return CovidActNowStateTimeseries(
         lat=projection_row[rc.LATITUDE],
         long=projection_row[rc.LONGITUDE],
-        actuals=_generate_state_actuals(projection_row, state_abbrev),
-        stateName=projection_row[rc.STATE],
+        actuals=_generate_state_actuals(projection_row, state),
+        stateName=projection_row[rc.STATE_FULL_NAME],
         fips=projection_row[rc.FIPS],
         lastUpdatedDate=_format_date(projection_row[rc.LAST_UPDATED]),
         projections=projections,
@@ -195,7 +193,7 @@ def generate_state_timeseries(
 
 
 def generate_county_timeseries(projection_row, intervention, input_dir):
-    state_abbrev = US_STATE_ABBREV[projection_row[rc.STATE]]
+    state_abbrev = US_STATE_ABBREV[projection_row[rc.STATE_FULL_NAME]]
     fips = projection_row[rc.FIPS]
     can_dataseries = get_can_projection.get_can_raw_data(
         input_dir, state_abbrev, fips, AggregationLevel.COUNTY, intervention
@@ -211,7 +209,7 @@ def generate_county_timeseries(projection_row, intervention, input_dir):
         lat=projection_row[rc.LATITUDE],
         long=projection_row[rc.LONGITUDE],
         actuals=_generate_county_actuals(projection_row, state_abbrev),
-        stateName=projection_row[rc.STATE],
+        stateName=projection_row[rc.STATE_FULL_NAME],
         countyName=projection_row[rc.COUNTY],
         fips=projection_row[rc.FIPS],
         lastUpdatedDate=_format_date(projection_row[rc.LAST_UPDATED]),
@@ -221,14 +219,14 @@ def generate_county_timeseries(projection_row, intervention, input_dir):
 
 
 def generate_api_for_state_projection_row(projection_row) -> CovidActNowStateSummary:
-    state_abbrev = US_STATE_ABBREV[projection_row[rc.STATE]]
+    state_abbrev = US_STATE_ABBREV[projection_row[rc.STATE_FULL_NAME]]
     projections = _generate_api_for_projections(projection_row)
 
     state_result = CovidActNowStateSummary(
         lat=projection_row[rc.LATITUDE],
         long=projection_row[rc.LONGITUDE],
         actuals=_generate_state_actuals(projection_row, state_abbrev),
-        stateName=projection_row[rc.STATE],
+        stateName=projection_row[rc.STATE_FULL_NAME],
         fips=projection_row[rc.FIPS],
         lastUpdatedDate=_format_date(projection_row[rc.LAST_UPDATED]),
         projections=projections,
@@ -237,14 +235,14 @@ def generate_api_for_state_projection_row(projection_row) -> CovidActNowStateSum
 
 
 def generate_api_for_county_projection_row(projection_row):
-    state_abbrev = US_STATE_ABBREV[projection_row[rc.STATE]]
+    state_abbrev = US_STATE_ABBREV[projection_row[rc.STATE_FULL_NAME]]
     projections = _generate_api_for_projections(projection_row)
 
     county_result = CovidActNowCountySummary(
         lat=projection_row[rc.LATITUDE],
         long=projection_row[rc.LONGITUDE],
         actuals=_generate_county_actuals(projection_row, state_abbrev),
-        stateName=projection_row[rc.STATE],
+        stateName=projection_row[rc.STATE_FULL_NAME],
         countyName=projection_row[rc.COUNTY],
         fips=projection_row[rc.FIPS],
         lastUpdatedDate=_format_date(projection_row[rc.LAST_UPDATED]),

--- a/libs/functions/generate_api.py
+++ b/libs/functions/generate_api.py
@@ -126,9 +126,11 @@ def _generate_state_timeseries_row(json_data_row):
         hospitalBedsRequired=json_data_row[can_schema.ALL_HOSPITALIZED],
         hospitalBedCapacity=json_data_row[can_schema.BEDS],
         ICUBedsInUse=json_data_row[can_schema.INFECTED_C],
-        ICUBedCapacity=None,
+        ICUBedCapacity=json_data_row[can_schema.ICU_BED_CAPACITY],
         cumulativeDeaths=json_data_row[can_schema.DEAD],
         cumulativeInfected=json_data_row[can_schema.CUMULATIVE_INFECTED],
+        VentilatorsInUse=json_data_row[can_schema.CURRENT_VENTILATED],
+        VentilatorCapacity=json_data_row[can_schema.VENTILATOR_CAPACITY],
         cumulativePositiveTests=_get_or_none(
             json_data_row[CovidTrackingDataSource.Fields.POSITIVE_TESTS]
         ),
@@ -144,7 +146,9 @@ def _generate_county_timeseries_row(json_data_row):
         hospitalBedsRequired=json_data_row[can_schema.ALL_HOSPITALIZED],
         hospitalBedCapacity=json_data_row[can_schema.BEDS],
         ICUBedsInUse=json_data_row[can_schema.INFECTED_C],
-        ICUBedCapacity=None,
+        ICUBedCapacity=json_data_row[can_schema.ICU_BED_CAPACITY],
+        VentilatorsInUse=json_data_row[can_schema.CURRENT_VENTILATED],
+        VentilatorCapacity=json_data_row[can_schema.VENTILATOR_CAPACITY],
         cumulativeDeaths=json_data_row[can_schema.DEAD],
         cumulativeInfected=json_data_row[can_schema.CUMULATIVE_INFECTED],
         cumulativePositiveTests=None,

--- a/libs/functions/generate_api.py
+++ b/libs/functions/generate_api.py
@@ -129,8 +129,8 @@ def _generate_state_timeseries_row(json_data_row):
         ICUBedCapacity=json_data_row[can_schema.ICU_BED_CAPACITY],
         cumulativeDeaths=json_data_row[can_schema.DEAD],
         cumulativeInfected=json_data_row[can_schema.CUMULATIVE_INFECTED],
-        VentilatorsInUse=json_data_row[can_schema.CURRENT_VENTILATED],
-        VentilatorCapacity=json_data_row[can_schema.VENTILATOR_CAPACITY],
+        ventilatorsInUse=json_data_row[can_schema.CURRENT_VENTILATED],
+        ventilatorCapacity=json_data_row[can_schema.VENTILATOR_CAPACITY],
         cumulativePositiveTests=_get_or_none(
             json_data_row[CovidTrackingDataSource.Fields.POSITIVE_TESTS]
         ),
@@ -147,8 +147,8 @@ def _generate_county_timeseries_row(json_data_row):
         hospitalBedCapacity=json_data_row[can_schema.BEDS],
         ICUBedsInUse=json_data_row[can_schema.INFECTED_C],
         ICUBedCapacity=json_data_row[can_schema.ICU_BED_CAPACITY],
-        VentilatorsInUse=json_data_row[can_schema.CURRENT_VENTILATED],
-        VentilatorCapacity=json_data_row[can_schema.VENTILATOR_CAPACITY],
+        ventilatorsInUse=json_data_row[can_schema.CURRENT_VENTILATED],
+        ventilatorCapacity=json_data_row[can_schema.VENTILATOR_CAPACITY],
         cumulativeDeaths=json_data_row[can_schema.DEAD],
         cumulativeInfected=json_data_row[can_schema.CUMULATIVE_INFECTED],
         cumulativePositiveTests=None,
@@ -166,7 +166,8 @@ def generate_state_timeseries(
     )
 
     # join in state testing data onto the timeseries
-    # left join '%m/%d/%y', so the left join gracefully handles missing state testing data (i.e. NE)
+    # left join '%m/%d/%y', so the left join gracefully handles
+    # missing state testing data (i.e. NE)
     testing_df = get_testing_timeseries_by_state(state)
     new_df = pd.DataFrame(raw_dataseries).merge(
         testing_df, on="date", how="left"

--- a/libs/functions/get_can_projection.py
+++ b/libs/functions/get_can_projection.py
@@ -28,6 +28,7 @@ def _get_intervention(intervention, state):
         return get_intervention_for_state(state)
     return intervention
 
+
 def get_can_projection_path(
     input_dir, state_abbrev, fips, aggregation_level, initial_intervention
 ):

--- a/libs/pipelines/api_pipeline.py
+++ b/libs/pipelines/api_pipeline.py
@@ -59,7 +59,7 @@ def _get_api_prefix(aggregation_level, row):
     if aggregation_level == AggregationLevel.COUNTY:
         return row[rc.FIPS]
     elif aggregation_level == AggregationLevel.STATE:
-        full_state_name = row[rc.STATE]
+        full_state_name = row[rc.STATE_FULL_NAME]
         return US_STATE_ABBREV[full_state_name]
     else:
         raise ValueError("Only County and State Aggregate Levels supported")


### PR DESCRIPTION
Adds ICU/Vent capacity/utilization numbers to state and county timeseries.

Also fixes a bug i introduced where it was pulling incorrect values for cumulative testing data + add a validation to make sure it never happens again.

### Please Check
- [x] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [x] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [ ] Are tests passing?
