### PR TITLE
Revert revert and gracefully handle error

### DIFF
--- a/.github/workflows/python_unit_tests.yml
+++ b/.github/workflows/python_unit_tests.yml
@@ -29,6 +29,14 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Cache Pip
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+          ${{ runner.os }}-
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ setup-dev: requirements.txt requirements_test.txt
 	nbstripout --install
 
 unittest:
-	pytest test/
+	pytest -n 2 test/
 
 lint:
 	pytest --pylint -m pylint --pylint-error-types=EF .

--- a/api/schemas/CovidActNowAreaSummary.json
+++ b/api/schemas/CovidActNowAreaSummary.json
@@ -33,6 +33,12 @@
     },
     "actuals": {
       "$ref": "#/definitions/_Actuals"
+    },
+    "population": {
+      "title": "Population",
+      "description": "Total Population in geographic area.",
+      "exclusiveMinimum": 0,
+      "type": "integer"
     }
   },
   "required": [
@@ -41,7 +47,8 @@
     "long",
     "lastUpdatedDate",
     "projections",
-    "actuals"
+    "actuals",
+    "population"
   ],
   "definitions": {
     "_ResourceUsageProjection": {
@@ -118,12 +125,17 @@
       "properties": {
         "capacity": {
           "title": "Capacity",
-          "description": "Total capacity for resource",
+          "description": "*deprecated*: Capacity for resource. In the case of ICUs, this refers to total capacity. For hospitalization this refers to free capacity for COVID patients. This value is calculated by (1 - typicalUsageRate) * totalCapacity * 2.07",
           "type": "integer"
         },
-        "currentUsage": {
-          "title": "Currentusage",
-          "description": "Currently used capacity for resource",
+        "totalCapacity": {
+          "title": "Totalcapacity",
+          "description": "Total capacity for resource.",
+          "type": "integer"
+        },
+        "currentUsageCovid": {
+          "title": "Currentusagecovid",
+          "description": "Currently used capacity for resource by COVID ",
           "type": "integer"
         },
         "typicalUsageRate": {
@@ -134,7 +146,8 @@
       },
       "required": [
         "capacity",
-        "currentUsage",
+        "totalCapacity",
+        "currentUsageCovid",
         "typicalUsageRate"
       ]
     },
@@ -144,7 +157,7 @@
       "properties": {
         "population": {
           "title": "Population",
-          "description": "Total population in geographic area",
+          "description": "Total population in geographic area [*deprecated*: refer to summary for this]",
           "exclusiveMinimum": 0,
           "type": "integer"
         },

--- a/api/schemas/CovidActNowCountiesAPI.json
+++ b/api/schemas/CovidActNowCountiesAPI.json
@@ -79,12 +79,17 @@
       "properties": {
         "capacity": {
           "title": "Capacity",
-          "description": "Total capacity for resource",
+          "description": "*deprecated*: Capacity for resource. In the case of ICUs, this refers to total capacity. For hospitalization this refers to free capacity for COVID patients. This value is calculated by (1 - typicalUsageRate) * totalCapacity * 2.07",
           "type": "integer"
         },
-        "currentUsage": {
-          "title": "Currentusage",
-          "description": "Currently used capacity for resource",
+        "totalCapacity": {
+          "title": "Totalcapacity",
+          "description": "Total capacity for resource.",
+          "type": "integer"
+        },
+        "currentUsageCovid": {
+          "title": "Currentusagecovid",
+          "description": "Currently used capacity for resource by COVID ",
           "type": "integer"
         },
         "typicalUsageRate": {
@@ -95,7 +100,8 @@
       },
       "required": [
         "capacity",
-        "currentUsage",
+        "totalCapacity",
+        "currentUsageCovid",
         "typicalUsageRate"
       ]
     },
@@ -105,7 +111,7 @@
       "properties": {
         "population": {
           "title": "Population",
-          "description": "Total population in geographic area",
+          "description": "Total population in geographic area [*deprecated*: refer to summary for this]",
           "exclusiveMinimum": 0,
           "type": "integer"
         },
@@ -188,6 +194,12 @@
         "actuals": {
           "$ref": "#/definitions/_Actuals"
         },
+        "population": {
+          "title": "Population",
+          "description": "Total Population in geographic area.",
+          "exclusiveMinimum": 0,
+          "type": "integer"
+        },
         "stateName": {
           "title": "Statename",
           "description": "The state name",
@@ -206,6 +218,7 @@
         "lastUpdatedDate",
         "projections",
         "actuals",
+        "population",
         "stateName",
         "countyName"
       ]

--- a/api/schemas/CovidActNowCountiesSummary.json
+++ b/api/schemas/CovidActNowCountiesSummary.json
@@ -79,12 +79,17 @@
       "properties": {
         "capacity": {
           "title": "Capacity",
-          "description": "Total capacity for resource",
+          "description": "*deprecated*: Capacity for resource. In the case of ICUs, this refers to total capacity. For hospitalization this refers to free capacity for COVID patients. This value is calculated by (1 - typicalUsageRate) * totalCapacity * 2.07",
           "type": "integer"
         },
-        "currentUsage": {
-          "title": "Currentusage",
-          "description": "Currently used capacity for resource",
+        "totalCapacity": {
+          "title": "Totalcapacity",
+          "description": "Total capacity for resource.",
+          "type": "integer"
+        },
+        "currentUsageCovid": {
+          "title": "Currentusagecovid",
+          "description": "Currently used capacity for resource by COVID ",
           "type": "integer"
         },
         "typicalUsageRate": {
@@ -95,7 +100,8 @@
       },
       "required": [
         "capacity",
-        "currentUsage",
+        "totalCapacity",
+        "currentUsageCovid",
         "typicalUsageRate"
       ]
     },
@@ -105,7 +111,7 @@
       "properties": {
         "population": {
           "title": "Population",
-          "description": "Total population in geographic area",
+          "description": "Total population in geographic area [*deprecated*: refer to summary for this]",
           "exclusiveMinimum": 0,
           "type": "integer"
         },
@@ -188,6 +194,12 @@
         "actuals": {
           "$ref": "#/definitions/_Actuals"
         },
+        "population": {
+          "title": "Population",
+          "description": "Total Population in geographic area.",
+          "exclusiveMinimum": 0,
+          "type": "integer"
+        },
         "stateName": {
           "title": "Statename",
           "description": "The state name",
@@ -206,6 +218,7 @@
         "lastUpdatedDate",
         "projections",
         "actuals",
+        "population",
         "stateName",
         "countyName"
       ]

--- a/api/schemas/CovidActNowCountiesTimeseries.json
+++ b/api/schemas/CovidActNowCountiesTimeseries.json
@@ -79,12 +79,17 @@
       "properties": {
         "capacity": {
           "title": "Capacity",
-          "description": "Total capacity for resource",
+          "description": "*deprecated*: Capacity for resource. In the case of ICUs, this refers to total capacity. For hospitalization this refers to free capacity for COVID patients. This value is calculated by (1 - typicalUsageRate) * totalCapacity * 2.07",
           "type": "integer"
         },
-        "currentUsage": {
-          "title": "Currentusage",
-          "description": "Currently used capacity for resource",
+        "totalCapacity": {
+          "title": "Totalcapacity",
+          "description": "Total capacity for resource.",
+          "type": "integer"
+        },
+        "currentUsageCovid": {
+          "title": "Currentusagecovid",
+          "description": "Currently used capacity for resource by COVID ",
           "type": "integer"
         },
         "typicalUsageRate": {
@@ -95,7 +100,8 @@
       },
       "required": [
         "capacity",
-        "currentUsage",
+        "totalCapacity",
+        "currentUsageCovid",
         "typicalUsageRate"
       ]
     },
@@ -105,7 +111,7 @@
       "properties": {
         "population": {
           "title": "Population",
-          "description": "Total population in geographic area",
+          "description": "Total population in geographic area [*deprecated*: refer to summary for this]",
           "exclusiveMinimum": 0,
           "type": "integer"
         },
@@ -239,6 +245,66 @@
         "cumulativeNegativeTests"
       ]
     },
+    "CANActualsTimeseriesRow": {
+      "title": "CANActualsTimeseriesRow",
+      "type": "object",
+      "properties": {
+        "population": {
+          "title": "Population",
+          "description": "Total population in geographic area [*deprecated*: refer to summary for this]",
+          "exclusiveMinimum": 0,
+          "type": "integer"
+        },
+        "intervention": {
+          "title": "Intervention",
+          "description": "Name of high-level intervention in-place",
+          "type": "string"
+        },
+        "cumulativeConfirmedCases": {
+          "title": "Cumulativeconfirmedcases",
+          "description": "Number of confirmed cases so far",
+          "type": "integer"
+        },
+        "cumulativePositiveTests": {
+          "title": "Cumulativepositivetests",
+          "description": "Number of positive test results to date",
+          "type": "integer"
+        },
+        "cumulativeNegativeTests": {
+          "title": "Cumulativenegativetests",
+          "description": "Number of negative test results to date",
+          "type": "integer"
+        },
+        "cumulativeDeaths": {
+          "title": "Cumulativedeaths",
+          "description": "Number of deaths so far",
+          "type": "integer"
+        },
+        "hospitalBeds": {
+          "$ref": "#/definitions/_ResourceUtilization"
+        },
+        "ICUBeds": {
+          "$ref": "#/definitions/_ResourceUtilization"
+        },
+        "date": {
+          "title": "Date",
+          "descrition": "Date of timeseries data point",
+          "type": "string",
+          "format": "date"
+        }
+      },
+      "required": [
+        "population",
+        "intervention",
+        "cumulativeConfirmedCases",
+        "cumulativePositiveTests",
+        "cumulativeNegativeTests",
+        "cumulativeDeaths",
+        "hospitalBeds",
+        "ICUBeds",
+        "date"
+      ]
+    },
     "CovidActNowCountyTimeseries": {
       "title": "CovidActNowCountyTimeseries",
       "type": "object",
@@ -275,6 +341,12 @@
         "actuals": {
           "$ref": "#/definitions/_Actuals"
         },
+        "population": {
+          "title": "Population",
+          "description": "Total Population in geographic area.",
+          "exclusiveMinimum": 0,
+          "type": "integer"
+        },
         "stateName": {
           "title": "Statename",
           "description": "The state name",
@@ -291,6 +363,13 @@
           "items": {
             "$ref": "#/definitions/CANPredictionTimeseriesRow"
           }
+        },
+        "actuals_timeseries": {
+          "title": "Actuals Timeseries",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CANActualsTimeseriesRow"
+          }
         }
       },
       "required": [
@@ -300,9 +379,11 @@
         "lastUpdatedDate",
         "projections",
         "actuals",
+        "population",
         "stateName",
         "countyName",
-        "timeseries"
+        "timeseries",
+        "actuals_timeseries"
       ]
     }
   }

--- a/api/schemas/CovidActNowStatesSummary.json
+++ b/api/schemas/CovidActNowStatesSummary.json
@@ -79,12 +79,17 @@
       "properties": {
         "capacity": {
           "title": "Capacity",
-          "description": "Total capacity for resource",
+          "description": "*deprecated*: Capacity for resource. In the case of ICUs, this refers to total capacity. For hospitalization this refers to free capacity for COVID patients. This value is calculated by (1 - typicalUsageRate) * totalCapacity * 2.07",
           "type": "integer"
         },
-        "currentUsage": {
-          "title": "Currentusage",
-          "description": "Currently used capacity for resource",
+        "totalCapacity": {
+          "title": "Totalcapacity",
+          "description": "Total capacity for resource.",
+          "type": "integer"
+        },
+        "currentUsageCovid": {
+          "title": "Currentusagecovid",
+          "description": "Currently used capacity for resource by COVID ",
           "type": "integer"
         },
         "typicalUsageRate": {
@@ -95,7 +100,8 @@
       },
       "required": [
         "capacity",
-        "currentUsage",
+        "totalCapacity",
+        "currentUsageCovid",
         "typicalUsageRate"
       ]
     },
@@ -105,7 +111,7 @@
       "properties": {
         "population": {
           "title": "Population",
-          "description": "Total population in geographic area",
+          "description": "Total population in geographic area [*deprecated*: refer to summary for this]",
           "exclusiveMinimum": 0,
           "type": "integer"
         },
@@ -188,6 +194,12 @@
         "actuals": {
           "$ref": "#/definitions/_Actuals"
         },
+        "population": {
+          "title": "Population",
+          "description": "Total Population in geographic area.",
+          "exclusiveMinimum": 0,
+          "type": "integer"
+        },
         "stateName": {
           "title": "Statename",
           "description": "The state name",
@@ -206,6 +218,7 @@
         "lastUpdatedDate",
         "projections",
         "actuals",
+        "population",
         "stateName"
       ]
     }

--- a/api/schemas/CovidActNowStatesTimeseries.json
+++ b/api/schemas/CovidActNowStatesTimeseries.json
@@ -79,12 +79,17 @@
       "properties": {
         "capacity": {
           "title": "Capacity",
-          "description": "Total capacity for resource",
+          "description": "*deprecated*: Capacity for resource. In the case of ICUs, this refers to total capacity. For hospitalization this refers to free capacity for COVID patients. This value is calculated by (1 - typicalUsageRate) * totalCapacity * 2.07",
           "type": "integer"
         },
-        "currentUsage": {
-          "title": "Currentusage",
-          "description": "Currently used capacity for resource",
+        "totalCapacity": {
+          "title": "Totalcapacity",
+          "description": "Total capacity for resource.",
+          "type": "integer"
+        },
+        "currentUsageCovid": {
+          "title": "Currentusagecovid",
+          "description": "Currently used capacity for resource by COVID ",
           "type": "integer"
         },
         "typicalUsageRate": {
@@ -95,7 +100,8 @@
       },
       "required": [
         "capacity",
-        "currentUsage",
+        "totalCapacity",
+        "currentUsageCovid",
         "typicalUsageRate"
       ]
     },
@@ -105,7 +111,7 @@
       "properties": {
         "population": {
           "title": "Population",
-          "description": "Total population in geographic area",
+          "description": "Total population in geographic area [*deprecated*: refer to summary for this]",
           "exclusiveMinimum": 0,
           "type": "integer"
         },
@@ -239,6 +245,66 @@
         "cumulativeNegativeTests"
       ]
     },
+    "CANActualsTimeseriesRow": {
+      "title": "CANActualsTimeseriesRow",
+      "type": "object",
+      "properties": {
+        "population": {
+          "title": "Population",
+          "description": "Total population in geographic area [*deprecated*: refer to summary for this]",
+          "exclusiveMinimum": 0,
+          "type": "integer"
+        },
+        "intervention": {
+          "title": "Intervention",
+          "description": "Name of high-level intervention in-place",
+          "type": "string"
+        },
+        "cumulativeConfirmedCases": {
+          "title": "Cumulativeconfirmedcases",
+          "description": "Number of confirmed cases so far",
+          "type": "integer"
+        },
+        "cumulativePositiveTests": {
+          "title": "Cumulativepositivetests",
+          "description": "Number of positive test results to date",
+          "type": "integer"
+        },
+        "cumulativeNegativeTests": {
+          "title": "Cumulativenegativetests",
+          "description": "Number of negative test results to date",
+          "type": "integer"
+        },
+        "cumulativeDeaths": {
+          "title": "Cumulativedeaths",
+          "description": "Number of deaths so far",
+          "type": "integer"
+        },
+        "hospitalBeds": {
+          "$ref": "#/definitions/_ResourceUtilization"
+        },
+        "ICUBeds": {
+          "$ref": "#/definitions/_ResourceUtilization"
+        },
+        "date": {
+          "title": "Date",
+          "descrition": "Date of timeseries data point",
+          "type": "string",
+          "format": "date"
+        }
+      },
+      "required": [
+        "population",
+        "intervention",
+        "cumulativeConfirmedCases",
+        "cumulativePositiveTests",
+        "cumulativeNegativeTests",
+        "cumulativeDeaths",
+        "hospitalBeds",
+        "ICUBeds",
+        "date"
+      ]
+    },
     "CovidActNowStateTimeseries": {
       "title": "CovidActNowStateTimeseries",
       "type": "object",
@@ -275,6 +341,12 @@
         "actuals": {
           "$ref": "#/definitions/_Actuals"
         },
+        "population": {
+          "title": "Population",
+          "description": "Total Population in geographic area.",
+          "exclusiveMinimum": 0,
+          "type": "integer"
+        },
         "stateName": {
           "title": "Statename",
           "description": "The state name",
@@ -291,6 +363,13 @@
           "items": {
             "$ref": "#/definitions/CANPredictionTimeseriesRow"
           }
+        },
+        "actuals_timeseries": {
+          "title": "Actuals Timeseries",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CANActualsTimeseriesRow"
+          }
         }
       },
       "required": [
@@ -300,8 +379,10 @@
         "lastUpdatedDate",
         "projections",
         "actuals",
+        "population",
         "stateName",
-        "timeseries"
+        "timeseries",
+        "actuals_timeseries"
       ]
     }
   }

--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -1,0 +1,177 @@
+from typing import Dict, Type, List, NewType
+import functools
+import pandas as pd
+from libs.datasets import dataset_utils
+from libs.datasets import dataset_base
+from libs.datasets import data_source
+from libs.datasets.timeseries import TimeseriesDataset
+from libs.datasets.latest_values_dataset import LatestValuesDataset
+from libs.datasets.sources.jhu_dataset import JHUDataset
+from libs.datasets.sources.nha_hospitalization import NevadaHospitalAssociationData
+from libs.datasets.sources.cds_dataset import CDSDataset
+from libs.datasets.sources.covid_tracking_source import CovidTrackingDataSource
+from libs.datasets.sources.covid_care_map import CovidCareMapBeds
+from libs.datasets.sources.fips_population import FIPSPopulation
+from libs.datasets import CommonFields
+from libs.datasets import dataset_filter
+from libs import us_state_abbrev
+
+FeatureDataSourceMap = NewType(
+    'FeatureDataSourceMap', Dict[str, List[Type[data_source.DataSource]]]
+)
+
+# Below are two instances of feature definitions. These define
+# how to assemble values for a specific field.  Right now, we only
+# support overlaying values. i.e. a row of
+# {CommonFields.POSITIVE_TESTS: [CDSDataset, CovidTrackingDataSource]}
+# will first get all values for positive tests in CDSDataset and then overlay any data
+# From CovidTracking.
+# This is just a start to this sort of definition - in the future, we may want more advanced
+# capabilities around what data to apply and how to apply it.
+# This structure still hides a lot of what is done under the hood and it's not
+# immediately obvious as to the transformations that are or are not applied.
+# One way of dealing with this is going from showcasing datasets dependencies
+# to showingcasing a dependency graph of transformations.
+ALL_FIELDS_FEATURE_DEFINITION: FeatureDataSourceMap = {
+    CommonFields.CASES: [JHUDataset],
+    CommonFields.DEATHS: [JHUDataset],
+    CommonFields.RECOVERED: [JHUDataset],
+    CommonFields.CUMULATIVE_ICU: [CovidTrackingDataSource],
+    CommonFields.CUMULATIVE_HOSPITALIZED: [CovidTrackingDataSource],
+    CommonFields.CURRENT_ICU: [
+        CovidTrackingDataSource, NevadaHospitalAssociationData
+    ],
+    CommonFields.CURRENT_HOSPITALIZED: [
+        CovidTrackingDataSource, NevadaHospitalAssociationData
+    ],
+    CommonFields.CURRENT_VENTILATED: [
+        CovidTrackingDataSource, NevadaHospitalAssociationData
+    ],
+    CommonFields.POPULATION: [FIPSPopulation],
+    CommonFields.STAFFED_BEDS: [CovidCareMapBeds],
+    CommonFields.LICENSED_BEDS: [CovidCareMapBeds],
+    CommonFields.ICU_BEDS: [CovidCareMapBeds, NevadaHospitalAssociationData],
+    CommonFields.ALL_BED_TYPICAL_OCCUPANCY_RATE: [CovidCareMapBeds],
+    CommonFields.ICU_TYPICAL_OCCUPANCY_RATE: [CovidCareMapBeds],
+    CommonFields.MAX_BED_COUNT: [CovidCareMapBeds],
+    CommonFields.POSITIVE_TESTS: [CDSDataset, CovidTrackingDataSource],
+    CommonFields.NEGATIVE_TESTS: [CDSDataset, CovidTrackingDataSource],
+}
+
+ALL_TIMESERIES_FEATURE_DEFINITION: FeatureDataSourceMap = {
+    CommonFields.CASES: [JHUDataset],
+    CommonFields.DEATHS: [JHUDataset],
+    CommonFields.RECOVERED: [JHUDataset],
+    CommonFields.CUMULATIVE_ICU: [CovidTrackingDataSource],
+    CommonFields.CUMULATIVE_HOSPITALIZED: [CovidTrackingDataSource],
+    CommonFields.CURRENT_ICU: [
+        CovidTrackingDataSource, NevadaHospitalAssociationData
+    ],
+    CommonFields.CURRENT_HOSPITALIZED: [
+        CovidTrackingDataSource, NevadaHospitalAssociationData
+    ],
+    CommonFields.CURRENT_VENTILATED: [
+        CovidTrackingDataSource, NevadaHospitalAssociationData
+    ],
+    CommonFields.STAFFED_BEDS: [],
+    CommonFields.LICENSED_BEDS: [],
+    CommonFields.MAX_BED_COUNT: [],
+    CommonFields.ICU_BEDS: [NevadaHospitalAssociationData],
+    CommonFields.ALL_BED_TYPICAL_OCCUPANCY_RATE: [],
+    CommonFields.ICU_TYPICAL_OCCUPANCY_RATE: [],
+    CommonFields.POSITIVE_TESTS: [CDSDataset, CovidTrackingDataSource],
+    CommonFields.NEGATIVE_TESTS: [CDSDataset, CovidTrackingDataSource],
+}
+
+US_STATES_FILTER = dataset_filter.DatasetFilter(
+    country="USA", states=list(us_state_abbrev.abbrev_us_state.keys())
+)
+
+
+@functools.lru_cache(None)
+def build_timeseries_with_all_fields() -> TimeseriesDataset:
+    return build_combined_dataset_from_sources(
+        TimeseriesDataset,
+        ALL_TIMESERIES_FEATURE_DEFINITION,
+    )
+
+
+@functools.lru_cache(None)
+def build_us_timeseries_with_all_fields() -> TimeseriesDataset:
+    return build_combined_dataset_from_sources(
+        TimeseriesDataset,
+        ALL_TIMESERIES_FEATURE_DEFINITION,
+        filters=[US_STATES_FILTER]
+    )
+
+
+@functools.lru_cache(None)
+def build_us_latest_with_all_fields() -> LatestValuesDataset:
+    return build_combined_dataset_from_sources(
+        LatestValuesDataset,
+        ALL_FIELDS_FEATURE_DEFINITION,
+        filters=[US_STATES_FILTER]
+    )
+
+
+def load_data_sources(
+    feature_definition_config
+) -> Dict[Type[data_source.DataSource], data_source.DataSource]:
+
+    data_source_classes = []
+    for classes in feature_definition_config.values():
+        data_source_classes.extend(classes)
+    loaded_data_sources = {}
+
+    for data_source_class in data_source_classes:
+        for data_source_cls in data_source_classes:
+            # only load data source once
+            if data_source_cls not in loaded_data_sources:
+                loaded_data_sources[data_source_cls] = data_source_cls.local()
+
+    return loaded_data_sources
+
+
+def build_combined_dataset_from_sources(
+    target_dataset_cls: Type[dataset_base.DatasetBase],
+    feature_definition_config: FeatureDataSourceMap,
+    filters: List[dataset_filter.DatasetFilter] = None
+):
+    """Builds a combined dataset from a feature definition.
+
+    Args:
+        target_dataset_cls: Target dataset class.
+        feature_definition_config: Dictionary mapping an output field to the
+            data sources that will be used to pull values from.
+        filters: A list of dataset filters applied to the datasets before
+            assembling features.
+    """
+    loaded_data_sources = load_data_sources(feature_definition_config)
+
+    # Convert data sources to instances of `target_data_cls`.
+    intermediate_datasets = {
+        data_source_cls: target_dataset_cls.build_from_data_source(source)
+        for data_source_cls, source in loaded_data_sources.items()
+    }
+
+    # Apply filters to datasets.
+    for key in intermediate_datasets:
+        dataset = intermediate_datasets[key]
+        for data_filter in filters or []:
+            dataset = data_filter.apply(dataset)
+        intermediate_datasets[key] = dataset
+
+    # Build feature columns from feature_definition_config.
+    data = pd.DataFrame({})
+    for field, data_source_classes in feature_definition_config.items():
+        for data_source_cls in data_source_classes:
+            dataset = intermediate_datasets[data_source_cls]
+
+            data = dataset_utils.fill_fields_with_data_source(
+                data,
+                dataset.data,
+                target_dataset_cls.INDEX_FIELDS,
+                [field]
+            )
+
+    return target_dataset_cls(data)

--- a/libs/datasets/common_fields.py
+++ b/libs/datasets/common_fields.py
@@ -1,14 +1,57 @@
 
-
 class CommonFields(object):
     """Common field names shared across different sources of data"""
 
-    # Column for FIPS code. Right now a column containing fips data may be
-    # county fips (a length 5 string) or state fips (a length 2 string).
     FIPS = "fips"
 
     # 2 letter state abbreviation, i.e. MA
     STATE = "state"
 
+    COUNTRY = "country"
+
+    COUNTY = "county"
+
+    AGGREGATE_LEVEL = "aggregate_level"
+
+    DATE = "date"
+
     # Full state name, i.e. Massachusetts
     STATE_FULL_NAME = "state_full_name"
+
+    CASES = "cases"
+    DEATHS = "deaths"
+    RECOVERED = "recovered"
+    CUMULATIVE_HOSPITALIZED = "cumulative_hospitalized"
+    CUMULATIVE_ICU = "cumulative_icu"
+
+    POSITIVE_TESTS = "positive_tests"
+    NEGATIVE_TESTS = "negative_tests"
+
+    # Current values
+    CURRENT_ICU = "current_icu"
+    CURRENT_HOSPITALIZED = "current_hospitalized"
+    CURRENT_VENTILATED = "current_ventilated"
+
+    POPULATION = "population"
+
+    STAFFED_BEDS = "staffed_beds"
+    LICENSED_BEDS = "licensed_beds"
+    ICU_BEDS = "icu_beds"
+    ALL_BED_TYPICAL_OCCUPANCY_RATE = "all_beds_occupancy_rate"
+    ICU_TYPICAL_OCCUPANCY_RATE = "icu_occupancy_rate"
+    MAX_BED_COUNT = "max_bed_count"
+
+
+class CommonIndexFields(object):
+    # Column for FIPS code. Right now a column containing fips data may be
+    # county fips (a length 5 string) or state fips (a length 2 string).
+    FIPS = CommonFields.FIPS
+
+    # 2 letter state abbreviation, i.e. MA
+    STATE = CommonFields.STATE
+
+    COUNTRY = CommonFields.COUNTRY
+
+    AGGREGATE_LEVEL = CommonFields.AGGREGATE_LEVEL
+
+    DATE = CommonFields.DATE

--- a/libs/datasets/data_source.py
+++ b/libs/datasets/data_source.py
@@ -1,8 +1,9 @@
 import pandas as pd
-from libs.datasets.beds import BedsDataset
 from libs.datasets.timeseries import TimeseriesDataset
-from libs.datasets.population import PopulationDataset
+from libs.datasets.latest_values_dataset import LatestValuesDataset
+from libs.datasets.dataset_utils import AggregationLevel
 from functools import lru_cache
+from libs.datasets.common_fields import CommonFields
 
 
 class DataSource(object):
@@ -12,18 +13,9 @@ class DataSource(object):
     class Fields(object):
         pass
 
-    # Subclasses must define mapping from Timeseries fields.
-    # eg: {TimseriesDataset.Fields.DATE: Fields.Date}
-    # Optional if dataset does not support timeseries data.
-    TIMESERIES_FIELD_MAP = None
+    INDEX_FIELD_MAP = None
 
-    # Map of field names from BedsDataset.Fields to dataset source fields.
-    # Optional if dataset does not support converting to beds data.
-    BEDS_FIELD_MAP = None
-
-    # Map of field names from PopulationDataset.Fields to dataset source fields.
-    # Optional if dataset does not support population data.
-    POPULATION_FIELD_MAP = None
+    COMMON_FIELD_MAP = None
 
     # Name of dataset source
     SOURCE_NAME = None
@@ -34,29 +26,44 @@ class DataSource(object):
     def __init__(self, data: pd.DataFrame):
         self.data = data
 
+    def all_fields_map(self):
+        return {**self.COMMON_FIELD_MAP, **self.INDEX_FIELD_MAP}
+
+    @property
+    def state_data(self) -> pd.DataFrame:
+        """Returns a new BedsDataset containing only state data."""
+        is_state = (
+            self.data[CommonFields.AGGREGATE_LEVEL] == AggregationLevel.STATE.value
+        )
+        return self.data[is_state]
+
+    @property
+    def county_data(self) -> pd.DataFrame:
+        """Returns a new BedsDataset containing only county data."""
+        is_county = (
+            self.data[CommonFields.AGGREGATE_LEVEL] == AggregationLevel.COUNTY.value
+        )
+        return self.data[is_county]
+
     @classmethod
-    def local(cls) -> "cls":
+    def local(cls) -> "DataSource":
         """Builds data from local covid-public-data github repo.
 
         Returns: Instantiated class with data loaded.
         """
         raise NotImplementedError("Subclass must implement")
 
-    @lru_cache(maxsize=1)
-    def beds(self) -> "BedsDataset":
+    @lru_cache(None)
+    def beds(self) -> LatestValuesDataset:
         """Builds generic beds dataset"""
-        return BedsDataset.from_source(self)
+        return LatestValuesDataset.build_from_data_source(self)
 
-    @lru_cache(maxsize=1)
-    def population(self) -> "PopulationDataset":
+    @lru_cache(None)
+    def population(self) -> LatestValuesDataset:
         """Builds generic beds dataset"""
-        return PopulationDataset.from_source(self)
+        return LatestValuesDataset.build_from_data_source(self)
 
-    @lru_cache(maxsize=1)
-    def timeseries(self, fill_na: bool = True) -> "TimeseriesDataset":
-        """Builds generic timeseries dataset.
-
-        Args:
-            fill_na: If True, fills all NA values with 0.
-        """
-        return TimeseriesDataset.from_source(self, fill_na=fill_na)
+    @lru_cache(None)
+    def timeseries(self) -> TimeseriesDataset:
+        """Builds generic beds dataset"""
+        return TimeseriesDataset.build_from_data_source(self)

--- a/libs/datasets/dataset_base.py
+++ b/libs/datasets/dataset_base.py
@@ -1,0 +1,23 @@
+from typing import List
+import pandas as pd
+from libs.datasets.dataset_utils import AggregationLevel
+
+
+class DatasetBase(object):
+
+    # Class of Fields in this dataset
+    Fields = None
+
+    INDEX_FIELDS: List[str] = []
+
+    def __init__(self, data: pd.DataFrame):
+        self.data = data
+
+    def get_subset(self, aggregation_level: AggregationLevel, **filters) -> "DatasetBase":
+        """Returns a subset of the existing dataset."""
+        raise NotImplementedError("Subsclass must implement")
+
+    @classmethod
+    def build_from_data_source(cls, source) -> "DatasetBase":
+        """Builds an instance of the dataset from a data source."""
+        raise NotImplementedError("Subsclass must implement")

--- a/libs/datasets/dataset_filter.py
+++ b/libs/datasets/dataset_filter.py
@@ -1,0 +1,21 @@
+from typing import Union
+from libs.datasets.dataset_utils import AggregationLevel
+from libs.datasets.timeseries import TimeseriesDataset
+from libs.datasets.latest_values_dataset import LatestValuesDataset
+
+
+class DatasetFilter(object):
+    """Defines a filter to apply to a dataset."""
+    def __init__(self, aggregation_level: AggregationLevel = None, **filters):
+        """
+        Args:
+            aggregation_level: AggregationLevel of dataset
+            filters: Filters to apply to dataset.  Must match arguments of the respective
+                `get_subset` function.
+        """
+        self.aggregation_level = aggregation_level
+        self.filters = filters
+
+    def apply(self, dataset: Union[TimeseriesDataset, LatestValuesDataset]):
+        """Applies filter to dataset by returning subset that matches filter arguments."""
+        return dataset.get_subset(self.aggregation_level, **self.filters)

--- a/libs/datasets/dataset_utils.py
+++ b/libs/datasets/dataset_utils.py
@@ -1,3 +1,4 @@
+from typing import List
 import os
 import enum
 import logging
@@ -246,12 +247,12 @@ def add_fips_using_county(data, fips_data) -> pd.Series:
     if len(data) != original_rows:
         raise Exception("Non-unique join, check for duplicate fips data.")
 
-    non_matching = data[data.county.notnull() & data.fips.isnull()]
+    non_matching = data.loc[data.county.notnull() & data.fips.isnull(), :]
 
     # Not all datasources have country.  If the dataset doesn't have country,
     # assuming that data is from the us.
     if "country" in non_matching.columns:
-        non_matching = non_matching[data.country == "USA"]
+        non_matching = non_matching.loc[data.country == "USA", :]
 
     if len(non_matching):
         unique_counties = sorted(non_matching.county.unique())
@@ -279,3 +280,97 @@ def summarize(data, aggregate_level, groupby):
     print(key_fmt.format("Missing Fips Code:", missing_fips))
     print(key_fmt.format("Num non unique rows:", num_non_unique))
     print(index_size[index_size > 1])
+
+
+def fill_fields_with_data_source(
+    existing_df: pd.DataFrame,
+    data_source: pd.DataFrame,
+    index_fields: List[str],
+    columns_to_fill: List[str],
+) -> pd.DataFrame:
+    """Pull columns from an existing data source into an existing data frame.
+
+    Example:
+
+        existing_df:
+        ----------------
+        | date | cases |
+        | 4/2  | 1     |
+        | 4/3  | 2     |
+        | 4/4  | 3     |
+        ----------------
+
+        data_source:
+        ----------------------
+        | date | current_icu |
+        | 4/3  | 4           |
+        | 4/5  | 5           |
+        ----------------------
+
+        index_fields: ['date']
+
+        columns_to_fill: ['current_icu']
+
+        output:
+        ------------------------------
+        | date | cases | current_icu |
+        | 4/2  | 1     | Na          |
+        | 4/3  | 2     | 4           |
+        | 4/4  | 3     | Na          |
+        | 4/5  | Na    | 5           |
+        ------------------------------
+
+    Args:
+        existing_df: Existing data frame
+        data_source: Data used to fill existing df columns
+        index_fields: List of columns to use as common index.
+        columns_to_fill: List of columns to add into existing_df from data_source
+
+    Returns: Updated dataframe with requested columns filled from data_source data.
+    """
+    new_data = data_source.set_index(index_fields)
+
+    # If no data exists, return all rows from new data with just the requested columns.
+    if not len(existing_df):
+        for column in columns_to_fill:
+            if column not in new_data.columns:
+                new_data[column] = None
+        return new_data[columns_to_fill].reset_index()
+    existing_df = existing_df.set_index(index_fields)
+
+    # Sort indices so that we have chunks of equal length in the
+    # correct order so that we can splice in values.
+    existing_df = existing_df.sort_index()
+    new_data = new_data.sort_index()
+
+    # Build series that point to rows that match in each data frame.
+    existing_df_in_new_data = existing_df.index.isin(new_data.index)
+    new_data_in_existing_df = new_data.index.isin(existing_df.index)
+
+    if not sum(existing_df_in_new_data) == sum(new_data_in_existing_df):
+        print(new_data.loc[new_data_in_existing_df, columns_to_fill])
+        existing_in_new = sum(existing_df_in_new_data)
+        new_in_existing = sum(new_data_in_existing_df)
+        raise ValueError(f"Number of rows should be the for data to replace: {existing_in_new} -> {new_in_existing}: {columns_to_fill}")
+
+    # If a column doesn't exist in the existing data, add it (throws an error)
+    # otherwise.
+    for column in columns_to_fill:
+        if column not in existing_df.columns:
+            existing_df[column] = None
+
+    # Fill in values for rows that match in both data frames.
+    existing_df.loc[existing_df_in_new_data, columns_to_fill] = new_data.loc[
+        new_data_in_existing_df, columns_to_fill
+    ]
+    # Get rows that do not exist in the existing data frame
+    missing_new_data = new_data[~new_data_in_existing_df]
+
+    data = pd.concat(
+        [
+            existing_df.reset_index(),
+            missing_new_data[columns_to_fill].reset_index(),
+        ]
+    )
+
+    return data

--- a/libs/datasets/latest_values_dataset.py
+++ b/libs/datasets/latest_values_dataset.py
@@ -1,0 +1,204 @@
+from typing import Type, List
+
+from libs import us_state_abbrev
+import pandas as pd
+from libs.datasets.dataset_utils import AggregationLevel
+from libs.datasets import dataset_utils
+from libs.datasets import custom_aggregations
+from libs.datasets import dataset_base
+from libs.datasets.common_fields import CommonIndexFields
+from libs.datasets.common_fields import CommonFields
+
+
+class LatestValuesDataset(dataset_base.DatasetBase):
+
+    INDEX_FIELDS = [
+        CommonIndexFields.AGGREGATE_LEVEL,
+        CommonIndexFields.COUNTRY,
+        CommonIndexFields.STATE,
+        CommonIndexFields.FIPS,
+    ]
+    STATE_GROUP_KEY = [
+        CommonIndexFields.AGGREGATE_LEVEL,
+        CommonIndexFields.COUNTRY,
+        CommonIndexFields.STATE,
+    ]
+
+    class Fields(CommonFields):
+        COUNTRY = CommonIndexFields.COUNTRY
+        STATE = CommonIndexFields.STATE
+        AGGREGATE_LEVEL = CommonIndexFields.AGGREGATE_LEVEL
+        FIPS = CommonIndexFields.FIPS
+
+    def __init__(self, data):
+        self.data = data
+
+    @classmethod
+    def from_source(cls, source: "DataSource", fill_missing_state=True):
+        """Loads data from a specific datasource.
+
+        Remaps columns from source dataset, fills in missing data
+        by computing aggregates, and adds standardized county names from fips.
+
+        Args:
+            source: Data source.
+            fill_missing_state: If True, fills in missing state level data by
+                aggregating county level for a given state.
+        """
+        if not source.COMMON_FIELD_MAP and not source.INDEX_FIELD_MAP:
+            raise ValueError("Source must have metadata field map.")
+
+        data = source.data
+        fields = source.all_fields_map().items()
+        to_common_fields = {value: key for key, value in fields}
+        final_columns = to_common_fields.values()
+        data = data.rename(columns=to_common_fields)[final_columns]
+
+        data = cls._aggregate_new_york_data(data)
+        if fill_missing_state:
+            non_matching = dataset_utils.aggregate_and_get_nonmatching(
+                data,
+                cls.STATE_GROUP_KEY,
+                AggregationLevel.COUNTY,
+                AggregationLevel.STATE,
+            ).reset_index()
+
+            data = pd.concat([data, non_matching])
+
+        fips_data = dataset_utils.build_fips_data_frame()
+        data = dataset_utils.add_county_using_fips(data, fips_data)
+
+        # Add state fips
+        is_state = data[cls.Fields.AGGREGATE_LEVEL] == AggregationLevel.STATE.value
+        state_fips = data.loc[is_state, cls.Fields.STATE].map(us_state_abbrev.ABBREV_US_FIPS)
+        data.loc[is_state, cls.Fields.FIPS] = state_fips
+
+        return cls(data)
+
+    @classmethod
+    def build_from_data_source(cls, source):
+        from libs.datasets.timeseries import TimeseriesDataset
+
+        if set(source.INDEX_FIELD_MAP.keys()) == set(TimeseriesDataset.INDEX_FIELDS):
+            timeseries = TimeseriesDataset.build_from_data_source(source)
+            return timeseries.to_latest_values_dataset()
+
+        if set(source.INDEX_FIELD_MAP.keys()) != set(cls.INDEX_FIELDS):
+            raise ValueError("Index fields must match")
+
+        return cls.from_source(source)
+
+    def get_subset(
+        self,
+        aggregation_level,
+        country=None,
+        state=None,
+        county=None,
+        fips=None,
+        states=None,
+    ) -> "LatestValuesDataset":
+        data = self.data
+
+        if aggregation_level:
+            data = data[data.aggregate_level == aggregation_level.value]
+        if country:
+            data = data[data.country == country]
+        if state:
+            data = data[data.state == state]
+        if county:
+            data = data[data.county == county]
+        if fips:
+            data = data[data.fips == fips]
+        if states:
+            data = data[data[self.Fields.STATE].isin(states)]
+
+        return self.__class__(data)
+
+    @classmethod
+    def _aggregate_new_york_data(cls, data):
+        # When grouping nyc data, we don't want to count the generated field
+        # as a value to sum.
+        nyc_data = data[data[cls.Fields.FIPS].isin(custom_aggregations.ALL_NYC_FIPS)]
+        if not len(nyc_data):
+            return data
+        group = cls.STATE_GROUP_KEY
+        weighted_all_bed_occupancy = None
+
+        if cls.Fields.ALL_BED_TYPICAL_OCCUPANCY_RATE in data.columns:
+            licensed_beds = nyc_data[cls.Fields.LICENSED_BEDS]
+            occupancy_rates = nyc_data[cls.Fields.ALL_BED_TYPICAL_OCCUPANCY_RATE]
+            weighted_all_bed_occupancy = (
+                (licensed_beds * occupancy_rates).sum() / licensed_beds.sum()
+            )
+        weighted_icu_occupancy = None
+        if cls.Fields.ICU_TYPICAL_OCCUPANCY_RATE in data.columns:
+            icu_beds = nyc_data[cls.Fields.ICU_BEDS]
+            occupancy_rates = nyc_data[cls.Fields.ICU_TYPICAL_OCCUPANCY_RATE]
+            weighted_icu_occupancy = (
+                (icu_beds * occupancy_rates).sum() / icu_beds.sum()
+            )
+
+        data = custom_aggregations.update_with_combined_new_york_counties(
+            data, group, are_boroughs_zero=False
+        )
+
+        nyc_fips = custom_aggregations.NEW_YORK_COUNTY_FIPS
+        if weighted_all_bed_occupancy:
+            data.loc[data[cls.Fields.FIPS] == nyc_fips, cls.Fields.ALL_BED_TYPICAL_OCCUPANCY_RATE] = (
+                weighted_all_bed_occupancy
+            )
+
+        if weighted_icu_occupancy:
+            data.loc[data[cls.Fields.FIPS] == nyc_fips, cls.Fields.ICU_TYPICAL_OCCUPANCY_RATE] = (
+                weighted_icu_occupancy
+            )
+
+        return data
+
+    @property
+    def state_data(self) -> pd.DataFrame:
+        """Returns a new BedsDataset containing only state data."""
+
+        is_state = (
+            self.data[self.Fields.AGGREGATE_LEVEL] == AggregationLevel.STATE.value
+        )
+        return self.data[is_state]
+
+    @property
+    def county_data(self) -> pd.DataFrame:
+        """Returns a new BedsDataset containing only county data."""
+        is_county = (
+            self.data[self.Fields.AGGREGATE_LEVEL] == AggregationLevel.COUNTY.value
+        )
+        return self.data[is_county]
+
+    def get_record_for_state(self, state) -> dict:
+        """Gets all data for a given state.
+
+        Args:
+            state: State abbreviation.
+
+        Returns: Dictionary with all data for a given state.
+        """
+        # we map NaNs to none here so that they can be generated via the API easier
+        data = self.state_data.where(pd.notnull(self.state_data), None)
+        row = data[data[self.Fields.STATE] == state]
+        if not len(row):
+            return {}
+
+        return row.iloc[0].to_dict()
+
+    def get_record_for_fips(self, fips) -> dict:
+        """Gets all data for a given fips code.
+
+        Args:
+            fips: fips code.
+
+        Returns: Dictionary with all data for a given fips code.
+        """
+        # we map NaNs to none here so that they can be generated via the API easier
+        row = self.data[self.data[self.Fields.FIPS] == fips].where(pd.notnull(self.data), None)
+        if not len(row):
+            return {}
+
+        return row.iloc[0].to_dict()

--- a/libs/datasets/sources/cds_dataset.py
+++ b/libs/datasets/sources/cds_dataset.py
@@ -1,12 +1,11 @@
-from typing import List
 import logging
 import numpy
 import pandas as pd
-from libs.datasets.timeseries import TimeseriesDataset
-from libs.datasets.population import PopulationDataset
 from libs.datasets import data_source
 from libs.datasets import dataset_utils
 from libs.us_state_abbrev import US_STATE_ABBREV
+from libs.datasets.common_fields import CommonIndexFields
+from libs.datasets.common_fields import CommonFields
 
 _logger = logging.getLogger(__name__)
 
@@ -45,22 +44,21 @@ class CDSDataset(data_source.DataSource):
         DATE = "date"
         AGGREGATE_LEVEL = "aggregate_level"
         FIPS = "fips"
+        NEGATIVE_TESTS = "negative_tests"
 
-    TIMESERIES_FIELD_MAP = {
-        TimeseriesDataset.Fields.DATE: Fields.DATE,
-        TimeseriesDataset.Fields.COUNTRY: Fields.COUNTRY,
-        TimeseriesDataset.Fields.STATE: Fields.STATE,
-        TimeseriesDataset.Fields.FIPS: Fields.FIPS,
-        TimeseriesDataset.Fields.CASES: Fields.CASES,
-        TimeseriesDataset.Fields.AGGREGATE_LEVEL: Fields.AGGREGATE_LEVEL,
+    INDEX_FIELD_MAP = {
+        CommonIndexFields.DATE: Fields.DATE,
+        CommonIndexFields.COUNTRY: Fields.COUNTRY,
+        CommonIndexFields.STATE: Fields.STATE,
+        CommonIndexFields.FIPS: Fields.FIPS,
+        CommonIndexFields.AGGREGATE_LEVEL: Fields.AGGREGATE_LEVEL,
     }
 
-    POPULATION_FIELD_MAP = {
-        PopulationDataset.Fields.COUNTRY: Fields.COUNTRY,
-        PopulationDataset.Fields.STATE: Fields.STATE,
-        PopulationDataset.Fields.FIPS: Fields.FIPS,
-        PopulationDataset.Fields.POPULATION: Fields.POPULATION,
-        PopulationDataset.Fields.AGGREGATE_LEVEL: Fields.AGGREGATE_LEVEL,
+    COMMON_FIELD_MAP = {
+        CommonFields.CASES: Fields.CASES,
+        CommonFields.POSITIVE_TESTS: Fields.CASES,
+        CommonFields.NEGATIVE_TESTS: Fields.NEGATIVE_TESTS,
+        CommonFields.POPULATION: Fields.POPULATION,
     }
 
     TEST_FIELDS = [
@@ -79,7 +77,7 @@ class CDSDataset(data_source.DataSource):
         super().__init__(data)
 
     @classmethod
-    def local(cls) -> "CDSTimeseriesData":
+    def local(cls) -> "CDSDataset":
         data_root = dataset_utils.LOCAL_PUBLIC_DATA_PATH
         return cls(data_root / cls.DATA_PATH)
 
@@ -130,6 +128,9 @@ class CDSDataset(data_source.DataSource):
 
         fips_data = dataset_utils.build_fips_data_frame()
         data = dataset_utils.add_fips_using_county(data, fips_data)
+
+        # ADD Negative tests
+        data[cls.Fields.NEGATIVE_TESTS] = data[cls.Fields.TESTED] - data[cls.Fields.CASES]
 
         # put the state column back
         data['state'] = data['state_tmp']

--- a/libs/datasets/sources/covid_care_map.py
+++ b/libs/datasets/sources/covid_care_map.py
@@ -1,10 +1,11 @@
 import logging
 from libs import enums
 import pandas as pd
-from libs.datasets.beds import BedsDataset
-from libs.datasets.dataset_utils import AggregationLevel
 from libs.datasets import dataset_utils
 from libs.datasets import data_source
+from libs.datasets.common_fields import CommonIndexFields
+from libs.datasets.common_fields import CommonFields
+from libs.datasets.dataset_utils import AggregationLevel
 
 _logger = logging.getLogger(__name__)
 
@@ -28,17 +29,22 @@ class CovidCareMapBeds(data_source.DataSource):
         # Added in standardize data.
         AGGREGATE_LEVEL = "aggregate_level"
         COUNTRY = "country"
+        MAX_BED_COUNT = "max_bed_count"
 
-    BEDS_FIELD_MAP = {
-        BedsDataset.Fields.COUNTRY: Fields.COUNTRY,
-        BedsDataset.Fields.STATE: Fields.STATE,
-        BedsDataset.Fields.FIPS: Fields.FIPS,
-        BedsDataset.Fields.STAFFED_BEDS: Fields.STAFFED_ALL_BEDS,
-        BedsDataset.Fields.LICENSED_BEDS: Fields.LICENSED_ALL_BEDS,
-        BedsDataset.Fields.ICU_BEDS: Fields.STAFFED_ICU_BEDS,
-        BedsDataset.Fields.AGGREGATE_LEVEL: Fields.AGGREGATE_LEVEL,
-        BedsDataset.Fields.ALL_BED_TYPICAL_OCCUPANCY_RATE: Fields.ALL_BED_TYPICAL_OCCUPANCY_RATE,
-        BedsDataset.Fields.ICU_TYPICAL_OCCUPANCY_RATE: Fields.ICU_TYPICAL_OCCUPANCY_RATE,
+    INDEX_FIELD_MAP = {
+        CommonIndexFields.COUNTRY: Fields.COUNTRY,
+        CommonIndexFields.STATE: Fields.STATE,
+        CommonIndexFields.FIPS: Fields.FIPS,
+        CommonIndexFields.AGGREGATE_LEVEL: Fields.AGGREGATE_LEVEL,
+    }
+
+    COMMON_FIELD_MAP = {
+        CommonFields.STAFFED_BEDS: Fields.STAFFED_ALL_BEDS,
+        CommonFields.LICENSED_BEDS: Fields.LICENSED_ALL_BEDS,
+        CommonFields.ICU_BEDS: Fields.STAFFED_ICU_BEDS,
+        CommonFields.ALL_BED_TYPICAL_OCCUPANCY_RATE: Fields.ALL_BED_TYPICAL_OCCUPANCY_RATE,
+        CommonFields.ICU_TYPICAL_OCCUPANCY_RATE: Fields.ICU_TYPICAL_OCCUPANCY_RATE,
+        CommonFields.MAX_BED_COUNT: Fields.MAX_BED_COUNT,
     }
 
     def __init__(self, data):
@@ -63,6 +69,8 @@ class CovidCareMapBeds(data_source.DataSource):
             # (icu_beds - (total_icu_beds_used - covid_icu_beds_used)) / icu_beds
             # (844 - (583 - 158)) / 844 == 0.4964
             #data.loc[data[cls.Fields.STATE] == 'NV', [cls.Fields.ICU_TYPICAL_OCCUPANCY_RATE]] = 0.4964
+
+        data[cls.Fields.MAX_BED_COUNT] = data[[cls.Fields.STAFFED_ALL_BEDS, cls.Fields.LICENSED_ALL_BEDS]].max(axis=1)
 
         # The virgin islands do not currently have associated fips codes.
         # if VI is supported in the future, this should be removed.

--- a/libs/datasets/sources/covid_tracking_source.py
+++ b/libs/datasets/sources/covid_tracking_source.py
@@ -1,9 +1,10 @@
 import logging
 import pandas as pd
-from libs.datasets.timeseries import TimeseriesDataset
 from libs.datasets import data_source
 from libs.datasets import dataset_utils
 from libs.datasets.dataset_utils import AggregationLevel
+from libs.datasets.common_fields import CommonIndexFields
+from libs.datasets.common_fields import CommonFields
 
 _logger = logging.getLogger(__name__)
 
@@ -56,17 +57,23 @@ class CovidTrackingDataSource(data_source.DataSource):
         AGGREGATE_LEVEL = "aggregate_level"
         FIPS = "fips"
 
-    TIMESERIES_FIELD_MAP = {
-        TimeseriesDataset.Fields.DATE: Fields.DATE,
-        TimeseriesDataset.Fields.COUNTRY: Fields.COUNTRY,
-        TimeseriesDataset.Fields.STATE: Fields.STATE,
-        TimeseriesDataset.Fields.FIPS: Fields.FIPS,
-        TimeseriesDataset.Fields.DEATHS: Fields.DEATHS,
-        TimeseriesDataset.Fields.CURRENT_HOSPITALIZED: Fields.CURRENT_HOSPITALIZED,
-        TimeseriesDataset.Fields.CURRENT_ICU: Fields.IN_ICU_CURRENTLY,
-        TimeseriesDataset.Fields.CUMULATIVE_HOSPITALIZED: Fields.TOTAL_HOSPITALIZED,
-        TimeseriesDataset.Fields.CUMULATIVE_ICU: Fields.TOTAL_IN_ICU,
-        TimeseriesDataset.Fields.AGGREGATE_LEVEL: Fields.AGGREGATE_LEVEL,
+    INDEX_FIELD_MAP = {
+        CommonIndexFields.DATE: Fields.DATE,
+        CommonIndexFields.COUNTRY: Fields.COUNTRY,
+        CommonIndexFields.STATE: Fields.STATE,
+        CommonIndexFields.FIPS: Fields.FIPS,
+        CommonIndexFields.AGGREGATE_LEVEL: Fields.AGGREGATE_LEVEL,
+    }
+
+    COMMON_FIELD_MAP = {
+        CommonFields.DEATHS: Fields.DEATHS,
+        CommonFields.CURRENT_HOSPITALIZED: Fields.CURRENT_HOSPITALIZED,
+        CommonFields.CURRENT_ICU: Fields.IN_ICU_CURRENTLY,
+        CommonFields.CURRENT_VENTILATED: Fields.ON_VENTILATOR_CURRENTLY,
+        CommonFields.CUMULATIVE_HOSPITALIZED: Fields.TOTAL_HOSPITALIZED,
+        CommonFields.CUMULATIVE_ICU: Fields.TOTAL_IN_ICU,
+        CommonFields.POSITIVE_TESTS: Fields.POSITIVE_TESTS,
+        CommonFields.NEGATIVE_TESTS: Fields.NEGATIVE_TESTS
     }
 
     TESTS_ONLY_FIELDS = [
@@ -86,7 +93,11 @@ class CovidTrackingDataSource(data_source.DataSource):
     ]
 
     def __init__(self, input_path):
-        data = pd.read_csv(input_path, parse_dates=[self.Fields.DATE_CHECKED])
+        data = pd.read_csv(
+            input_path,
+            parse_dates=[self.Fields.DATE_CHECKED],
+            dtype={self.Fields.FIPS: str}
+        )
         data = self.standardize_data(data)
         super().__init__(data)
 
@@ -113,13 +124,6 @@ class CovidTrackingDataSource(data_source.DataSource):
 
         data = data.astype(dtypes)
 
-        # Covid Tracking source has the state level fips, however none of the other
-        # data sources have state level fips, and the generic code may implicitly assume
-        # it doesn't.  I would like to add a state level fips (maybe for example a state fips code
-        # of 45 being 45000), but it's not there, so in the meantime we're setting fips to null so
-        # as not to confuse downstream data.
-        data[cls.Fields.FIPS] = None
-
         # must stay true: positive + negative  ==  total
         assert (
             data[cls.Fields.POSITIVE_TESTS]
@@ -133,62 +137,6 @@ class CovidTrackingDataSource(data_source.DataSource):
             == data[cls.Fields.TOTAL_TEST_RESULTS_INCREASE]
         ).all()
 
-        nevada_data = cls._load_nevada_override_data()
-        data = cls._add_nevada_data(data, nevada_data)
-
         # TODO implement assertion to check for shift, as sliced by geo
         # df['totalTestResults'] - df['totalTestResultsIncrease']  ==  df['totalTestResults'].shift(-1)
         return data
-
-    @classmethod
-    def _load_nevada_override_data(cls):
-        from libs.datasets import NevadaHospitalAssociationData
-
-        data = NevadaHospitalAssociationData.local().timeseries(fill_na=False).data
-        columns_to_include = []
-        for timeseries_column, ct_column in cls.TIMESERIES_FIELD_MAP.items():
-            if timeseries_column in data.columns:
-                columns_to_include.append(ct_column)
-
-        data = data.rename(cls.TIMESERIES_FIELD_MAP, axis=1)
-        return data[columns_to_include]
-
-    @classmethod
-    def _add_nevada_data(cls, data, nevada_data):
-        """Adds nevada data, replacing any state or county level values that match index.
-
-        Args:
-            data: Covid tracking data
-            nevada_data: Nevada specific override data.
-
-        Returns: Updated dataframe with
-        """
-        # NOTE(chris): This logic will most likely work as we have more hospitalization data
-        # numbers that will override covid tracking data.
-        matching_index_group = [
-            cls.Fields.DATE,
-            cls.Fields.AGGREGATE_LEVEL,
-            cls.Fields.COUNTRY,
-            cls.Fields.STATE,
-            cls.Fields.FIPS,
-        ]
-        data = data.set_index(matching_index_group)
-        nevada_data = nevada_data.set_index(matching_index_group)
-        # Sort indices so that we have chunks of equal length in the
-        # correct order so that we can splice in values from nevada data.
-        data = data.sort_index()
-        nevada_data = nevada_data.sort_index()
-        data_in_nevada = data.index.isin(nevada_data.index)
-        nevada_in_data = nevada_data.index.isin(data.index)
-
-        if not sum(data_in_nevada) == sum(nevada_in_data):
-            raise ValueError("Number of rows should be the for data to replace")
-
-        # Fill in values with data that matches index in nevada data.
-        data.loc[data_in_nevada, nevada_data.columns] = nevada_data.loc[nevada_in_data, :]
-
-        # Combine updated data with rows not present in covid tracking data.
-        return pd.concat([
-            data,
-            nevada_data[~nevada_in_data]
-        ]).reset_index()

--- a/libs/datasets/sources/fips_population.py
+++ b/libs/datasets/sources/fips_population.py
@@ -1,12 +1,12 @@
 import pathlib
-import numpy
 import pandas as pd
-from libs.datasets.population import PopulationDataset
 from libs.datasets import dataset_utils
 from libs.datasets import data_source
 from libs.us_state_abbrev import US_STATE_ABBREV, ABBREV_US_FIPS
 from libs import enums
 from libs.datasets.dataset_utils import AggregationLevel
+from libs.datasets.common_fields import CommonIndexFields
+from libs.datasets.common_fields import CommonFields
 
 CURRENT_FOLDER = pathlib.Path(__file__).parent
 
@@ -32,12 +32,15 @@ class FIPSPopulation(data_source.DataSource):
         AGGREGATE_LEVEL = "aggregate_level"
         COUNTRY = "country"
 
-    POPULATION_FIELD_MAP = {
-        PopulationDataset.Fields.COUNTRY: Fields.COUNTRY,
-        PopulationDataset.Fields.STATE: Fields.STATE,
-        PopulationDataset.Fields.FIPS: Fields.FIPS,
-        PopulationDataset.Fields.POPULATION: Fields.POPULATION,
-        PopulationDataset.Fields.AGGREGATE_LEVEL: Fields.AGGREGATE_LEVEL,
+    INDEX_FIELD_MAP = {
+        CommonIndexFields.COUNTRY: Fields.COUNTRY,
+        CommonIndexFields.STATE: Fields.STATE,
+        CommonIndexFields.FIPS: Fields.FIPS,
+        CommonIndexFields.AGGREGATE_LEVEL: Fields.AGGREGATE_LEVEL,
+    }
+
+    COMMON_FIELD_MAP = {
+        CommonFields.POPULATION: Fields.POPULATION,
     }
 
     def __init__(self, path):

--- a/libs/datasets/sources/jhu_dataset.py
+++ b/libs/datasets/sources/jhu_dataset.py
@@ -2,9 +2,10 @@ import logging
 import numpy
 import pandas as pd
 import pathlib
-from libs.datasets.timeseries import TimeseriesDataset
 from libs.datasets import dataset_utils
 from libs.datasets import data_source
+from libs.datasets.common_fields import CommonIndexFields
+from libs.datasets.common_fields import CommonFields
 from libs.datasets.dataset_utils import AggregationLevel
 from libs import enums
 _logger = logging.getLogger(__name__)
@@ -46,16 +47,17 @@ class JHUDataset(data_source.DataSource):
         "Long_": Fields.LONGITUDE,
         "Last Update": Fields.LAST_UPDATE,
     }
-
-    TIMESERIES_FIELD_MAP = {
-        TimeseriesDataset.Fields.DATE: Fields.DATE,
-        TimeseriesDataset.Fields.COUNTRY: Fields.COUNTRY,
-        TimeseriesDataset.Fields.STATE: Fields.STATE,
-        TimeseriesDataset.Fields.FIPS: Fields.FIPS,
-        TimeseriesDataset.Fields.CASES: Fields.CONFIRMED,
-        TimeseriesDataset.Fields.DEATHS: Fields.DEATHS,
-        TimeseriesDataset.Fields.RECOVERED: Fields.RECOVERED,
-        TimeseriesDataset.Fields.AGGREGATE_LEVEL: Fields.AGGREGATE_LEVEL,
+    INDEX_FIELD_MAP = {
+        CommonIndexFields.DATE: Fields.DATE,
+        CommonIndexFields.COUNTRY: Fields.COUNTRY,
+        CommonIndexFields.STATE: Fields.STATE,
+        CommonIndexFields.FIPS: Fields.FIPS,
+        CommonIndexFields.AGGREGATE_LEVEL: Fields.AGGREGATE_LEVEL,
+    }
+    COMMON_FIELD_MAP = {
+        CommonFields.CASES: Fields.CONFIRMED,
+        CommonFields.DEATHS: Fields.DEATHS,
+        CommonFields.RECOVERED: Fields.RECOVERED,
     }
 
     def __init__(self, input_dir):
@@ -162,7 +164,7 @@ class JHUDataset(data_source.DataSource):
         ])
 
     @classmethod
-    def local(cls) -> "JHUTimeseriesData":
+    def local(cls) -> "JHUDataset":
         data_root = dataset_utils.LOCAL_PUBLIC_DATA_PATH
         return cls(data_root / cls.DATA_FOLDER)
 

--- a/libs/datasets/sources/nha_hospitalization.py
+++ b/libs/datasets/sources/nha_hospitalization.py
@@ -3,6 +3,8 @@ from libs.datasets.timeseries import TimeseriesDataset
 from libs.datasets import data_source
 from libs.datasets import dataset_utils
 from libs.datasets.dataset_utils import AggregationLevel
+from libs.datasets.common_fields import CommonIndexFields
+from libs.datasets.common_fields import CommonFields
 
 
 class NevadaHospitalAssociationData(data_source.DataSource):
@@ -28,15 +30,19 @@ class NevadaHospitalAssociationData(data_source.DataSource):
         AGGREGATE_LEVEL = "aggregate_level"
         COUNTRY = "country"
 
-    TIMESERIES_FIELD_MAP = {
-        TimeseriesDataset.Fields.DATE: Fields.DATE,
-        TimeseriesDataset.Fields.COUNTRY: Fields.COUNTRY,
-        TimeseriesDataset.Fields.STATE: Fields.STATE,
-        TimeseriesDataset.Fields.FIPS: Fields.FIPS,
-        TimeseriesDataset.Fields.AGGREGATE_LEVEL: Fields.AGGREGATE_LEVEL,
-        TimeseriesDataset.Fields.CURRENT_HOSPITALIZED: Fields.COVID_CONFIRMED,
-        TimeseriesDataset.Fields.CURRENT_ICU: Fields.COVID_ICU_OCCUPIED,
-        TimeseriesDataset.Fields.CURRENT_VENTILATED: Fields.COVID_VENTILATOR,
+    INDEX_FIELD_MAP = {
+        CommonIndexFields.DATE: Fields.DATE,
+        CommonIndexFields.COUNTRY: Fields.COUNTRY,
+        CommonIndexFields.STATE: Fields.STATE,
+        CommonIndexFields.FIPS: Fields.FIPS,
+        CommonIndexFields.AGGREGATE_LEVEL: Fields.AGGREGATE_LEVEL,
+    }
+
+    COMMON_FIELD_MAP = {
+        CommonFields.CURRENT_HOSPITALIZED: Fields.COVID_CONFIRMED,
+        CommonFields.CURRENT_ICU: Fields.COVID_ICU_OCCUPIED,
+        CommonFields.CURRENT_VENTILATED: Fields.COVID_VENTILATOR,
+        CommonFields.ICU_BEDS: Fields.ICU_STAFFED,
     }
 
     @classmethod

--- a/libs/datasets/sources/nytimes_dataset.py
+++ b/libs/datasets/sources/nytimes_dataset.py
@@ -5,6 +5,8 @@ import pandas as pd
 from libs.datasets.timeseries import TimeseriesDataset
 from libs.datasets import data_source
 from libs.datasets import dataset_utils
+from libs.datasets.common_fields import CommonIndexFields
+from libs.datasets.common_fields import CommonFields
 
 
 class NYTimesDataset(data_source.DataSource):
@@ -18,20 +20,21 @@ class NYTimesDataset(data_source.DataSource):
         COUNTY = "county"
         STATE = "state"
         FIPS = "fips"
+        COUNTRY = "country"
+        AGGREGATE_LEVEL = "aggregate_level"
         CASES = "cases"
         DEATHS = "deaths"
 
-        COUNTRY = "country"
-        AGGREGATE_LEVEL = "aggregate_level"
-
-    TIMESERIES_FIELD_MAP = {
-        TimeseriesDataset.Fields.DATE: Fields.DATE,
-        TimeseriesDataset.Fields.COUNTRY: Fields.COUNTRY,
-        TimeseriesDataset.Fields.STATE: Fields.STATE,
-        TimeseriesDataset.Fields.FIPS: Fields.FIPS,
+    INDEX_FIELD_MAP = {
+        CommonIndexFields.DATE: Fields.DATE,
+        CommonIndexFields.COUNTRY: Fields.COUNTRY,
+        CommonIndexFields.STATE: Fields.STATE,
+        CommonIndexFields.FIPS: Fields.FIPS,
+        CommonIndexFields.AGGREGATE_LEVEL: Fields.AGGREGATE_LEVEL,
+    }
+    COMMON_FIELD_MAP = {
         TimeseriesDataset.Fields.CASES: Fields.CASES,
         TimeseriesDataset.Fields.DEATHS: Fields.DEATHS,
-        TimeseriesDataset.Fields.AGGREGATE_LEVEL: Fields.AGGREGATE_LEVEL,
     }
 
     def __init__(self, input_path):
@@ -40,7 +43,7 @@ class NYTimesDataset(data_source.DataSource):
         super().__init__(data)
 
     @classmethod
-    def load(cls) -> "CDSTimeseriesData":
+    def load(cls) -> "NYTimesDataset":
         return cls(cls.DATA_URL)
 
     @classmethod

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -1,58 +1,38 @@
-from typing import List, Iterator
-import enum
+from typing import List
 import pandas as pd
-import datetime
+from libs import us_state_abbrev
 from libs.datasets import dataset_utils
+from libs.datasets import dataset_base
 from libs.datasets import custom_aggregations
+from libs.datasets.common_fields import CommonIndexFields
+from libs.datasets.common_fields import CommonFields
 from libs.datasets.dataset_utils import AggregationLevel
 
 
-class TimeseriesDataset(object):
-    """Represents timeseries Case data.
+class TimeseriesDataset(dataset_base.DatasetBase):
+    """Represents timeseries dataset.
 
     To make a data source compatible with the timeseries, it must have the required
     fields in the Fields class below + metrics. The other fields are generated
     in the `from_source` method.
     """
 
-    class Fields(object):
-        # Required Fields
-        DATE = "date"
-        COUNTRY = "country"
-        STATE = "state"
-        FIPS = "fips"
-        AGGREGATE_LEVEL = "aggregate_level"
+    class Fields(CommonFields):
+        COUNTRY = CommonIndexFields.COUNTRY
+        STATE = CommonIndexFields.STATE
+        AGGREGATE_LEVEL = CommonIndexFields.AGGREGATE_LEVEL
+        FIPS = CommonIndexFields.FIPS
+        DATE = CommonIndexFields.DATE
 
-        # Target metrics
-        CASES = "cases"
-        DEATHS = "deaths"
-        RECOVERED = "recovered"
-        CURRENT_HOSPITALIZED = "current_hospitalized"
-        CUMULATIVE_HOSPITALIZED = "cumulative_hospitalized"
-        CUMULATIVE_ICU = "cumulative_icu"
+    INDEX_FIELDS = [
+        CommonIndexFields.DATE,
+        CommonIndexFields.AGGREGATE_LEVEL,
+        CommonIndexFields.COUNTRY,
+        CommonIndexFields.STATE,
+        CommonIndexFields.FIPS,
+    ]
 
-        # Current values
-        CURRENT_ICU = "current_icu"
-        CURRENT_VENTILATED = "current_ventilated"
-
-        # Generated in from_source
-        COUNTY = "county"
-        SOURCE = "source"
-        IS_SYNTHETIC = "is_synthetic"
-        GENERATED = "generated"
-
-        @classmethod
-        def metrics(cls) -> List[str]:
-            """Fields that contain metrics and can be aggregated."""
-            return [
-                cls.CASES,
-                cls.DEATHS,
-                cls.RECOVERED,
-                cls.CURRENT_HOSPITALIZED,
-                cls.CUMULATIVE_HOSPITALIZED
-            ]
-
-    def __init__(self, data: pd.DataFrame, source_data=None):
+    def __init__(self, data: pd.DataFrame):
         self.data = data
 
     @property
@@ -86,8 +66,20 @@ class TimeseriesDataset(object):
         values = set(data.index.to_list())
         return sorted(values)
 
-    def latest_values(self, aggregation_level):
-        """Gets the most recent values for index in array."""
+    def latest_values(self, aggregation_level=None) -> pd.DataFrame:
+        """Gets the most recent values.
+
+        Args:
+            aggregation_level: If specified, only gets latest values for that aggregation,
+                otherwise returns values for entire aggretation.
+
+        Return: DataFrame
+        """
+        if not aggregation_level:
+            county = self.latest_values(aggregation_level=AggregationLevel.COUNTY)
+            state = self.latest_values(aggregation_level=AggregationLevel.STATE)
+            return pd.concat([county, state])
+
         if aggregation_level == AggregationLevel.COUNTY:
             group = [self.Fields.COUNTRY, self.Fields.STATE, self.Fields.FIPS]
         if aggregation_level == AggregationLevel.STATE:
@@ -110,6 +102,7 @@ class TimeseriesDataset(object):
         state=None,
         county=None,
         fips=None,
+        states=None
     ) -> "TimeseriesDataset":
         data = self.data
 
@@ -123,6 +116,8 @@ class TimeseriesDataset(object):
             data = data[data.county == county]
         if fips:
             data = data[data.fips == fips]
+        if states:
+            data = data[data[self.Fields.STATE].isin(states)]
 
         if on:
             data = data[data.date == on]
@@ -133,8 +128,32 @@ class TimeseriesDataset(object):
 
         return self.__class__(data)
 
+    def get_records_for_fips(self, fips) -> List[dict]:
+        """Get data for FIPS code.
+
+        Args:
+            fips: FIPS code.
+
+        Returns: List of dictionary records with NA values replaced to be None
+        """
+
+        pd_data = self.get_subset(None, fips=fips).data
+        pd_data = pd_data.where(pd.notnull(pd_data), None)
+        return pd_data.to_dict(orient="records")
+
+    def get_records_for_state(self, state) -> List[dict]:
+        """Get data for state.
+
+        Args:
+            state: 2 letter state abbrev.
+
+        Returns: List of dictionary records with NA values replaced to be None.
+        """
+        pd_data = self.get_subset(AggregationLevel.STATE, state=state).data
+        return pd_data.where(pd.notnull(pd_data), None).to_dict(orient="records")
+
     def get_data(
-        self, country=None, state=None, county=None, fips=None
+        self, country=None, state=None, county=None, fips=None, states=None
     ) -> pd.DataFrame:
         data = self.data
         if country:
@@ -145,41 +164,35 @@ class TimeseriesDataset(object):
             data = data[data.county == county]
         if fips:
             data = data[data.fips == fips]
+        if states:
+            data = data[data[self.Fields.STATE].isin(states)]
+
         return data
 
     @classmethod
     def from_source(
-        cls, source: "DataSource", fill_missing_state: bool = True, fill_na: bool = True
-    ) -> "Timeseries":
+        cls, source: "DataSource", fill_missing_state: bool = True
+    ) -> "TimeseriesDataset":
         """Loads data from a specific datasource.
 
         Args:
             source: DataSource to standardize for timeseries dataset
             fill_missing_state: If True, backfills missing state data by
                 calculating county level aggregates.
-            fill_na: If True, fills in all NaN values for metrics columns.
 
         Returns: Timeseries object.
         """
-        if not source.TIMESERIES_FIELD_MAP:
-            raise ValueError("Source must have field timeseries field map.")
-
         data = source.data
         to_common_fields = {
-            value: key for key, value in source.TIMESERIES_FIELD_MAP.items()
+            value: key for key, value in source.all_fields_map().items()
         }
         final_columns = to_common_fields.values()
         data = data.rename(columns=to_common_fields)[final_columns]
-        data[cls.Fields.SOURCE] = source.SOURCE_NAME
-        data[cls.Fields.GENERATED] = False
-
         group = [
             cls.Fields.DATE,
-            cls.Fields.SOURCE,
             cls.Fields.COUNTRY,
             cls.Fields.AGGREGATE_LEVEL,
             cls.Fields.STATE,
-            cls.Fields.GENERATED,
         ]
         data = custom_aggregations.update_with_combined_new_york_counties(
             data, group, are_boroughs_zero=source.HAS_AGGREGATED_NYC_BOROUGH
@@ -188,7 +201,6 @@ class TimeseriesDataset(object):
         if fill_missing_state:
             state_groupby_fields = [
                 cls.Fields.DATE,
-                cls.Fields.SOURCE,
                 cls.Fields.COUNTRY,
                 cls.Fields.STATE,
             ]
@@ -198,24 +210,30 @@ class TimeseriesDataset(object):
                 AggregationLevel.COUNTY,
                 AggregationLevel.STATE,
             ).reset_index()
-            non_matching[cls.Fields.GENERATED] = True
             data = pd.concat([data, non_matching])
-
-        if fill_na:
-            # Filtering out metric columns that don't exist in the dataset.
-            # It might be that we all timeseries datasets to have all of the metric
-            # columns. If so, initialization of the missing columns should come earlier.
-            metric_columns = [
-                field for field in cls.Fields.metrics() if field in data.columns
-            ]
-            data[metric_columns] = data[metric_columns].fillna(0.0)
 
         fips_data = dataset_utils.build_fips_data_frame()
         data = dataset_utils.add_county_using_fips(data, fips_data)
+        is_state = data[cls.Fields.AGGREGATE_LEVEL] == AggregationLevel.STATE.value
+        state_fips = data.loc[is_state, cls.Fields.STATE].map(us_state_abbrev.ABBREV_US_FIPS)
+        data.loc[is_state, cls.Fields.FIPS] = state_fips
 
         # Choosing to sort by date
         data = data.sort_values(cls.Fields.DATE)
         return cls(data)
+
+    @classmethod
+    def build_from_data_source(cls, source):
+        """Build TimeseriesDataset from a data source."""
+        if set(source.INDEX_FIELD_MAP.keys()) != set(cls.INDEX_FIELDS):
+            raise ValueError("Index fields must match")
+
+        return cls.from_source(source)
+
+    def to_latest_values_dataset(self):
+        from libs.datasets.latest_values_dataset import LatestValuesDataset
+
+        return LatestValuesDataset(self.latest_values())
 
     def summarize(self):
         dataset_utils.summarize(

--- a/libs/enums.py
+++ b/libs/enums.py
@@ -4,6 +4,7 @@ import enum
 # TODO: This should maybe be unique per state.
 UNKNOWN_FIPS = "99999"
 
+
 class Intervention(enum.Enum):
     NO_INTERVENTION = 0
     STRONG_INTERVENTION = 1 # on the webiste, strictDistancingNow

--- a/libs/functions/get_can_projection.py
+++ b/libs/functions/get_can_projection.py
@@ -4,7 +4,6 @@ import requests
 
 from libs.enums import Intervention
 from libs.datasets.dataset_utils import AggregationLevel
-from libs.datasets.beds import BedsDataset
 from libs.datasets import CovidCareMapBeds
 from libs.datasets.can_model_output_schema import CAN_MODEL_OUTPUT_SCHEMA
 import functools

--- a/libs/us_state_abbrev.py
+++ b/libs/us_state_abbrev.py
@@ -77,6 +77,7 @@ us_fips = {
     "Colorado": "08",
     "Connecticut": "09",
     "Delaware": "10",
+    "District of Columbia": "11",
     "Florida": "12",
     "Georgia": "13",
     "Hawaii": "15",
@@ -128,6 +129,7 @@ us_fips = {
 
 
 ABBREV_US_FIPS = {US_STATE_ABBREV[state]: fips for state, fips in us_fips.items()}
+
 # thank you to @kinghelix and @trevormarburger for this idea
 abbrev_us_state = dict(map(reversed, US_STATE_ABBREV.items()))
 

--- a/pyseir/deployment/webui_data_adaptor_v1.py
+++ b/pyseir/deployment/webui_data_adaptor_v1.py
@@ -10,6 +10,7 @@ from pyseir import load_data
 from pyseir.inference.fit_results import load_inference_result, load_Rt_result
 from pyseir.utils import get_run_artifact_path, RunArtifact, RunMode
 from libs.enums import Intervention
+from libs.datasets import CommonFields
 from libs.datasets import FIPSPopulation, JHUDataset, CDSDataset
 from libs.datasets.dataset_utils import build_aggregate_county_data_frame
 from libs.datasets.dataset_utils import AggregationLevel
@@ -89,9 +90,9 @@ class WebUIDataAdaptorV1:
             category='icu')
 
         if len(fips) == 5:
-            population = self.population_data.get_county_level('USA', state=self.state_abbreviation, fips=fips)
+            population = self.population_data.get_record_for_fips(fips)[CommonFields.POPULATION]
         else:
-            population = self.population_data.get_state_level('USA', state=self.state_abbreviation)
+            population = self.population_data.get_record_for_state(self.state_abbreviation)[CommonFields.POPULATION]
 
         if current_hosp is not None:
             t_latest_hosp_data, current_hosp = hosp_times[-1], current_hosp[-1]

--- a/pyseir/inference/infer_rt.py
+++ b/pyseir/inference/infer_rt.py
@@ -1,6 +1,7 @@
 import math
 from datetime import datetime, timedelta
 import numpy as np
+import sentry_sdk
 import logging
 import pandas as pd
 from scipy import stats as sps
@@ -484,8 +485,12 @@ class RtInferenceEngine:
 
     @classmethod
     def run_for_fips(cls, fips):
-        engine = cls(fips)
-        return engine.infer_all()
+        try:
+            engine = cls(fips)
+            return engine.infer_all()
+        except Exception as e:
+            sentry_sdk.capture_exception(e)
+            return None
 
 
 def run_state(state, states_only=False):

--- a/pyseir/load_data.py
+++ b/pyseir/load_data.py
@@ -335,7 +335,7 @@ def load_new_case_data_by_fips(fips, t0):
 
 
 def get_hospitalization_data():
-    data = CovidTrackingDataSource.local().timeseries(fill_na=False).data
+    data = CovidTrackingDataSource.local().timeseries().data
     # Since we're using this data for hospitalized data only, only returning
     # values with hospitalization data.  I think as the use cases of this data source
     # expand, we may not want to drop. For context, as of 4/8 607/1821 rows contained
@@ -426,7 +426,7 @@ def load_hospitalization_data_by_state(state, t0, convert_cumulative_to_current=
     """
     abbr = us.states.lookup(state).abbr
     hospitalization_data = (
-        CovidTrackingDataSource.local().timeseries(fill_na=False)
+        CovidTrackingDataSource.local().timeseries()
         .get_subset(AggregationLevel.STATE, country='USA', state=abbr)
         .get_data(country='USA', state=abbr)
     )

--- a/pyseir/parameters/parameter_ensemble_generator.py
+++ b/pyseir/parameters/parameter_ensemble_generator.py
@@ -3,8 +3,8 @@ import pandas as pd
 import us
 from pyseir import load_data
 from libs.datasets import FIPSPopulation
-from libs.datasets.beds import BedsDataset
 from libs.datasets import CovidCareMapBeds
+from libs.datasets.common_fields import CommonFields
 from libs.datasets.dataset_utils import AggregationLevel
 
 
@@ -49,31 +49,31 @@ class ParameterEnsembleGenerator:
         if self.agg_level is AggregationLevel.COUNTY:
             self.county_metadata = load_data.load_county_metadata().set_index('fips').loc[fips].to_dict()
             self.state_abbr = us.states.lookup(self.county_metadata['state']).abbr
-            self.population = population_data.get_county_level('USA', state=self.state_abbr, fips=self.fips)
+            self.population = population_data.get_record_for_fips(fips=self.fips)[CommonFields.POPULATION]
             # TODO: Some counties do not have hospitals. Likely need to go to HRR level..
-            self._beds_data = beds_data.get_data_for_fips(fips)
+            self._beds_data = beds_data.get_record_for_fips(fips)
         else:
             self.state_abbr = us.states.lookup(fips).abbr
-            self.population = population_data.get_state_level('USA', state=self.state_abbr)
-            self._beds_data = beds_data.get_data_for_state(self.state_abbr)
+            self.population = population_data.get_record_for_state(self.state_abbr)[CommonFields.POPULATION]
+            self._beds_data = beds_data.get_record_for_state(self.state_abbr)
 
     @property
     def beds(self) -> int:
-        return self._beds_data.get(BedsDataset.Fields.MAX_BED_COUNT) or 0
+        return self._beds_data.get(CommonFields.MAX_BED_COUNT) or 0
 
     @property
     def icu_beds(self) -> int:
-        return self._beds_data.get(BedsDataset.Fields.ICU_BEDS) or 0
+        return self._beds_data.get(CommonFields.ICU_BEDS) or 0
 
     @property
     def icu_utilization(self) -> float:
         """Returns the ICU utilization rate if known, otherwise default."""
-        return self._beds_data.get(BedsDataset.Fields.ICU_TYPICAL_OCCUPANCY_RATE) or 0.75
+        return self._beds_data.get(CommonFields.ICU_TYPICAL_OCCUPANCY_RATE) or 0.75
 
     @property
     def bed_utilization(self) -> float:
         """Returns the utilization rate if known, otherwise default."""
-        return self._beds_data.get(BedsDataset.Fields.ALL_BED_TYPICAL_OCCUPANCY_RATE) or 0.4
+        return self._beds_data.get(CommonFields.ALL_BED_TYPICAL_OCCUPANCY_RATE) or 0.4
 
     def sample_seir_parameters(self, override_params=None):
         """

--- a/pyseir/utils.py
+++ b/pyseir/utils.py
@@ -12,6 +12,7 @@ WEB_UI_FOLDER = lambda output_dir: os.path.join(output_dir, 'web_ui')
 STATE_SUMMARY_FOLDER = lambda output_dir: os.path.join(output_dir, 'pyseir', 'state_summaries')
 REF_DATE = datetime(year=2020, month=1, day=1)
 
+
 class TimeseriesType(Enum):
     NEW_CASES = 'new_cases'
     NEW_DEATHS = 'new_deaths'

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,6 +3,7 @@
 
 pytest==4.6.3
 pytest-pylint==0.14.1
+pytest-xdist==1.32.0
 pytest-mock >= 1.10.4
 black==19.10b0
 nbstripout==0.3.7

--- a/test/api/test_can_predictions.py
+++ b/test/api/test_can_predictions.py
@@ -14,6 +14,7 @@ def test_counties_api_output():
         fips="06075",
         lat=37.7749,
         long=122.4194,
+        population=100,
         lastUpdatedDate=date.today(),
         projections={
             "totalHospitalBeds": {
@@ -40,8 +41,12 @@ def test_counties_api_output():
             "cumulativeDeaths": 5,
             "cumulativePositiveTests": None,
             "cumulativeNegativeTests": 20,
-            "hospitalBeds": {"capacity": 100, "currentUsage": 3, "typicalUsageRate": 0.4},
-            "ICUBeds": {"capacity": 10, "currentUsage": 2, "typicalUsageRate": 0.6},
+            "hospitalBeds": {
+                "capacity": 100, "totalCapacity": 100, "currentUsageCovid": 3, "typicalUsageRate": 0.4
+            },
+            "ICUBeds": {
+                "capacity": 10, "totalCapacity": 10, "currentUsageCovid": 2, "typicalUsageRate": 0.6
+            },
         },
     )
     counties = CovidActNowCountiesAPI(__root__=[county_summary])

--- a/test/beds_dataset_test.py
+++ b/test/beds_dataset_test.py
@@ -106,16 +106,16 @@ def test_dh_beds_loading():
 
 def test_get_data():
     beds_data = CovidCareMapBeds.local().beds()
-    data = beds_data.get_data_for_state('MA')
+    data = beds_data.get_record_for_state('MA')
     assert data
 
-    data = beds_data.get_data_for_state('NOTSTATE')
+    data = beds_data.get_record_for_state('NOTSTATE')
     assert not data
 
 
 def test_nyc_aggregation():
     beds_data = CovidCareMapBeds.local().beds()
-    data = beds_data.get_data_for_fips(custom_aggregations.NEW_YORK_COUNTY_FIPS)
+    data = beds_data.get_record_for_fips(custom_aggregations.NEW_YORK_COUNTY_FIPS)
     # Check to make sure that beds occupancy rates are below 1,
     # signaling that it is properly combining occupancy rates.
     assert data['all_beds_occupancy_rate'] < 1

--- a/test/combined_dataset_test.py
+++ b/test/combined_dataset_test.py
@@ -1,0 +1,44 @@
+
+import pytest
+
+from libs.datasets import combined_datasets
+
+from libs.datasets.timeseries import TimeseriesDataset
+from libs.datasets import JHUDataset
+from libs.datasets import CDSDataset
+from libs.datasets import CovidTrackingDataSource
+from libs.datasets import NevadaHospitalAssociationData
+
+
+# Tests to make sure that combined datasets are building data with unique indexes
+# If this test is failing, it means that there is one of the data sources that
+# is returning multiple values for a single row.
+def test_unique_index_values_us_timeseries():
+    timeseries = combined_datasets.build_us_timeseries_with_all_fields()
+    timeseries_data = timeseries.data.set_index(timeseries.INDEX_FIELDS)
+    duplicates = timeseries_data.index.duplicated()
+    assert not sum(duplicates)
+
+
+def test_unique_index_values_us_latest():
+    latest = combined_datasets.build_us_latest_with_all_fields()
+    latest_data = latest.data.set_index(latest.INDEX_FIELDS)
+    duplicates = latest_data.index.duplicated()
+    assert not sum(duplicates)
+
+
+@pytest.mark.parametrize("data_source_cls", [
+    JHUDataset,
+    CDSDataset,
+    CovidTrackingDataSource,
+    NevadaHospitalAssociationData,
+
+])
+def test_unique_timeseries(data_source_cls):
+
+    data_source = data_source_cls.local()
+    timeseries = TimeseriesDataset.build_from_data_source(data_source)
+    timeseries = combined_datasets.US_STATES_FILTER.apply(timeseries)
+    timeseries_data = timeseries.data.set_index(timeseries.INDEX_FIELDS)
+    duplicates = timeseries_data.index.duplicated()
+    assert not sum(duplicates)


### PR DESCRIPTION
Reverts the changes and fixes the error that was failing.

This is a quick fix for the errant borough - lets us not fail but still get alerted in sentry.

I have another task up next for handling this in a more cohesive way.