### PR TITLE
Feature/nytimes snapshot

### DIFF
--- a/libs/datasets/sources/nytimes_dataset.py
+++ b/libs/datasets/sources/nytimes_dataset.py
@@ -45,7 +45,7 @@ class NYTimesDataset(data_source.DataSource):
         super().__init__(data)
 
     @classmethod
-    def load(cls) -> "NYTimesDataset":
+    def local(cls) -> "NYTimesDataset":
         data_root = dataset_utils.LOCAL_PUBLIC_DATA_PATH
         return cls(data_root / cls.DATA_FOLDER / cls.COUNTIES_DATA_FILE)
 

--- a/libs/datasets/sources/nytimes_dataset.py
+++ b/libs/datasets/sources/nytimes_dataset.py
@@ -1,9 +1,7 @@
 import pandas as pd
-from libs.datasets.timeseries import TimeseriesDataset
 from libs.datasets import data_source
 from libs.datasets import dataset_utils
-from libs.datasets.common_fields import CommonIndexFields
-
+from libs.datasets.common_fields import CommonFields, CommonIndexFields
 
 
 class NYTimesDataset(data_source.DataSource):
@@ -33,8 +31,8 @@ class NYTimesDataset(data_source.DataSource):
         CommonIndexFields.AGGREGATE_LEVEL: Fields.AGGREGATE_LEVEL,
     }
     COMMON_FIELD_MAP = {
-        TimeseriesDataset.Fields.CASES: Fields.CASES,
-        TimeseriesDataset.Fields.DEATHS: Fields.DEATHS,
+        CommonFields.CASES: Fields.CASES,
+        CommonFields.DEATHS: Fields.DEATHS,
     }
 
     def __init__(self, input_path):

--- a/libs/datasets/sources/nytimes_dataset.py
+++ b/libs/datasets/sources/nytimes_dataset.py
@@ -1,17 +1,17 @@
-from typing import List
-import logging
-import numpy
 import pandas as pd
 from libs.datasets.timeseries import TimeseriesDataset
 from libs.datasets import data_source
 from libs.datasets import dataset_utils
 from libs.datasets.common_fields import CommonIndexFields
-from libs.datasets.common_fields import CommonFields
+
 
 
 class NYTimesDataset(data_source.DataSource):
     DATA_URL = "https://github.com/nytimes/covid-19-data/raw/master/us-counties.csv"
     SOURCE_NAME = "NYTimes"
+
+    DATA_FOLDER = "data/cases-nytimes"
+    COUNTIES_DATA_FILE = "us-counties.csv"
 
     HAS_AGGREGATED_NYC_BOROUGH = True
 
@@ -46,7 +46,8 @@ class NYTimesDataset(data_source.DataSource):
 
     @classmethod
     def load(cls) -> "NYTimesDataset":
-        return cls(cls.DATA_URL)
+        data_root = dataset_utils.LOCAL_PUBLIC_DATA_PATH
+        return cls(data_root / cls.DATA_FOLDER / cls.COUNTIES_DATA_FILE)
 
     @classmethod
     def standardize_data(cls, data: pd.DataFrame) -> pd.DataFrame:

--- a/pyseir/cli.py
+++ b/pyseir/cli.py
@@ -49,7 +49,7 @@ def _cache_global_datasets():
     if cds_dataset is None:
         cds_dataset = CDSDataset.local()
     if nyt_dataset is None:
-        nyt_dataset = NYTimesDataset.load()
+        nyt_dataset = NYTimesDataset.local()
 
 
 @click.group()

--- a/pyseir/load_data.py
+++ b/pyseir/load_data.py
@@ -170,7 +170,7 @@ def load_county_case_data():
     -------
     : pd.DataFrame
     """
-    county_case_data = NYTimesDataset.load().timeseries() \
+    county_case_data = NYTimesDataset.local().timeseries() \
                          .get_subset(AggregationLevel.COUNTY, country='USA') \
                          .get_data(country='USA')
     return county_case_data
@@ -186,7 +186,7 @@ def load_state_case_data():
     : pd.DataFrame
     """
 
-    state_case_data = NYTimesDataset.load().timeseries() \
+    state_case_data = NYTimesDataset.local().timeseries() \
                          .get_subset(AggregationLevel.STATE, country='USA') \
                          .get_data(country='USA')
     return state_case_data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-astroid==2.3.0
+astroid==2.4.1
 certifi==2019.11.28
 chardet==3.0.4
 cycler==0.10.0


### PR DESCRIPTION
This PR addresses issue of nytimes data being read directly from the nytimes github repo instead of using our existing snapshot infra. 

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [ ] Are tests passing?
