### PR TITLE
Remove bad data states

### DIFF
--- a/pyseir/deployment/webui_data_adaptor_v1.py
+++ b/pyseir/deployment/webui_data_adaptor_v1.py
@@ -112,7 +112,9 @@ class WebUIDataAdaptorV1:
 
             hosp_rescaling_factor = current_hosp / (state_hosp_gen + state_hosp_icu)
 
-            if current_icu is not None:
+            # Some states have covidtracking issues. We shouldn't ground ICU cases
+            # to zero since so far these have all been bad reporting.
+            if current_icu is not None and current_icu[-1] > 0:
                 icu_rescaling_factor = current_icu[-1] / state_hosp_icu
             else:
                 icu_rescaling_factor = current_hosp / (state_hosp_gen + state_hosp_icu)

--- a/pyseir/inference/infer_rt.py
+++ b/pyseir/inference/infer_rt.py
@@ -465,7 +465,7 @@ class RtInferenceEngine:
         shift: int
             A shift period applied to series b that aligns to series a
         """
-        shifts = range(-30, 5)
+        shifts = range(-21, 5)
         valid_shifts = []
         xcor = []
         np.random.seed(42)  # Xcor has some stochastic FFT elements.

--- a/pyseir/load_data.py
+++ b/pyseir/load_data.py
@@ -21,8 +21,6 @@ from enum import Enum
 
 DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'pyseir_data')
 
-BAD_ICU_DATA_STATES = ['AR']
-
 
 class HospitalizationDataType(Enum):
     CUMULATIVE_HOSPITALIZATIONS = 'cumulative_hospitalizations'
@@ -432,7 +430,7 @@ def load_hospitalization_data_by_state(state, t0, convert_cumulative_to_current=
     if category not in categories:
         raise ValueError(f'Hospitalization category {category} is not in {categories}')
 
-    if len(hospitalization_data) == 0 or (category == 'icu' and abbr in BAD_ICU_DATA_STATES):
+    if len(hospitalization_data) == 0:
         return None, None, None
 
     if (hospitalization_data[f'current_{category}'] > 0).any():


### PR DESCRIPTION
This PR addresses issues with AR and HI reporting erroneously 0 ICU hosps. (HI may not be an error), but AR certainly is.  This removes grounding to zero. 

For R_t inference, we also bound the backward shift to 3 weeks instead of 4 to prevent some spurious fits back to old data.



### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [ ] Are tests passing?
