### PR TITLE
clean lint and upgrade pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+# Per https://stackoverflow.com/a/42281313/341400
+python_classes=NoThanksNoClassDiscovery

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ certifi==2019.11.28
 chardet==3.0.4
 cycler==0.10.0
 idna==2.9
-isort==4.3.4
+isort==4.3.21
 kiwisolver==1.1.0
 lazy-object-proxy==1.3.1
 GitPython==3.1.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,11 +1,11 @@
 # Requirements file containing packages needed for testing.
 # These should *not* be installed in non-test environments.
 
-pytest==4.6.3
-pytest-pylint==0.14.1
+pytest==5.4.2
+pytest-pylint==0.17.0
 pytest-xdist==1.32.0
 pytest-mock >= 1.10.4
 black==19.10b0
 nbstripout==0.3.7
-pylint==2.4.4
+pylint==2.5.2
 pre-commit==2.3.0

--- a/run.py
+++ b/run.py
@@ -20,10 +20,13 @@ from libs.datasets import dataset_cache
 
 @click.group()
 @click.pass_context
-def entry_point(ctx):
+# Disable pylint warning as suggested by https://stackoverflow.com/a/49680253
+def entry_point(ctx):  # pylint: disable=no-value-for-parameter
     """Entry point for covid-data-model CLI."""
     with sentry_sdk.configure_scope() as scope:
         scope.set_tag("command", ctx.invoked_subcommand)
+        # changes applied to scope remain after scope exits. See
+        # https://github.com/getsentry/sentry-python/issues/184
 
 
 # adding the QA command
@@ -34,6 +37,10 @@ entry_point.add_command(run_counties_api.deploy_counties_api)
 entry_point.add_command(run_states_api.deploy_states_api)
 entry_point.add_command(api.main)
 
+
+# This code is executed when invoked as `python run.py ...` and will need to be changed if you
+# want to add run.py to setup.py entry_points console_scripts. See
+# https://github.com/pallets/click/issues/571#issuecomment-216261699
 if __name__ == "__main__":
     sentry_sdk.init(os.getenv("SENTRY_DSN"))
 
@@ -41,7 +48,7 @@ if __name__ == "__main__":
     dataset_cache.set_pickle_cache_tempdir()
     pandarallel.initialize(progress_bar=False)
     try:
-        entry_point()
+        entry_point()  # pylint: disable=no-value-for-parameter
     except Exception as e:
         # blanket catch exceptions at the entry point and send them to sentry
         sentry_sdk.capture_exception(e)


### PR DESCRIPTION
This PR fixes some lint warnings introduced recently and fixes version conflicts in the requirements files.

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [ ] Are tests passing?
