### PR TITLE
R_t Add KeyError handling

### DIFF
--- a/pyseir/deployment/webui_data_adaptor_v1.py
+++ b/pyseir/deployment/webui_data_adaptor_v1.py
@@ -232,7 +232,7 @@ class WebUIDataAdaptorV1:
                 output_model[schema.RT_INDICATOR] = merged['Rt_MAP_composite']
                 # With 90% probability the value is between rt_indicator - ci90 to rt_indicator + ci90
                 output_model[schema.RT_INDICATOR_CI90] = merged['Rt_ci95_composite'] - merged['Rt_MAP_composite']
-            except ValueError as e:
+            except (ValueError, KeyError) as e:
                 output_model[schema.RT_INDICATOR] = "NaN"
                 output_model[schema.RT_INDICATOR_CI90] = "NaN"
 


### PR DESCRIPTION
Some edge counties do not contain a composite R_t measure. This fills NaNs in those cases.