### PR TITLE
rm skiprows in NevadaHospitalAssociationData

### DIFF
--- a/libs/datasets/sources/nha_hospitalization.py
+++ b/libs/datasets/sources/nha_hospitalization.py
@@ -58,7 +58,6 @@ class NevadaHospitalAssociationData(data_source.DataSource):
         input_path = data_root / cls.DATA_PATH
         data = pd.read_csv(
             input_path,
-            skiprows=1,
             parse_dates=[cls.Fields.DATE],
             dtype={cls.Fields.FIPS: str}
         )


### PR DESCRIPTION
Not needed after https://github.com/covid-projections/covid-data-public/pull/40 is merged

Part of https://trello.com/c/oGNg8jGK/17-update-icu-hospital-data-from-daily-nevada-emails

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [ ] Are tests passing?
