### PR TITLE
build_processed_data gets test data from combined_datasets

### DIFF
--- a/libs/build_processed_dataset.py
+++ b/libs/build_processed_dataset.py
@@ -4,6 +4,7 @@ import logging
 import sentry_sdk
 from functools import lru_cache
 
+from libs.datasets.combined_datasets import build_us_timeseries_with_all_fields
 from libs.us_state_abbrev import US_STATE_ABBREV
 from libs.us_state_abbrev import abbrev_us_state
 from libs.us_state_abbrev import us_fips
@@ -40,55 +41,48 @@ def _get_interventions_df():
     return pd.DataFrame(list(interventions.items()), columns=columns)
 
 
-@lru_cache(None)
-def _get_testing_df():
-    # TODO: read this from a dataset class
-    ctd_df = CovidTrackingDataSource.local().data
-    # use a string for dates
-    ctd_df["date"] = ctd_df.date.apply(lambda x: x.strftime("%m/%d/%y"))
-    # handle missing data
-    ctd_df[CovidTrackingDataSource.Fields.POSITIVE_TESTS] = ctd_df[
-        CovidTrackingDataSource.Fields.POSITIVE_TESTS
-    ].apply(lambda x: x if pd.isna(x) else int(x))
-    ctd_df[CovidTrackingDataSource.Fields.NEGATIVE_TESTS] = ctd_df[
-        CovidTrackingDataSource.Fields.NEGATIVE_TESTS
-    ].apply(lambda x: x if pd.isna(x) else int(x))
-    ctd_df = ctd_df[CovidTrackingDataSource.TEST_FIELDS]
-    return ctd_df
-
-
-@lru_cache(None)
-def get_cds():
-    cds_df = CDSDataset.local().data
-    cds_df["date"] = cds_df.date.apply(lambda x: x.strftime("%m/%d/%y"))
-    cds_df = cds_df[CDSDataset.TEST_FIELDS]
-    return cds_df
+TEST_FIELDS = [
+    CommonFields.NEGATIVE_TESTS,
+    CommonFields.POSITIVE_TESTS,
+    CommonFields.STATE,
+    CommonFields.DATE,
+]
 
 
 def get_testing_timeseries_by_state(state):
-    testing_df = _get_testing_df()
-    is_state = (
-        testing_df[CovidTrackingDataSource.Fields.AGGREGATE_LEVEL] == AggregationLevel.STATE.value
+    testing_df = (
+        build_us_timeseries_with_all_fields()
+        .get_data(aggregation_level=AggregationLevel.STATE, state=state)
+        .loc[:, (CommonFields.NEGATIVE_TESTS, CommonFields.POSITIVE_TESTS, CommonFields.DATE)]
     )
-    testing_df = testing_df[is_state]
-    # just select state
-    state_testing_df = testing_df[testing_df[CovidTrackingDataSource.Fields.STATE] == state]
-    return state_testing_df[CovidTrackingDataSource.TESTS_ONLY_FIELDS]
+    testing_df.rename(
+        columns={
+            CommonFields.POSITIVE_TESTS: CovidTrackingDataSource.Fields.POSITIVE_TESTS,
+            CommonFields.NEGATIVE_TESTS: CovidTrackingDataSource.Fields.NEGATIVE_TESTS,
+        },
+        inplace=True,
+    )
+    testing_df["date"] = testing_df.date.apply(lambda x: x.strftime("%m/%d/%y"))
+    return testing_df
 
 
 def get_testing_timeseries_by_fips(fips):
-    testing_df = get_cds()
-    # select by fips
-    fips_testing_df = testing_df[testing_df[CDSDataset.Fields.FIPS] == fips]
-    before = len(fips_testing_df)
-    fips_testing_df = fips_testing_df.set_index([CDSDataset.Fields.FIPS, CDSDataset.Fields.DATE])
-    fips_testing_df = fips_testing_df[~fips_testing_df.index.duplicated(keep="last")]
-    if before != len(fips_testing_df):
-        _logger.warning(
-            f"Testing DF contained duplicate rows for {fips}: {before} -> {len(fips_testing_df)}"
-        )
-        sentry_sdk.capture_message(f"Testing DF contained duplicate rows for {fips}")
-    return fips_testing_df
+    """Called by generate_api"""
+    all_data = build_us_timeseries_with_all_fields().data
+    print(all_data.info())
+    testing_df = (
+        build_us_timeseries_with_all_fields()
+        .get_data(fips=fips)
+        .loc[:, CDSDataset.COMMON_TEST_FIELDS]
+    )
+    testing_df[CDSDataset.Fields.TESTED] = (
+        testing_df[CommonFields.NEGATIVE_TESTS] + testing_df[CommonFields.POSITIVE_TESTS]
+    )
+    testing_df.drop(columns=[CommonFields.NEGATIVE_TESTS], inplace=True)
+    all_fields = dict(**CDSDataset.INDEX_FIELD_MAP, **CDSDataset.COMMON_FIELD_MAP)
+    testing_df.rename(columns=all_fields, inplace=True)
+    testing_df.set_index([CDSDataset.Fields.FIPS, CDSDataset.Fields.DATE], inplace=True)
+    return testing_df
 
 
 county_replace_with_null = {"Unassigned": NULL_VALUE}
@@ -175,18 +169,26 @@ def get_usa_by_county_with_projection_df(input_dir, intervention_type):
     return counties
 
 
-def get_usa_by_states_df(input_dir, intervention_type):
+def get_usa_by_states_df(input_dir: str, intervention_type):
     us_only = _get_usa_by_county_df()
     interventions_df = _get_interventions_df()
     projections_df = get_state_projections_df(input_dir, intervention_type, interventions_df)
-    testing_df = _get_testing_df()
+    testing_df = (
+        build_us_timeseries_with_all_fields()
+        .get_data(aggregation_level=AggregationLevel.STATE)
+        .loc[:, (CommonFields.STATE, CommonFields.POSITIVE_TESTS, CommonFields.NEGATIVE_TESTS)]
+    )
     test_max_df = (
-        testing_df.groupby(CommonFields.STATE)[
-            CovidTrackingDataSource.Fields.POSITIVE_TESTS,
-            CovidTrackingDataSource.Fields.NEGATIVE_TESTS,
+        testing_df.groupby(CommonFields.STATE, as_index=False)[
+            [CommonFields.POSITIVE_TESTS, CommonFields.NEGATIVE_TESTS]
         ]
         .max()
-        .reset_index()
+        .rename(
+            columns={
+                CommonFields.POSITIVE_TESTS: CovidTrackingDataSource.Fields.POSITIVE_TESTS,
+                CommonFields.NEGATIVE_TESTS: CovidTrackingDataSource.Fields.NEGATIVE_TESTS,
+            }
+        )
     )
     states_group = us_only.groupby([CommonFields.STATE])
     states_agg = states_group.aggregate(

--- a/libs/build_processed_dataset.py
+++ b/libs/build_processed_dataset.py
@@ -5,6 +5,7 @@ import sentry_sdk
 from functools import lru_cache
 
 from libs.datasets.combined_datasets import build_us_timeseries_with_all_fields
+from libs.enums import Intervention
 from libs.us_state_abbrev import US_STATE_ABBREV
 from libs.us_state_abbrev import abbrev_us_state
 from libs.us_state_abbrev import us_fips
@@ -68,8 +69,6 @@ def get_testing_timeseries_by_state(state):
 
 def get_testing_timeseries_by_fips(fips):
     """Called by generate_api"""
-    all_data = build_us_timeseries_with_all_fields().data
-    print(all_data.info())
     testing_df = (
         build_us_timeseries_with_all_fields()
         .get_data(fips=fips)
@@ -169,10 +168,10 @@ def get_usa_by_county_with_projection_df(input_dir, intervention_type):
     return counties
 
 
-def get_usa_by_states_df(input_dir: str, intervention_type):
+def get_usa_by_states_df(input_dir: str, intervention: Intervention):
     us_only = _get_usa_by_county_df()
     interventions_df = _get_interventions_df()
-    projections_df = get_state_projections_df(input_dir, intervention_type, interventions_df)
+    projections_df = get_state_projections_df(input_dir, intervention.value, interventions_df)
     testing_df = (
         build_us_timeseries_with_all_fields()
         .get_data(aggregation_level=AggregationLevel.STATE)

--- a/libs/datasets/dataset_utils.py
+++ b/libs/datasets/dataset_utils.py
@@ -243,7 +243,7 @@ def add_fips_using_county(data, fips_data) -> pd.Series:
     if len(non_matching):
         unique_counties = sorted(non_matching.county.unique())
         _logger.warning(f"Did not match {len(unique_counties)} counties to fips data.")
-        _logger.warning(f"{unique_counties}")
+        _logger.warning(f"{non_matching}")
         # TODO: Make this an error?
 
     # Handles if a fips column already in the dataframe.
@@ -334,9 +334,16 @@ def fill_fields_with_data_source(
     new_data_in_existing_df = new_data.index.isin(existing_df.index)
 
     if not sum(existing_df_in_new_data) == sum(new_data_in_existing_df):
+        print("Intersection")
         print(new_data.loc[new_data_in_existing_df, columns_to_fill])
+        print("new data not in existing")
+        print(new_data.loc[~new_data.index.isin(existing_df.index), columns_to_fill])
+        if columns_to_fill[0] in existing_df.columns:
+            print("existing not in new")
+            print(existing_df.loc[~existing_df.index.isin(new_data.index), columns_to_fill])
         existing_in_new = sum(existing_df_in_new_data)
         new_in_existing = sum(new_data_in_existing_df)
+        # If this trips consider adding verify_integrity=True to the set_index calls above.
         raise ValueError(
             f"Number of rows should be the for data to replace: {existing_in_new} -> {new_in_existing}: {columns_to_fill}"
         )

--- a/libs/datasets/sources/cds_dataset.py
+++ b/libs/datasets/sources/cds_dataset.py
@@ -64,15 +64,28 @@ class CDSDataset(data_source.DataSource):
     TEST_FIELDS = [
         Fields.COUNTRY,
         Fields.STATE,
-        Fields.COUNTY,
         Fields.FIPS,
         Fields.DATE,
         Fields.CASES,
         Fields.TESTED,
     ]
 
+    COMMON_TEST_FIELDS = [
+        CommonFields.COUNTRY,
+        CommonFields.STATE,
+        CommonFields.FIPS,
+        CommonFields.DATE,
+        CommonFields.POSITIVE_TESTS,
+        CommonFields.NEGATIVE_TESTS,
+    ]
+
     def __init__(self, input_path):
-        data = pd.read_csv(input_path, parse_dates=[self.Fields.DATE])
+        data = pd.read_csv(
+            input_path,
+            parse_dates=[self.Fields.DATE],
+            dtype={self.Fields.FIPS: str},
+            low_memory=False,
+        )
         data = self.standardize_data(data)
         super().__init__(data)
 
@@ -111,20 +124,26 @@ class CDSDataset(data_source.DataSource):
         # The following abbrev mapping only makes sense for the US
         # TODO: Fix all missing cases
         data = data[data["country"] == "United States"]
-        data["state_abbr"] = data[cls.Fields.STATE].apply(
+        data[CommonFields.COUNTRY] = "USA"
+        data[CommonFields.STATE] = data[cls.Fields.STATE].apply(
             lambda x: US_STATE_ABBREV[x] if x in US_STATE_ABBREV else x
         )
-        data["state_tmp"] = data["state"]
-        data["state"] = data["state_abbr"]
 
         fips_data = dataset_utils.build_fips_data_frame()
         data = dataset_utils.add_fips_using_county(data, fips_data)
+        no_fips = data[CommonFields.FIPS].isna()
+        if no_fips.sum() > 0:
+            logging.warning(f"Removing rows without fips id: {str(data.loc[no_fips])}")
+            data = data.loc[~no_fips]
+
+        data.set_index(["date", "fips"], inplace=True)
+        if data.index.has_duplicates:
+            logging.warning(f"Removing duplicates: {str(data.index.duplicated(keep=False))}")
+            data = data.loc[~data.index.duplicated(keep=False)]
+        data.reset_index(inplace=True)
 
         # ADD Negative tests
         data[cls.Fields.NEGATIVE_TESTS] = data[cls.Fields.TESTED] - data[cls.Fields.CASES]
-
-        # put the state column back
-        data["state"] = data["state_tmp"]
 
         return data
 

--- a/libs/datasets/sources/cds_dataset.py
+++ b/libs/datasets/sources/cds_dataset.py
@@ -133,12 +133,14 @@ class CDSDataset(data_source.DataSource):
         data = dataset_utils.add_fips_using_county(data, fips_data)
         no_fips = data[CommonFields.FIPS].isna()
         if no_fips.sum() > 0:
-            logging.warning(f"Removing rows without fips id: {str(data.loc[no_fips])}")
+            logging.error(f"Removing rows without fips id: {str(data.loc[no_fips])}")
             data = data.loc[~no_fips]
 
         data.set_index(["date", "fips"], inplace=True)
         if data.index.has_duplicates:
-            logging.warning(f"Removing duplicates: {str(data.index.duplicated(keep=False))}")
+            # Use keep=False when logging so the output contains all duplicated rows, not just the first or last
+            # instance of each duplicate.
+            logging.error(f"Removing duplicates: {str(data.index.duplicated(keep=False))}")
             data = data.loc[~data.index.duplicated(keep=False)]
         data.reset_index(inplace=True)
 

--- a/libs/datasets/sources/covid_tracking_source.py
+++ b/libs/datasets/sources/covid_tracking_source.py
@@ -12,6 +12,7 @@ _logger = logging.getLogger(__name__)
 
 
 class CovidTrackingDataSource(data_source.DataSource):
+    # This
     DATA_PATH = "data/covid-tracking/covid_tracking_states.csv"
     SOURCE_NAME = "covid_tracking"
 

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -150,8 +150,12 @@ class TimeseriesDataset(dataset_base.DatasetBase):
         pd_data = self.get_subset(AggregationLevel.STATE, state=state).data
         return pd_data.where(pd.notnull(pd_data), None).to_dict(orient="records")
 
-    def get_data(self, country=None, state=None, fips=None, states=None) -> pd.DataFrame:
+    def get_data(
+        self, aggregation_level=None, country=None, state=None, fips=None, states=None
+    ) -> pd.DataFrame:
         data = self.data
+        if aggregation_level:
+            data = data[data.aggregate_level == aggregation_level.value]
         if country:
             data = data[data.country == country]
         if state:
@@ -177,6 +181,7 @@ class TimeseriesDataset(dataset_base.DatasetBase):
         Returns: Timeseries object.
         """
         data = source.data
+        # TODO(tom): Do this renaming upstream, when the source is loaded or when first copied from the third party.
         to_common_fields = {value: key for key, value in source.all_fields_map().items()}
         final_columns = to_common_fields.values()
         data = data.rename(columns=to_common_fields)[final_columns]

--- a/libs/pipelines/api_pipeline.py
+++ b/libs/pipelines/api_pipeline.py
@@ -74,7 +74,7 @@ def run_projections(
 
     if aggregation_level == AggregationLevel.STATE:
         states_key_name = f"states.{intervention.name}"
-        states_df = build_processed_dataset.get_usa_by_states_df(input_file, intervention.value)
+        states_df = build_processed_dataset.get_usa_by_states_df(input_file, intervention)
         if run_validation:
             validate_results.validate_states_df(states_key_name, states_df)
 

--- a/test/build_processed_data_test.py
+++ b/test/build_processed_data_test.py
@@ -17,7 +17,7 @@ def test_get_usa_by_states_df():
         "libs.build_processed_dataset.get_state_projections_df", return_value=empty_df_with_state
     ):
         df = build_processed_dataset.get_usa_by_states_df(
-            input_dir="/tmp", intervention_type=Intervention.OBSERVED_INTERVENTION
+            input_dir="/tmp", intervention=Intervention.OBSERVED_INTERVENTION
         )
     validate_results.validate_states_df("TX", df)
 

--- a/test/build_processed_data_test.py
+++ b/test/build_processed_data_test.py
@@ -17,7 +17,7 @@ def test_get_usa_by_states_df():
         "libs.build_processed_dataset.get_state_projections_df", return_value=empty_df_with_state
     ):
         df = build_processed_dataset.get_usa_by_states_df(
-            input_dir="/tmp", intervention_type=Intervention.OBSERVED_INTERVENTION.value
+            input_dir="/tmp", intervention_type=Intervention.OBSERVED_INTERVENTION
         )
     validate_results.validate_states_df("TX", df)
 
@@ -40,10 +40,8 @@ def test_get_testing_df_by_state():
     assert 0 < df.at["2020-04-10", negative_field] < df.at["2020-05-01", negative_field]
 
 
-# Check San Francisco/06075 and Houston (Harris County, TX)/48201
-@pytest.mark.parametrize(
-    "fips", ["06075", "48201"],
-)
+# Check some counties picked arbitrarily: San Francisco/06075 and Houston (Harris County, TX)/48201
+@pytest.mark.parametrize("fips", ["06075", "48201"])
 def test_get_testing_by_fips(fips):
     df = build_processed_dataset.get_testing_timeseries_by_fips(fips)
 

--- a/test/combined_dataset_test.py
+++ b/test/combined_dataset_test.py
@@ -36,8 +36,8 @@ def test_combined_county_has_some_data(fips):
     latest = combined_datasets.build_us_latest_with_all_fields().get_subset(
         AggregationLevel.COUNTY, fips=fips
     )
-    assert latest.data[CommonFields.POSITIVE_TESTS] > 0
-    assert latest.data[CommonFields.NEGATIVE_TESTS] > 0
+    assert latest.data[CommonFields.POSITIVE_TESTS].all()
+    assert latest.data[CommonFields.NEGATIVE_TESTS].all()
 
 
 # Check some counties picked arbitrarily: San Francisco/06075 and Houston (Harris County, TX)/48201


### PR DESCRIPTION
## Background

https://trello.com/c/tQj1yUjh/145-cds-data-source-missing-proper-county-level-data

https://github.com/covid-projections/covid-data-model/pull/438 added tests.

## This PR

Changes build_processed_data to get COVID negative/positive test data from combined_datasets instead of directly from the data source classes. It mostly transforms the columns back to their original form to reduce the chance of accidentally breaking code that depends on the current return value.

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [ ] Are tests passing?
