### PR TITLE
Expose inferred and "indicator" historical Rt values through the API timeseries

### DIFF
--- a/api/can_api_definition.py
+++ b/api/can_api_definition.py
@@ -122,6 +122,12 @@ class CANPredictionTimeseriesRow(pydantic.BaseModel):
         ...,
         description="Total ventilator capacity."
     )
+    Rt: float = pydantic.Field(
+        ..., description="Historical or Inferred Rt"
+    )
+    RtCI90: float = pydantic.Field(
+        ..., description="Rt standard deviation"
+    )
     cumulativeDeaths: int = pydantic.Field(..., description="Number of cumulative deaths")
     cumulativeInfected: Optional[int] = pydantic.Field(
         ..., description="Number of cumulative infections"

--- a/api/schemas/CANPredictionTimeseriesRow.json
+++ b/api/schemas/CANPredictionTimeseriesRow.json
@@ -38,6 +38,16 @@
       "description": "Total ventilator capacity.",
       "type": "integer"
     },
+    "Rt": {
+      "title": "Rt",
+      "description": "Historical or Inferred Rt",
+      "type": "float"
+    },
+    "RtCI90": {
+      "title": "Rtci90",
+      "description": "Rt standard deviation",
+      "type": "float"
+    },
     "cumulativeDeaths": {
       "title": "Cumulativedeaths",
       "description": "Number of cumulative deaths",
@@ -67,6 +77,8 @@
     "ICUBedCapacity",
     "ventilatorsInUse",
     "ventilatorCapacity",
+    "Rt",
+    "RtCI90",
     "cumulativeDeaths",
     "cumulativeInfected",
     "cumulativePositiveTests",

--- a/api/schemas/CovidActNowCountiesTimeseries.json
+++ b/api/schemas/CovidActNowCountiesTimeseries.json
@@ -186,6 +186,16 @@
           "description": "Total ventilator capacity.",
           "type": "integer"
         },
+	"Rt": {
+	  "title": "Rt",
+	  "description": "Historical or Inferred Rt",
+	  "type": "float"
+	},
+	"RtCI90": {
+	  "title": "Rtci90",
+	  "description": "Rt standard deviation",
+	  "type": "float"
+	},
         "cumulativeDeaths": {
           "title": "Cumulativedeaths",
           "description": "Number of cumulative deaths",
@@ -215,6 +225,8 @@
         "ICUBedCapacity",
         "ventilatorsInUse",
         "ventilatorCapacity",
+        "Rt",
+        "RtCI90",
         "cumulativeDeaths",
         "cumulativeInfected",
         "cumulativePositiveTests",

--- a/api/schemas/CovidActNowStatesTimeseries.json
+++ b/api/schemas/CovidActNowStatesTimeseries.json
@@ -186,6 +186,16 @@
           "description": "Total ventilator capacity.",
           "type": "integer"
         },
+	"Rt": {
+	  "title": "Rt",
+	  "description": "Historical or Inferred Rt",
+	  "type": "float"
+	},
+	"RtCI90": {
+	  "title": "Rtci90",
+	  "description": "Rt standard deviation",
+	  "type": "float"
+	},
         "cumulativeDeaths": {
           "title": "Cumulativedeaths",
           "description": "Number of cumulative deaths",
@@ -215,6 +225,8 @@
         "ICUBedCapacity",
         "ventilatorsInUse",
         "ventilatorCapacity",
+        "Rt",
+        "RtCI90",
         "cumulativeDeaths",
         "cumulativeInfected",
         "cumulativePositiveTests",

--- a/libs/datasets/can_model_output_schema.py
+++ b/libs/datasets/can_model_output_schema.py
@@ -22,7 +22,6 @@ POPULATION = "population"
 ICU_BED_CAPACITY = "icu_bed_capacity"
 VENTILATOR_CAPACITY = "ventilator_capacity"
 
-
 CAN_MODEL_OUTPUT_SCHEMA = [
     DAY_NUM,
     # ^ for index column

--- a/libs/functions/generate_api.py
+++ b/libs/functions/generate_api.py
@@ -131,6 +131,8 @@ def _generate_state_timeseries_row(json_data_row):
         cumulativeInfected=json_data_row[can_schema.CUMULATIVE_INFECTED],
         ventilatorsInUse=json_data_row[can_schema.CURRENT_VENTILATED],
         ventilatorCapacity=json_data_row[can_schema.VENTILATOR_CAPACITY],
+        Rt=json_data_row[can_schema.Rt],
+        RtCI90=json_data_row[can_schema.Rt_ci90],
         cumulativePositiveTests=_get_or_none(
             json_data_row[CovidTrackingDataSource.Fields.POSITIVE_TESTS]
         ),

--- a/libs/functions/generate_api.py
+++ b/libs/functions/generate_api.py
@@ -151,6 +151,8 @@ def _generate_county_timeseries_row(json_data_row):
         ICUBedCapacity=json_data_row[can_schema.ICU_BED_CAPACITY],
         ventilatorsInUse=json_data_row[can_schema.CURRENT_VENTILATED],
         ventilatorCapacity=json_data_row[can_schema.VENTILATOR_CAPACITY],
+        Rt=json_data_row[can_schema.Rt],
+        RtCI90=json_data_row[can_schema.Rt_ci90],
         cumulativeDeaths=json_data_row[can_schema.DEAD],
         cumulativeInfected=json_data_row[can_schema.CUMULATIVE_INFECTED],
         cumulativePositiveTests=None,


### PR DESCRIPTION
This PR addresses issue #309

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [ ] Are tests passing?
