### PR TITLE
Add TestAndTrace to api output

### DIFF
--- a/api/can_api_definition.py
+++ b/api/can_api_definition.py
@@ -80,7 +80,7 @@ class _Actuals(pydantic.BaseModel):
     hospitalBeds: Optional[_ResourceUtilization] = pydantic.Field(...)
     ICUBeds: Optional[_ResourceUtilization] = pydantic.Field(...)
     contactTracers: Optional[int] = pydantic.Field(
-        ..., description="# of Contact Tracers"
+        default=None, description="# of Contact Tracers"
     )
 
 

--- a/api/can_api_definition.py
+++ b/api/can_api_definition.py
@@ -79,6 +79,9 @@ class _Actuals(pydantic.BaseModel):
     )
     hospitalBeds: Optional[_ResourceUtilization] = pydantic.Field(...)
     ICUBeds: Optional[_ResourceUtilization] = pydantic.Field(...)
+    contactTracers: Optional[int] = pydantic.Field(
+        ..., description="# of Contact Tracers"
+    )
 
 
 class CovidActNowAreaSummary(pydantic.BaseModel):

--- a/api/can_api_definition.py
+++ b/api/can_api_definition.py
@@ -79,6 +79,7 @@ class _Actuals(pydantic.BaseModel):
     )
     hospitalBeds: Optional[_ResourceUtilization] = pydantic.Field(...)
     ICUBeds: Optional[_ResourceUtilization] = pydantic.Field(...)
+    # contactTracers count is available for states, not counties.
     contactTracers: Optional[int] = pydantic.Field(
         default=None, description="# of Contact Tracers"
     )

--- a/api/can_api_definition.py
+++ b/api/can_api_definition.py
@@ -3,8 +3,9 @@ import pydantic
 import datetime
 
 """
-Documented https://www.dropbox.com/scl/fi/o4bec2kz8dkcxdtabtqda/CAN-V1-API-Draft.paper?dl=0&rlkey=f7elx3zmo6tt5s7mj5nvap9a0
+CovidActNow API
 
+Documentation at https://github.com/covid-projections/covid-data-model/tree/master/api
 """
 
 

--- a/api/schemas/CovidActNowAreaSummary.json
+++ b/api/schemas/CovidActNowAreaSummary.json
@@ -197,6 +197,11 @@
         },
         "ICUBeds": {
           "$ref": "#/definitions/_ResourceUtilization"
+        },
+        "contactTracers": {
+          "title": "Contacttracers",
+          "description": "# of Contact Tracers",
+          "type": "integer"
         }
       },
       "required": [

--- a/api/schemas/CovidActNowCountiesAPI.json
+++ b/api/schemas/CovidActNowCountiesAPI.json
@@ -151,6 +151,11 @@
         },
         "ICUBeds": {
           "$ref": "#/definitions/_ResourceUtilization"
+        },
+        "contactTracers": {
+          "title": "Contacttracers",
+          "description": "# of Contact Tracers",
+          "type": "integer"
         }
       },
       "required": [

--- a/api/schemas/CovidActNowCountiesSummary.json
+++ b/api/schemas/CovidActNowCountiesSummary.json
@@ -151,6 +151,11 @@
         },
         "ICUBeds": {
           "$ref": "#/definitions/_ResourceUtilization"
+        },
+        "contactTracers": {
+          "title": "Contacttracers",
+          "description": "# of Contact Tracers",
+          "type": "integer"
         }
       },
       "required": [

--- a/api/schemas/CovidActNowCountiesTimeseries.json
+++ b/api/schemas/CovidActNowCountiesTimeseries.json
@@ -151,6 +151,11 @@
         },
         "ICUBeds": {
           "$ref": "#/definitions/_ResourceUtilization"
+        },
+        "contactTracers": {
+          "title": "Contacttracers",
+          "description": "# of Contact Tracers",
+          "type": "integer"
         }
       },
       "required": [
@@ -291,6 +296,11 @@
         },
         "ICUBeds": {
           "$ref": "#/definitions/_ResourceUtilization"
+        },
+        "contactTracers": {
+          "title": "Contacttracers",
+          "description": "# of Contact Tracers",
+          "type": "integer"
         },
         "date": {
           "title": "Date",

--- a/api/schemas/CovidActNowStatesAPI.json
+++ b/api/schemas/CovidActNowStatesAPI.json
@@ -145,7 +145,12 @@
         },
         "ICUBeds": {
           "$ref": "#/definitions/_ResourceUtilization"
-        }
+        },
+	"contactTracersCount": {
+          "title": "contactTracersCount",
+          "description": "Number of contact tracers in the region",
+          "type": "integer"
+	}
       },
       "required": [
         "population",

--- a/api/schemas/CovidActNowStatesSummary.json
+++ b/api/schemas/CovidActNowStatesSummary.json
@@ -151,6 +151,11 @@
         },
         "ICUBeds": {
           "$ref": "#/definitions/_ResourceUtilization"
+        },
+        "contactTracers": {
+          "title": "Contacttracers",
+          "description": "# of Contact Tracers",
+          "type": "integer"
         }
       },
       "required": [

--- a/api/schemas/CovidActNowStatesSummary.json
+++ b/api/schemas/CovidActNowStatesSummary.json
@@ -151,7 +151,12 @@
         },
         "ICUBeds": {
           "$ref": "#/definitions/_ResourceUtilization"
-        }
+        },
+	"contactTracersCount": {
+          "title": "contactTracersCount",
+          "description": "Number of contact tracers in the region",
+          "type": "integer"
+	}
       },
       "required": [
         "population",

--- a/api/schemas/CovidActNowStatesSummary.json
+++ b/api/schemas/CovidActNowStatesSummary.json
@@ -151,12 +151,7 @@
         },
         "ICUBeds": {
           "$ref": "#/definitions/_ResourceUtilization"
-        },
-	"contactTracersCount": {
-          "title": "contactTracersCount",
-          "description": "Number of contact tracers in the region",
-          "type": "integer"
-	}
+        }
       },
       "required": [
         "population",

--- a/api/schemas/CovidActNowStatesTimeseries.json
+++ b/api/schemas/CovidActNowStatesTimeseries.json
@@ -151,7 +151,12 @@
         },
         "ICUBeds": {
           "$ref": "#/definitions/_ResourceUtilization"
-        }
+        },
+	"contactTracersCount": {
+          "title": "contactTracersCount",
+          "description": "Number of contact tracers in the region",
+          "type": "integer"
+	}
       },
       "required": [
         "population",
@@ -292,6 +297,11 @@
         "ICUBeds": {
           "$ref": "#/definitions/_ResourceUtilization"
         },
+	"contactTracersCount": {
+          "title": "contactTracersCount",
+          "description": "Number of contact tracers in the region",
+          "type": "integer"
+	},
         "date": {
           "title": "Date",
           "descrition": "Date of timeseries data point",

--- a/api/schemas/CovidActNowStatesTimeseries.json
+++ b/api/schemas/CovidActNowStatesTimeseries.json
@@ -151,6 +151,11 @@
         },
         "ICUBeds": {
           "$ref": "#/definitions/_ResourceUtilization"
+        },
+        "contactTracers": {
+          "title": "Contacttracers",
+          "description": "# of Contact Tracers",
+          "type": "integer"
         }
       },
       "required": [
@@ -291,6 +296,11 @@
         },
         "ICUBeds": {
           "$ref": "#/definitions/_ResourceUtilization"
+        },
+        "contactTracers": {
+          "title": "Contacttracers",
+          "description": "# of Contact Tracers",
+          "type": "integer"
         },
         "date": {
           "title": "Date",

--- a/api/schemas/CovidActNowStatesTimeseries.json
+++ b/api/schemas/CovidActNowStatesTimeseries.json
@@ -151,12 +151,7 @@
         },
         "ICUBeds": {
           "$ref": "#/definitions/_ResourceUtilization"
-        },
-	"contactTracersCount": {
-          "title": "contactTracersCount",
-          "description": "Number of contact tracers in the region",
-          "type": "integer"
-	}
+        }
       },
       "required": [
         "population",
@@ -297,11 +292,6 @@
         "ICUBeds": {
           "$ref": "#/definitions/_ResourceUtilization"
         },
-	"contactTracersCount": {
-          "title": "contactTracersCount",
-          "description": "Number of contact tracers in the region",
-          "type": "integer"
-	},
         "date": {
           "title": "Date",
           "descrition": "Date of timeseries data point",

--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -4,6 +4,7 @@ import pandas as pd
 from libs.datasets import dataset_utils
 from libs.datasets import dataset_base
 from libs.datasets import data_source
+from libs.datasets.sources.test_and_trace import TestAndTraceData
 from libs.datasets.timeseries import TimeseriesDataset
 from libs.datasets.latest_values_dataset import LatestValuesDataset
 from libs.datasets.sources.jhu_dataset import JHUDataset
@@ -58,7 +59,6 @@ ALL_FIELDS_FEATURE_DEFINITION: FeatureDataSourceMap = {
     CommonFields.MAX_BED_COUNT: [CovidCareMapBeds],
     CommonFields.POSITIVE_TESTS: [CDSDataset, CovidTrackingDataSource],
     CommonFields.NEGATIVE_TESTS: [CDSDataset, CovidTrackingDataSource],
-    CommonFields.CONTACT_TRACERS_COUNT: [TestAndTraceData],
 }
 
 ALL_TIMESERIES_FEATURE_DEFINITION: FeatureDataSourceMap = {
@@ -86,6 +86,7 @@ ALL_TIMESERIES_FEATURE_DEFINITION: FeatureDataSourceMap = {
     CommonFields.ICU_TYPICAL_OCCUPANCY_RATE: [],
     CommonFields.POSITIVE_TESTS: [CDSDataset, CovidTrackingDataSource],
     CommonFields.NEGATIVE_TESTS: [CDSDataset, CovidTrackingDataSource],
+    CommonFields.CONTACT_TRACERS_COUNT: [TestAndTraceData],
 }
 
 US_STATES_FILTER = dataset_filter.DatasetFilter(

--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -58,6 +58,7 @@ ALL_FIELDS_FEATURE_DEFINITION: FeatureDataSourceMap = {
     CommonFields.MAX_BED_COUNT: [CovidCareMapBeds],
     CommonFields.POSITIVE_TESTS: [CDSDataset, CovidTrackingDataSource],
     CommonFields.NEGATIVE_TESTS: [CDSDataset, CovidTrackingDataSource],
+    CommonFields.CONTACT_TRACERS_COUNT: [TestAndTraceData],
 }
 
 ALL_TIMESERIES_FEATURE_DEFINITION: FeatureDataSourceMap = {

--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -59,6 +59,7 @@ ALL_FIELDS_FEATURE_DEFINITION: FeatureDataSourceMap = {
     CommonFields.MAX_BED_COUNT: [CovidCareMapBeds],
     CommonFields.POSITIVE_TESTS: [CDSDataset, CovidTrackingDataSource],
     CommonFields.NEGATIVE_TESTS: [CDSDataset, CovidTrackingDataSource],
+    CommonFields.CONTACT_TRACERS_COUNT: [TestAndTraceData],
 }
 
 ALL_TIMESERIES_FEATURE_DEFINITION: FeatureDataSourceMap = {

--- a/libs/datasets/common_fields.py
+++ b/libs/datasets/common_fields.py
@@ -43,6 +43,8 @@ class CommonFields(object):
     CURRENT_HOSPITALIZED_TOTAL = "current_hospitalized_total"
     CURRENT_ICU_TOTAL = "current_icu_total"
 
+    CONTACT_TRACERS_COUNT = "contact_tracers_count"
+
 
 class CommonIndexFields(object):
     # Column for FIPS code. Right now a column containing fips data may be

--- a/libs/datasets/sources/test_and_trace.py
+++ b/libs/datasets/sources/test_and_trace.py
@@ -43,6 +43,8 @@ class TestAndTraceData(data_source.DataSource):
     def local(cls):
         data_root = dataset_utils.LOCAL_PUBLIC_DATA_PATH
         input_path = data_root / cls.DATA_PATH
-        data = pd.read_csv(input_path, dtype={cls.Fields.FIPS: str})
+        data = pd.read_csv(
+            input_path, parse_dates=[cls.Fields.DATE], dtype={cls.Fields.FIPS: str}
+        )
         data = cls.standardize_data(data)
         return cls(data)

--- a/libs/datasets/sources/test_and_trace.py
+++ b/libs/datasets/sources/test_and_trace.py
@@ -12,11 +12,12 @@ class TestAndTraceData(data_source.DataSource):
     SOURCE_NAME = "TestAndTrace"
 
     class Fields(object):
-        STATE = "state_code"
-        COUNTY = "county_name"
-        FIPS = "fips_code"
-        CONTACT_TRACERS = "# of Contact Tracers"
+        FIPS = (CommonFields.FIPS,)
+        STATE = (CommonFields.STATE,)
+        DATE = (CommonFields.DATE,)
+        CONTACT_TRACERS = (CommonFields.CONTACT_TRACERS_COUNT,)
 
+        # Not in the source file, added to conform to the expectations of this repo
         AGGREGATE_LEVEL = "aggregate_level"
         COUNTRY = "country"
 
@@ -24,6 +25,7 @@ class TestAndTraceData(data_source.DataSource):
         CommonIndexFields.COUNTRY: Fields.COUNTRY,
         CommonIndexFields.STATE: Fields.STATE,
         CommonIndexFields.FIPS: Fields.FIPS,
+        CommonIndexFields.DATE: Fields.DATE,
         CommonIndexFields.AGGREGATE_LEVEL: Fields.AGGREGATE_LEVEL,
     }
 

--- a/libs/datasets/sources/test_and_trace.py
+++ b/libs/datasets/sources/test_and_trace.py
@@ -1,0 +1,46 @@
+import pandas as pd
+from libs.datasets.timeseries import TimeseriesDataset
+from libs.datasets import data_source
+from libs.datasets import dataset_utils
+from libs.datasets.dataset_utils import AggregationLevel
+from libs.datasets.common_fields import CommonIndexFields
+from libs.datasets.common_fields import CommonFields
+
+
+class TestAndTraceData(data_source.DataSource):
+    DATA_PATH = "data/test-and-trace/state_data.csv"
+    SOURCE_NAME = "TestAndTrace"
+
+    class Fields(object):
+        STATE = "state_code"
+        COUNTY = "county_name"
+        FIPS = "fips_code"
+        CONTACT_TRACERS = "# of Contact Tracers"
+
+        AGGREGATE_LEVEL = "aggregate_level"
+        COUNTRY = "country"
+
+    INDEX_FIELD_MAP = {
+        CommonIndexFields.COUNTRY: Fields.COUNTRY,
+        CommonIndexFields.STATE: Fields.STATE,
+        CommonIndexFields.FIPS: Fields.FIPS,
+        CommonIndexFields.AGGREGATE_LEVEL: Fields.AGGREGATE_LEVEL,
+    }
+
+    COMMON_FIELD_MAP = {
+        CommonFields.CONTACT_TRACERS_COUNT: Fields.CONTACT_TRACERS,
+    }
+
+    @classmethod
+    def standardize_data(cls, data):
+        data[cls.Fields.COUNTRY] = "USA"
+        data[cls.Fields.AGGREGATE_LEVEL] = AggregationLevel.STATE.value
+        return data
+
+    @classmethod
+    def local(cls):
+        data_root = dataset_utils.LOCAL_PUBLIC_DATA_PATH
+        input_path = data_root / cls.DATA_PATH
+        data = pd.read_csv(input_path, dtype={cls.Fields.FIPS: str})
+        data = cls.standardize_data(data)
+        return cls(data)

--- a/libs/datasets/sources/test_and_trace.py
+++ b/libs/datasets/sources/test_and_trace.py
@@ -12,10 +12,10 @@ class TestAndTraceData(data_source.DataSource):
     SOURCE_NAME = "TestAndTrace"
 
     class Fields(object):
-        FIPS = (CommonFields.FIPS,)
-        STATE = (CommonFields.STATE,)
-        DATE = (CommonFields.DATE,)
-        CONTACT_TRACERS = (CommonFields.CONTACT_TRACERS_COUNT,)
+        FIPS = CommonFields.FIPS
+        STATE = CommonFields.STATE
+        DATE = CommonFields.DATE
+        CONTACT_TRACERS = CommonFields.CONTACT_TRACERS_COUNT
 
         # Not in the source file, added to conform to the expectations of this repo
         AGGREGATE_LEVEL = "aggregate_level"

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -90,6 +90,8 @@ class TimeseriesDataset(dataset_base.DatasetBase):
         data = self.data[
             self.data[self.Fields.AGGREGATE_LEVEL] == aggregation_level.value
         ].reset_index()
+        # If the groupby raises a ValueError check the dtype of date. If it was loaded
+        # by read_csv did you set parse_dates=["date"]?
         return data.iloc[data.groupby(group).date.idxmax(), :]
 
     def get_subset(

--- a/libs/functions/generate_api.py
+++ b/libs/functions/generate_api.py
@@ -110,7 +110,9 @@ def _generate_actuals(actual_data, intervention) -> _Actuals:
             "capacity": capacity,
             "totalCapacity": total_bed_capacity,
             "currentUsageCovid": actual_data.get(CommonFields.CURRENT_HOSPITALIZED),
-            "currentUsageTotal": actual_data.get(CommonFields.CURRENT_HOSPITALIZED_TOTAL),
+            "currentUsageTotal": actual_data.get(
+                CommonFields.CURRENT_HOSPITALIZED_TOTAL
+            ),
             "typicalUsageRate": typical_usage_rate,
         },
         ICUBeds={
@@ -122,6 +124,7 @@ def _generate_actuals(actual_data, intervention) -> _Actuals:
                 CommonFields.ICU_TYPICAL_OCCUPANCY_RATE
             ),
         },
+        contactTracers=actual_data.get(CommonFields.CONTACT_TRACERS_COUNT),
     )
 
 


### PR DESCRIPTION
## Background

See https://trello.com/c/eYwZ8roa/108-add-number-of-tracers-employed-to-our-api and 
https://covidactnow.slack.com/archives/C0110QQAPJA/p1589227207223300

### Please Check
- [x] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated? Not really, docs seem to be in flux
- [x] Are tests passing?
