### PR TITLE
Fix typos

### DIFF
--- a/api/README.V1.md
+++ b/api/README.V1.md
@@ -57,7 +57,7 @@ More information on interventions, including definitions, references, and R0 val
 
 An optional parameter `timeseries` can be added before the file format, for example: `*.timeseries.json` or `*.timeseries.csv`.
 
-If ommited, the API will return the date of projected hospital overloads, data of peak hospitalizations, and more.
+If omitted, the API will return the date of projected hospital overloads, data of peak hospitalizations, and more.
 
 If included, the API will return the projected hospitalization data every day for the next 90 days.
 
@@ -182,7 +182,7 @@ This is the data format for both states and counties. `timeseries` is only inclu
     hospitalBedsRequired,
     hospitalBedCapacity,
     ICUBedsInUse,
-    ICUBedCapacity, // Coming soon where availabe, null currently
+    ICUBedCapacity, // Coming soon where available, null currently
     cumulativePositiveTests,
     cumulativeNegativeTests,
     cumulativeDeaths,

--- a/cli/run_counties_api.py
+++ b/cli/run_counties_api.py
@@ -87,6 +87,6 @@ def deploy_counties_api(disable_validation, input_dir, output, summary_output):
     help="Output directory for artifacts",
 )
 def county_fips_summaries(input_dir, output):
-    """Generates sumary files by state and globally of counties with model output data."""
+    """Generates summary files by state and globally of counties with model output data."""
     county_summaries = api_pipeline.build_county_summary_from_model_output(input_dir)
     api_pipeline.deploy_results(county_summaries, output)

--- a/cli/run_dod_dataset.py
+++ b/cli/run_dod_dataset.py
@@ -20,13 +20,13 @@ def deploy_dod_projections(disable_validation, input_state_dir, input_county_dir
 
     Used for manual trigger
 
-    # triggering persistance to s3
+    # triggering persistence to s3
     AWS_PROFILE=covidactnow BUCKET_NAME=covidactnow-deleteme python run.py deploy-dod-projections
 
     # deploy to the data bucket
     AWS_PROFILE=covidactnow BUCKET_NAME=data.covidactnow.org python run.py deploy-dod-projections
 
-    # triggering persistance to local
+    # triggering persistence to local
     python run.py deploy-dod-projections
     """
 

--- a/libs/CovidDatasets.py
+++ b/libs/CovidDatasets.py
@@ -161,13 +161,13 @@ class Dataset:
         return self._TIME_SERIES_DATA
 
     def get_raw_timeseries(self):
-        raise NotImplementedError('The \'get_raw_timeseries\' method must be overriden by the child class')
+        raise NotImplementedError('The \'get_raw_timeseries\' method must be overridden by the child class')
 
     def get_all_population(self):
-        raise NotImplementedError('The \'get_all_population\' method must be overriden by the child class')
+        raise NotImplementedError('The \'get_all_population\' method must be overridden by the child class')
 
     def get_all_beds(self):
-        raise NotImplementedError('The \'get_all_beds\' method must be overriden by the child class')
+        raise NotImplementedError('The \'get_all_beds\' method must be overridden by the child class')
 
     def combine_state_county_data(self, country, state):
         # Create a single dataset from state and county data, using state data preferentially.

--- a/libs/datasets/can_model_output_schema.py
+++ b/libs/datasets/can_model_output_schema.py
@@ -1,5 +1,5 @@
 """
-One data model ouput of the modeling pipeline to serve to the API.
+One data model output of the modeling pipeline to serve to the API.
 """
 DAY_NUM = 'day_num'      # Index Column. Generally not the same between simulations.
 DATE = "date"            # Date in the timeseries.

--- a/libs/pipelines/top_counties_pipeline.py
+++ b/libs/pipelines/top_counties_pipeline.py
@@ -23,7 +23,7 @@ def run_projections(
     input_file, run_validation=True
 ) -> TopCountiesPipelineProjectionResult:
     """Run the projections for the current intervention for counties
-    in order to genereate a list of the 100 counties most affected
+    in order to generate a list of the 100 counties most affected
 
     Args:
         input_file: Input file to load model output results from.

--- a/pyseir/inference/initial_conditions_fitter.py
+++ b/pyseir/inference/initial_conditions_fitter.py
@@ -97,7 +97,7 @@ class InitialConditionsFitter:
         return np.sum(chi2) / (len(chi2) - 1)
 
     def exponential_loss(self, norm, t0, scale):
-        """Return the reduced chi2 for an exponential fit to teh data"""
+        """Return the reduced chi2 for an exponential fit to the data"""
         y_pred = self.exponential_model(norm, t0, scale, self.t)
         return self._reduced_chi2(y_pred, self.y)
 

--- a/pyseir/models/suppression_policies.py
+++ b/pyseir/models/suppression_policies.py
@@ -9,7 +9,7 @@ from pyseir.inference import fit_results
 
 # Fig 4 of Imperial college.
 # https://www.imperial.ac.uk/media/imperial-college/medicine/sph/ide/gida-fellowships/Imperial-College-COVID19-Europe-estimates-and-NPI-impact-30-03-2020.pdf
-# These are intended to act indendently, as shown by a multivariate fit from Imp. College.  The exception is lockdown which supercedes everything.
+# These are intended to act indendently, as shown by a multivariate fit from Imp. College.  The exception is lockdown which supersedes everything.
 distancing_measure_suppression = {
     'stay_at_home': .48,
     '50_gatherings': .05,
@@ -24,7 +24,7 @@ distancing_measure_suppression = {
 
 def generate_triggered_suppression_model(t_list, lockdown_days, open_days, reduction=0.25, start_on=0):
     """
-    Generates a contact reduction model which switches a binary supression
+    Generates a contact reduction model which switches a binary suppression
     policy on and off.
 
     Parameters

--- a/run.py
+++ b/run.py
@@ -41,6 +41,6 @@ if __name__ == "__main__":
     try:
         entry_point()
     except Exception as e:
-        # blanket catch excpetions at the entry point and send them to sentry
+        # blanket catch exceptions at the entry point and send them to sentry
         sentry_sdk.capture_exception(e)
         raise e


### PR DESCRIPTION
Hey,

This huge PR will fix : 

- 2 typos in `api/README.V1.md`
- 1 typo in `cli/run_counties_api.py`
- 2 typos in `cli/run_dod_dataset.py`
- 3 typos in `libs/CovidDatasets.py`
- 1 typo in `libs/datasets/can_model_output_schema.py`
- 1 typo in `libs/pipelines/top_counties_pipeline.py`
- 1 typo in `pyseir/inference/initial_conditions_fitter.py`
- 2 typos in `pyseir/models/suppression_policies.py`
- 1 typo in `run.py`



Bye! :robot: