### PR TITLE
Expand interventions that have inferred results to lower the threshold

### DIFF
--- a/libs/enums.py
+++ b/libs/enums.py
@@ -13,6 +13,15 @@ class Intervention(enum.Enum):
     OBSERVED_INTERVENTION = 2 # given the previous pattern, how do we predict going forward
 
     @classmethod
+    def inferred_interventions(cls):
+        return [
+            Intervention.NO_INTERVENTION,
+            Intervention.STRONG_INTERVENTION,
+            Intervention.WEAK_INTERVENTION,
+            Intervention.SELECTED_INTERVENTION,
+        ]
+
+    @classmethod
     def county_supported_interventions(cls):
         return [
             Intervention.NO_INTERVENTION,

--- a/libs/validate_results.py
+++ b/libs/validate_results.py
@@ -76,7 +76,7 @@ def validate_counties_df(key, counties_df, intervention):
     expected_missing = EXPECTED_MISSING_STATES.union(
         EXPECTED_MISSING_STATES_FROM_COUNTES
     )
-    is_observed = intervention is Intervention.OBSERVED_INTERVENTION
+    is_observed = intervention in Intervention.inferred_interventions()
     if is_observed:
         expected_missing = expected_missing.union(
             EXPECTED_MISSING_STATES_FROM_COUNTIES_OBSERVED_INTERVENTION


### PR DESCRIPTION
basically because all of the results are now using infernece there are less counties that are making it through.  this change counts all interventions as using the inference algorithm so it will lower the minimum acceptable counties in the output