### PR TITLE
Adding cache dir to combined datasets

### DIFF
--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -96,6 +96,39 @@ US_STATES_FILTER = dataset_filter.DatasetFilter(
 )
 
 
+@dataset_cache.cache_dataset_on_disk(TimeseriesDataset)
+def build_timeseries_with_all_fields() -> TimeseriesDataset:
+    return build_combined_dataset_from_sources(
+        TimeseriesDataset, ALL_TIMESERIES_FEATURE_DEFINITION,
+    )
+
+
+@dataset_cache.cache_dataset_on_disk(TimeseriesDataset)
+def build_us_timeseries_with_all_fields() -> TimeseriesDataset:
+    return build_combined_dataset_from_sources(
+        TimeseriesDataset, ALL_TIMESERIES_FEATURE_DEFINITION, filters=[US_STATES_FILTER]
+    )
+
+
+@dataset_cache.cache_dataset_on_disk(LatestValuesDataset)
+def build_us_latest_with_all_fields() -> LatestValuesDataset:
+    return build_combined_dataset_from_sources(
+        LatestValuesDataset, ALL_FIELDS_FEATURE_DEFINITION, filters=[US_STATES_FILTER]
+    )
+
+
+def get_us_latest_for_state(state) -> dict:
+    """Gets latest values for a given state."""
+    us_latest = build_us_latest_with_all_fields()
+    return us_latest.get_record_for_state(state)
+
+
+def get_us_latest_for_fips(fips) -> dict:
+    """Gets latest values for a given fips code."""
+    us_latest = build_us_latest_with_all_fields()
+    return us_latest.get_record_for_fips(fips)
+
+
 def load_data_sources(
     feature_definition_config,
 ) -> Dict[Type[data_source.DataSource], data_source.DataSource]:
@@ -154,36 +187,3 @@ def build_combined_dataset_from_sources(
             )
 
     return target_dataset_cls(data)
-
-
-@dataset_cache.cache_dataset_on_disk(TimeseriesDataset)
-def build_timeseries_with_all_fields() -> TimeseriesDataset:
-    return build_combined_dataset_from_sources(
-        TimeseriesDataset, ALL_TIMESERIES_FEATURE_DEFINITION,
-    )
-
-
-@dataset_cache.cache_dataset_on_disk(TimeseriesDataset)
-def build_us_timeseries_with_all_fields() -> TimeseriesDataset:
-    return build_combined_dataset_from_sources(
-        TimeseriesDataset, ALL_TIMESERIES_FEATURE_DEFINITION, filters=[US_STATES_FILTER]
-    )
-
-
-@dataset_cache.cache_dataset_on_disk(LatestValuesDataset)
-def build_us_latest_with_all_fields() -> LatestValuesDataset:
-    return build_combined_dataset_from_sources(
-        LatestValuesDataset, ALL_FIELDS_FEATURE_DEFINITION, filters=[US_STATES_FILTER]
-    )
-
-
-def get_us_latest_for_state(state) -> dict:
-    """Gets latest values for a given state."""
-    us_latest = build_us_latest_with_all_fields()
-    return us_latest.get_record_for_state(state)
-
-
-def get_us_latest_for_fips(fips) -> dict:
-    """Gets latest values for a given fips code."""
-    us_latest = build_us_latest_with_all_fields()
-    return us_latest.get_record_for_fips(fips)

--- a/libs/datasets/dataset_cache.py
+++ b/libs/datasets/dataset_cache.py
@@ -16,11 +16,21 @@ _EXISTING_CACHE_KEYS = set()
 _logger = logging.getLogger(__name__)
 
 
-def set_pickle_cache_tempdir() -> str:
+def set_pickle_cache_tempdir(force=False) -> str:
     """Sets the cache dir to a temporary directory.
 
     Note that the directory does not clean up after itself.
+
+    Args:
+        force: If True, will force a cache key to be a new tempdir
+            if key already exists.
     """
+
+    if os.getenv(PICKLE_CACHE_ENV_KEY) and not force:
+        directory = os.getenv(PICKLE_CACHE_ENV_KEY)
+        _logger.info(f"Using existing pickle cache tmpdir to {directory}")
+        return directory
+
     tempdir = tempfile.mkdtemp()
     os.environ[PICKLE_CACHE_ENV_KEY] = tempdir
     _logger.info(f"Setting pickle cache tmpdir to {tempdir}")

--- a/libs/datasets/dataset_cache.py
+++ b/libs/datasets/dataset_cache.py
@@ -1,0 +1,59 @@
+from typing import Dict, Type, List
+import os
+import tempfile
+import pathlib
+import logging
+import time
+import pandas as pd
+from libs.datasets import dataset_base
+
+
+PICKLE_CACHE_ENV_KEY = "PICKLE_CACHE_DIR"
+
+
+_logger = logging.getLogger(__name__)
+
+
+def set_pickle_cache_tempdir() -> str:
+    """Sets the cache dir to a temporary directory.
+
+    Note that the directory does not clean up after itself.
+    """
+    tempdir = tempfile.mkdtemp()
+    os.environ[PICKLE_CACHE_ENV_KEY] = tempdir
+    _logger.info(f"Setting pickle cache tmpdir to {tempdir}")
+    return tempdir
+
+
+def cache_dataset_on_disk(
+    target_dataset_cls: Type[dataset_base.DatasetBase], max_age_in_minutes=30
+):
+    """Caches underlying pandas data from to an on disk location.
+
+    Args:
+        target_dataset_cls: Class of dataset to wrap pandas data with.
+    """
+
+    def decorator(func):
+        def f() -> target_dataset_cls:
+            pickle_cache_dir = os.getenv(PICKLE_CACHE_ENV_KEY)
+            if not pickle_cache_dir:
+                return func()
+
+            cache_path = pathlib.Path(pickle_cache_dir) / (func.__name__ + ".pickle")
+
+            if cache_path.exists():
+                modified_time = cache_path.stat().st_mtime
+                cache_age_in_minutes = (time.time() - modified_time) / 60
+                if cache_age_in_minutes < max_age_in_minutes:
+                    return target_dataset_cls(pd.read_pickle(cache_path))
+                else:
+                    _logger.debug(f"Cache expired, reloading.")
+
+            dataset = func()
+            dataset.data.to_pickle(cache_path)
+            return dataset
+
+        return f
+
+    return decorator

--- a/libs/datasets/dataset_cache.py
+++ b/libs/datasets/dataset_cache.py
@@ -40,7 +40,7 @@ def cache_dataset_on_disk(
 
     def decorator(func):
         cache_key = key or func.__name__
-        print(cache_key)
+
         if cache_key in _EXISTING_CACHE_KEYS:
             raise ValueError(
                 f"Have already wrapped a function with the key name: {func.__name__}. "

--- a/pyseir/cli.py
+++ b/pyseir/cli.py
@@ -5,6 +5,7 @@ import logging
 import sentry_sdk
 from multiprocessing import Pool
 from functools import partial
+from libs.datasets import dataset_cache
 from pyseir.load_data import cache_all_data
 from pyseir.inference.initial_conditions_fitter import generate_start_times_for_state
 from pyseir.inference import infer_rt as infer_rt_module
@@ -56,6 +57,7 @@ def _cache_global_datasets():
 @click.group()
 def entry_point():
     """Basic entrypoint for cortex subcommands"""
+    dataset_cache.set_pickle_cache_tempdir()
     sentry_sdk.init(os.getenv("SENTRY_DSN"))
 
 

--- a/run.py
+++ b/run.py
@@ -9,11 +9,12 @@ import click
 import sentry_sdk
 from pandarallel import pandarallel
 
+from cli import api
 from cli import run_top_counties_dataset
 from cli import run_states_api
 from cli import run_counties_api
 
-from cli import api
+from libs.datasets import dataset_cache
 
 
 @click.group()
@@ -30,6 +31,7 @@ entry_point.add_command(api.main)
 if __name__ == "__main__":
     sentry_sdk.init(os.getenv("SENTRY_DSN"))
     logging.basicConfig(level=logging.INFO)
+    dataset_cache.set_pickle_cache_tempdir()
     pandarallel.initialize(progress_bar=False)
     try:
         entry_point()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+from libs.datasets import dataset_cache
+
+
+@pytest.fixture(scope="session", autouse=True)
+def set_timeseries_dataset_cache():
+    dataset_cache.set_pickle_cache_tempdir()

--- a/test/dataset_cache_test.py
+++ b/test/dataset_cache_test.py
@@ -1,0 +1,83 @@
+from libs.datasets import dataset_cache
+import pytest
+import pandas as pd
+from libs.datasets.latest_values_dataset import LatestValuesDataset
+
+
+@pytest.fixture(autouse=True)
+def clear_cache_keys():
+    # Clears existing cache keys so multiple tests can start with a clean slate
+    # and create functions that share the same name across tests.
+    yield
+    dataset_cache._EXISTING_CACHE_KEYS = set()
+
+
+def test_uses_cache_when_env_variable_saved(monkeypatch, tmp_path):
+
+    data = pd.DataFrame([{"date": "2020-01-01", "state": "DC", "fips": "11"}])
+    dataset = LatestValuesDataset(data)
+    calls = 0
+
+    original_records = dataset.data.to_dict(orient="records")
+
+    @dataset_cache.cache_dataset_on_disk(LatestValuesDataset)
+    def _wrapped_function():
+        nonlocal calls
+        calls += 1
+        return dataset
+
+    monkeypatch.setenv(dataset_cache.PICKLE_CACHE_ENV_KEY, str(tmp_path))
+
+    first_call = _wrapped_function()
+    assert first_call.data.to_dict(orient="records") == original_records
+
+    second_call = _wrapped_function()
+    assert second_call.data.to_dict(orient="records") == original_records
+    # Verify that second call was done through cache
+    assert calls == 1
+
+
+def test_doesnt_cache_without_env(monkeypatch, tmp_path):
+
+    monkeypatch.setenv(dataset_cache.PICKLE_CACHE_ENV_KEY, "")
+
+    data = pd.DataFrame([{"date": "2020-01-01", "state": "DC", "fips": "11"}])
+    dataset = LatestValuesDataset(data)
+    calls = 0
+
+    @dataset_cache.cache_dataset_on_disk(LatestValuesDataset)
+    def _wrapped_function():
+        nonlocal calls
+        calls += 1
+        return dataset
+
+    _wrapped_function()
+    _wrapped_function()
+    assert calls == 2
+
+
+def test_wrapping_multiple_times_fails(monkeypatch, tmp_path):
+
+    data = pd.DataFrame([{"date": "2020-01-01", "state": "DC", "fips": "11"}])
+    dataset = LatestValuesDataset(data)
+    calls = 0
+
+    @dataset_cache.cache_dataset_on_disk(LatestValuesDataset)
+    def _wrapped_function():
+        nonlocal calls
+        calls += 1
+        return dataset
+
+    with pytest.raises(ValueError):
+
+        @dataset_cache.cache_dataset_on_disk(LatestValuesDataset)
+        def _wrapped_function():
+            nonlocal calls
+            calls += 1
+            return dataset
+
+    @dataset_cache.cache_dataset_on_disk(LatestValuesDataset, key="some_other_name")
+    def _wrapped_function():
+        nonlocal calls
+        calls += 1
+        return dataset


### PR DESCRIPTION
Alrighty, so i found out that one of the main reasons the modeling code is very slow now is that it's reloading the combined datasets multiple times. 

We attempt to get around this with the lru_cache decorator, but it seems that the `lru_cache` does not cache across processes (which makes sense). So, as a result, it's reloading the combined datasets a lot of times.  This is a very slow operation which is not really intended to be done more than once. 

So, I added in a decorator that caches these datasets on disk which greatly speeds up the operations.  I don't really love this approach in general - I would much rather refactor the pyseir code to load the required data frames once and figure out the best way to pass that data through - but that requires a lot more refactoring and more time than i have right now.

Locally, for just massachusetts, this cuts the execution time on my 6-core machine from 5:00 -> 2:00 (with basically the first minute just being loading the dataset the first time).
There are a handful of other improvements i have that should drop the time as well, but this is a good start.