### PR TITLE
make pyseir load from combined datasets rather than pulling in covid tracking

### DIFF
--- a/api/can_api_definition.py
+++ b/api/can_api_definition.py
@@ -185,7 +185,7 @@ class PredictionTimeseriesRowWithHeader(CANPredictionTimeseriesRow):
 
 class CovidActNowStateTimeseries(CovidActNowStateSummary):
     timeseries: List[CANPredictionTimeseriesRow] = pydantic.Field(...)
-    actuals_timeseries: List[CANActualsTimeseriesRow] = pydantic.Field(...)
+    actualsTimeseries: List[CANActualsTimeseriesRow] = pydantic.Field(...)
 
     # pylint: disable=no-self-argument
     @pydantic.validator('timeseries')
@@ -223,7 +223,7 @@ class CovidActNowStateTimeseries(CovidActNowStateSummary):
 
 class CovidActNowCountyTimeseries(CovidActNowCountySummary):
     timeseries: List[CANPredictionTimeseriesRow] = pydantic.Field(...)
-    actuals_timeseries: List[CANActualsTimeseriesRow] = pydantic.Field(...)
+    actualsTimeseries: List[CANActualsTimeseriesRow] = pydantic.Field(...)
 
 class CovidActNowCountiesAPI(pydantic.BaseModel):
     __root__: List[CovidActNowCountySummary] = pydantic.Field(...)

--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -114,6 +114,21 @@ def build_us_latest_with_all_fields() -> LatestValuesDataset:
     )
 
 
+def get_us_latest(state=None, fips=None) -> dict:
+    """Gets latest values from from either a fips code or state."""
+    if state and fips:
+        raise ValueError("Must specify only state or fips")
+
+    if not (state or fips):
+        raise ValueError("Must specify either state or fips")
+
+    us_latest = build_us_latest_with_all_fields()
+    if state:
+        return us_latest.get_record_for_state(state)
+
+    return us_latest.get_record_for_fips(fips)
+
+
 def load_data_sources(
     feature_definition_config
 ) -> Dict[Type[data_source.DataSource], data_source.DataSource]:

--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -129,6 +129,18 @@ def get_us_latest(state=None, fips=None) -> dict:
     return us_latest.get_record_for_fips(fips)
 
 
+def get_us_latest_for_state(state) -> dict:
+    """Gets latest values for a given state."""
+    us_latest = build_us_latest_with_all_fields()
+    return us_latest.get_record_for_state(state)
+
+
+def get_us_latest_for_fips(fips) -> dict:
+    """Gets latest values for a given fips code."""
+    us_latest = build_us_latest_with_all_fields()
+    return us_latest.get_record_for_fips(fips)
+
+
 def load_data_sources(
     feature_definition_config
 ) -> Dict[Type[data_source.DataSource], data_source.DataSource]:

--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -114,21 +114,6 @@ def build_us_latest_with_all_fields() -> LatestValuesDataset:
     )
 
 
-def get_us_latest(state=None, fips=None) -> dict:
-    """Gets latest values from from either a fips code or state."""
-    if state and fips:
-        raise ValueError("Must specify only state or fips")
-
-    if not (state or fips):
-        raise ValueError("Must specify either state or fips")
-
-    us_latest = build_us_latest_with_all_fields()
-    if state:
-        return us_latest.get_record_for_state(state)
-
-    return us_latest.get_record_for_fips(fips)
-
-
 def get_us_latest_for_state(state) -> dict:
     """Gets latest values for a given state."""
     us_latest = build_us_latest_with_all_fields()

--- a/libs/datasets/dataset_export.py
+++ b/libs/datasets/dataset_export.py
@@ -7,8 +7,8 @@ from api.state_actuals_summary import StateCaseSummary
 
 _logger = logging.getLogger(__name__)
 
-STATE_EXPORT_FIELDS = ["state", "cases", "deaths", "source", "date"]
-COUNTY_EXPORT_FIELDS = ["fips", "cases", "deaths", "source", "date"]
+STATE_EXPORT_FIELDS = ["state", "cases", "deaths", "date"]
+COUNTY_EXPORT_FIELDS = ["fips", "cases", "deaths", "date"]
 
 
 def latest_case_summaries_by_state(dataset: TimeseriesDataset) -> Iterator[StateCaseSummary]:

--- a/libs/functions/generate_api.py
+++ b/libs/functions/generate_api.py
@@ -218,7 +218,7 @@ def generate_state_timeseries(
         lastUpdatedDate=_format_date(projection_row[rc.LAST_UPDATED]),
         projections=projections,
         timeseries=timeseries,
-        actuals_timeseries=_generate_actuals_timeseries(
+        actualsTimeseries=_generate_actuals_timeseries(
             actuals_ts.get_records_for_state(state), state_intervention
         ),
     )
@@ -262,7 +262,7 @@ def generate_county_timeseries(projection_row, intervention, input_dir):
         lastUpdatedDate=_format_date(projection_row[rc.LAST_UPDATED]),
         projections=projections,
         timeseries=timeseries,
-        actuals_timeseries=_generate_actuals_timeseries(
+        actualsTimeseries=_generate_actuals_timeseries(
             actuals_ts.get_records_for_fips(fips), state_intervention
         ),
     )

--- a/pyseir/load_data.py
+++ b/pyseir/load_data.py
@@ -11,6 +11,7 @@ import zipfile
 import json
 from datetime import datetime
 from libs.datasets import NYTimesDataset
+from libs.datasets import combined_datasets
 from libs.datasets.timeseries import TimeseriesDataset
 from libs.datasets.dataset_utils import AggregationLevel
 from libs.datasets import CovidTrackingDataSource
@@ -352,7 +353,7 @@ def load_new_case_data_by_fips(fips, t0):
 
 
 def get_hospitalization_data():
-    data = CovidTrackingDataSource.local().timeseries().data
+    data = combined_datasets.build_us_timeseries_with_all_fields().data
     # Since we're using this data for hospitalized data only, only returning
     # values with hospitalization data.  I think as the use cases of this data source
     # expand, we may not want to drop. For context, as of 4/8 607/1821 rows contained
@@ -443,7 +444,7 @@ def load_hospitalization_data_by_state(state, t0, convert_cumulative_to_current=
     """
     abbr = us.states.lookup(state).abbr
     hospitalization_data = (
-        CovidTrackingDataSource.local().timeseries()
+        combined_datasets.build_us_timeseries_with_all_fields()
         .get_subset(AggregationLevel.STATE, country='USA', state=abbr)
         .get_data(country='USA', state=abbr)
     )

--- a/pyseir/parameters/parameter_ensemble_generator.py
+++ b/pyseir/parameters/parameter_ensemble_generator.py
@@ -36,10 +36,10 @@ class ParameterEnsembleGenerator:
         if self.agg_level is AggregationLevel.COUNTY:
             self.county_metadata = load_data.load_county_metadata().set_index('fips').loc[fips].to_dict()
             self.state_abbr = us.states.lookup(self.county_metadata['state']).abbr
-            self._latest = combined_datasets.get_us_latest(fips=self.fips)
+            self._latest = combined_datasets.get_us_latest_for_fips(self.fips)
         else:
             self.state_abbr = us.states.lookup(fips).abbr
-            self._latest = combined_datasets.get_us_latest(state=self.state_abbr)
+            self._latest = combined_datasets.get_us_latest_for_state(self.state_abbr)
 
     @property
     def population(self) -> int:

--- a/pyseir/parameters/parameter_ensemble_generator.py
+++ b/pyseir/parameters/parameter_ensemble_generator.py
@@ -2,14 +2,9 @@ import numpy as np
 import pandas as pd
 import us
 from pyseir import load_data
-from libs.datasets import FIPSPopulation
-from libs.datasets import CovidCareMapBeds
+from libs.datasets import combined_datasets
 from libs.datasets.common_fields import CommonFields
 from libs.datasets.dataset_utils import AggregationLevel
-
-
-beds_data = None
-population_data = None
 
 
 class ParameterEnsembleGenerator:
@@ -31,14 +26,6 @@ class ParameterEnsembleGenerator:
     """
     def __init__(self, fips, N_samples, t_list,
                  I_initial=1, suppression_policy=None):
-
-        # Caching globally to avoid relatively significant performance overhead
-        # of loading for each county.
-        global beds_data, population_data
-        if not beds_data or not population_data:
-            beds_data = CovidCareMapBeds.local().beds()
-            population_data = FIPSPopulation.local().population()
-
         self.fips = fips
         self.agg_level = AggregationLevel.COUNTY if len(self.fips) == 5 else AggregationLevel.STATE
         self.N_samples = N_samples
@@ -49,31 +36,32 @@ class ParameterEnsembleGenerator:
         if self.agg_level is AggregationLevel.COUNTY:
             self.county_metadata = load_data.load_county_metadata().set_index('fips').loc[fips].to_dict()
             self.state_abbr = us.states.lookup(self.county_metadata['state']).abbr
-            self.population = population_data.get_record_for_fips(fips=self.fips)[CommonFields.POPULATION]
-            # TODO: Some counties do not have hospitals. Likely need to go to HRR level..
-            self._beds_data = beds_data.get_record_for_fips(fips)
+            self._latest = combined_datasets.get_us_latest(fips=self.fips)
         else:
             self.state_abbr = us.states.lookup(fips).abbr
-            self.population = population_data.get_record_for_state(self.state_abbr)[CommonFields.POPULATION]
-            self._beds_data = beds_data.get_record_for_state(self.state_abbr)
+            self._latest = combined_datasets.get_us_latest(state=self.state_abbr)
+
+    @property
+    def population(self) -> int:
+        return self._latest[CommonFields.POPULATION]
 
     @property
     def beds(self) -> int:
-        return self._beds_data.get(CommonFields.MAX_BED_COUNT) or 0
+        return self._latest[CommonFields.MAX_BED_COUNT] or 0
 
     @property
     def icu_beds(self) -> int:
-        return self._beds_data.get(CommonFields.ICU_BEDS) or 0
+        return self._latest[CommonFields.ICU_BEDS] or 0
 
     @property
     def icu_utilization(self) -> float:
         """Returns the ICU utilization rate if known, otherwise default."""
-        return self._beds_data.get(CommonFields.ICU_TYPICAL_OCCUPANCY_RATE) or 0.75
+        return self._latest[CommonFields.ICU_TYPICAL_OCCUPANCY_RATE] or 0.75
 
     @property
     def bed_utilization(self) -> float:
         """Returns the utilization rate if known, otherwise default."""
-        return self._beds_data.get(CommonFields.ALL_BED_TYPICAL_OCCUPANCY_RATE) or 0.4
+        return self._latest[CommonFields.ALL_BED_TYPICAL_OCCUPANCY_RATE] or 0.4
 
     def sample_seir_parameters(self, override_params=None):
         """


### PR DESCRIPTION
We moved the logic for where NV beds from covid tracking to the combined dataset.  use that for hospitalization numbers. 

Without this fix pyseir was not picking up the NV bed overrides