### PR TITLE
ICU Estimation from Cumulative ICU Data

### DIFF
--- a/pyseir/backtest/backtester.py
+++ b/pyseir/backtest/backtester.py
@@ -30,7 +30,7 @@ class Backtester:
     increases until it reaches max_observation_days_blinded.
     To remove unwanted feature (smooth) of the time series of the
     observation data, one can set window of ts_rolling_args greater than one.
-    To accelorate backtesting, one can set num_days_per_step greater than 1.
+    To accelerate backtesting, one can set num_days_per_step greater than 1.
     However it is recommended that num_days_per_step <= ts_rolling_args[
     'window'] to ensure a good coverage of the time series.
 

--- a/pyseir/parameters/parameter_ensemble_generator.py
+++ b/pyseir/parameters/parameter_ensemble_generator.py
@@ -89,7 +89,6 @@ class ParameterEnsembleGenerator:
             # boxes accordingly. Since we were not modeling different contact
             # rates, this has the same result.
             fraction_asymptomatic = 0
-
             parameter_sets.append(
                 dict(
                     t_list=self.t_list,
@@ -112,23 +111,18 @@ class ParameterEnsembleGenerator:
                         np.random.normal(loc=0.30, scale=0.05) * hospitalization_rate_general, 0
                     ),
                     fraction_icu_requiring_ventilator=max(np.random.normal(loc=0.6, scale=0.1), 0),
-                    sigma=1
-                    / np.random.normal(
-                        loc=3.0, scale=0.86
-                    ),  # Imperial college - 2 days since that is expected infectious period.
-                    delta=1
-                    / np.random.gamma(
-                        6.0, scale=1
-                    ),  # Kind of based on imperial college + CDC digest.
-                    delta_hospital=1
-                    / np.random.gamma(
-                        8.0, scale=1
-                    ),  # Kind of based on imperial college + CDC digest.
+                    sigma=1 / np.random.normal(loc=3.0, scale=0.86),
+                    # Sigma = Imperial college - 2 days since that is expected infectious period.
+                    delta=1 / np.random.gamma(6.0, scale=1),
+                    # Delta = Kind of based on imperial college + CDC digest.
+                    delta_hospital=1 / np.random.gamma(8.0, scale=1),
+                    # delta_hospitalKind of based on imperial college + CDC digest.
                     kappa=1,  # Contact rate for asympt
                     gamma=(1 - fraction_asymptomatic),
                     # https://www.cdc.gov/coronavirus/2019-ncov/hcp/clinical-guidance-management-patients.html
                     symptoms_to_hospital_days=np.random.normal(loc=6.0, scale=1.5),
                     hospitalization_length_of_stay_general=np.random.normal(loc=7, scale=1),
+                    hospitalization_length_of_stay_icu_avg=8.6,  # Weighted avg of icu w & w/o vent
                     hospitalization_length_of_stay_icu=np.random.normal(loc=8, scale=3),
                     hospitalization_length_of_stay_icu_and_ventilator=np.random.normal(
                         loc=9, scale=3


### PR DESCRIPTION
Improve the estimation of current icu covid patients in the case where we are only provided with cumulative icu patients.

Sometimes covidtracking provides cumulative, but not current, data for hospitalization and icu. We then estimate the number of patients currently in the ICU. There are multiple things with this implementation that need to be improved, however they can be done in stages. The first stage is to standardize the calculation of ICU. Right now the estimate uses a variable drawn from a wide distribution (roughly 8.6 +/- 2.6 days). This introduces a large source of noise in the snapshot to snapshot calculations. In other places this code is usually called multiple times and then averaged, but for here it is just called once. Instead of bumping up the call/average, I just calculated the value from the means. The consistency day-to-day is key, especially since this parameter isn't used in any monte-carlo modeling.

I left the hospitalization branch still drawing from the distribution, but averaging over 250 samples. Timeit shows an increase from 8.4ms to 27.2ms. If this becomes significant, we can refactor the params code and surface this constant.

Finally, our new linter just came online, so there will be misc line cleanups for a bit.

This PR addresses issue #<insert number>

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [YES] Are tests passing?
