### PR TITLE
Make whitelist slightly more stringent and tweak fitter.

### DIFF
--- a/pyseir/inference/infer_rt.py
+++ b/pyseir/inference/infer_rt.py
@@ -376,7 +376,7 @@ class RtInferenceEngine:
 
                 # Compute the indicator lag using the curvature alignment method.
                 if timeseries_type in (TimeseriesType.NEW_DEATHS, TimeseriesType.NEW_HOSPITALIZATIONS) \
-                        and TimeseriesType.NEW_CASES in available_timeseries:
+                        and f'Rt_MAP__{TimeseriesType.NEW_CASES.value}' in df_all.columns:
                     # Go back upto 30 days or the max time series length we have if shorter.
                     last_idx = max(-30, -len(df))
                     shift_in_days = self.align_time_series(

--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -67,7 +67,7 @@ class ModelFitter:
 
     DEFAULT_FIT_PARAMS = dict(
         R0=3.4, limit_R0=[2, 4.5], error_R0=.05,
-        log10_I_initial=1, limit_log10_I_initial=[.333, 3],
+        log10_I_initial=1, limit_log10_I_initial=[.333, 2],
         error_log10_I_initial=.33,
         t0=60, limit_t0=[10, 80], error_t0=2.0,
         eps=.3, limit_eps=[.20, 1.2], error_eps=.005,
@@ -170,7 +170,7 @@ class ModelFitter:
 
         if len(self.fips) == 5:
             # Setting
-            idx_enough_cases = np.argwhere(np.cumsum(self.observed_new_cases) >= 3)[0][0]
+            idx_enough_cases = np.argwhere(np.cumsum(self.observed_new_cases) >= 2)[0][0]
             initial_cases_guess = np.cumsum(self.observed_new_cases)[idx_enough_cases]
             t0_guess = list(self.times)[idx_enough_cases]
 
@@ -609,7 +609,7 @@ class ModelFitter:
                     color='k', alpha=0.5, fontsize=15)
 
         plt.ylim(*y_lim)
-        plt.xlim(data_dates[0], data_dates[-1] + timedelta(days=150))
+        plt.xlim(min(model_dates[0], data_dates[0]), data_dates[-1] + timedelta(days=150))
         plt.xticks(rotation=30, fontsize=14)
         plt.yticks(fontsize=14)
         plt.legend(loc=4, fontsize=14)

--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -169,8 +169,8 @@ class ModelFitter:
             self.fit_params['hosp_fraction'] = 1
 
         if len(self.fips) == 5:
-            # Setting
-            idx_enough_cases = np.argwhere(np.cumsum(self.observed_new_cases) >= 2)[0][0]
+            OBSERVED_NEW_CASES_GUESS_THRESHOLD = 2
+            idx_enough_cases = np.argwhere(np.cumsum(self.observed_new_cases) >= OBSERVED_NEW_CASES_GUESS_THRESHOLD)[0][0]
             initial_cases_guess = np.cumsum(self.observed_new_cases)[idx_enough_cases]
             t0_guess = list(self.times)[idx_enough_cases]
 

--- a/pyseir/inference/whitelist_generator.py
+++ b/pyseir/inference/whitelist_generator.py
@@ -27,7 +27,7 @@ class WhitelistGenerator:
     """
     def __init__(
             self,
-            total_cases=20,
+            total_cases=50,
             total_deaths=0,
             nonzero_case_datapoints=5,
             nonzero_death_datapoints=0):


### PR DESCRIPTION
Make the whitelist a little more conservative from now, going from 20 case low threshold to 50 case, which is 50% of counties -> 25% of counties due to the steep recall curve.  We can try to push this back down in a few days when we move to R_t suppression models.

Also some minor fit tweaks and plotting bug fix.

![image](https://user-images.githubusercontent.com/3518318/80828974-78276800-8ba3-11ea-8dbc-fc4206242bee.png)


### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [ ] Are tests passing?
