### PR TITLE
Improve Dataset Caching

### DIFF
--- a/libs/datasets/dataset_cache.py
+++ b/libs/datasets/dataset_cache.py
@@ -1,4 +1,5 @@
-from typing import Dict, Type, List
+from typing import Type
+import functools
 import os
 import tempfile
 import pathlib
@@ -7,7 +8,10 @@ import time
 import pandas as pd
 from libs.datasets import dataset_base
 
-
+# Defaulting cache dir to pyseir_data folder for convenience.
+# Note: this means that in development, data will be cached by default to
+# pyseir_data.
+DEFAULT_CACHE_DIR = "pyseir_data"
 PICKLE_CACHE_ENV_KEY = "PICKLE_CACHE_DIR"
 
 _EXISTING_CACHE_KEYS = set()
@@ -16,29 +20,30 @@ _EXISTING_CACHE_KEYS = set()
 _logger = logging.getLogger(__name__)
 
 
-def set_pickle_cache_tempdir(force=False) -> str:
-    """Sets the cache dir to a temporary directory.
+def set_pickle_cache_dir(force=False, cache_dir=DEFAULT_CACHE_DIR) -> str:
+    """Sets the cache dir to default cache directory.
 
     Note that the directory does not clean up after itself.
 
     Args:
         force: If True, will force a cache key to be a new tempdir
             if key already exists.
+        cache_dir: default directory, if None will set to a temporary directory.
     """
 
     if os.getenv(PICKLE_CACHE_ENV_KEY) and not force:
         directory = os.getenv(PICKLE_CACHE_ENV_KEY)
-        _logger.info(f"Using existing pickle cache tmpdir to {directory}")
+        _logger.info(f"Using existing pickle cache tmpdir: {directory}")
         return directory
 
-    tempdir = tempfile.mkdtemp()
-    os.environ[PICKLE_CACHE_ENV_KEY] = tempdir
-    _logger.info(f"Setting pickle cache tmpdir to {tempdir}")
-    return tempdir
+    cache_dir = cache_dir or tempfile.mkdtemp()
+    os.environ[PICKLE_CACHE_ENV_KEY] = cache_dir
+    _logger.info(f"Setting {PICKLE_CACHE_ENV_KEY} to {cache_dir}.")
+    return cache_dir
 
 
 def cache_dataset_on_disk(
-    target_dataset_cls: Type[dataset_base.DatasetBase], max_age_in_minutes=30, key=None
+    target_dataset_cls: Type[dataset_base.DatasetBase], max_age_in_minutes=60, key=None
 ):
     """Caches underlying pandas data from to an on disk location.
 
@@ -51,17 +56,29 @@ def cache_dataset_on_disk(
     def decorator(func):
         cache_key = key or func.__name__
 
-        if cache_key in _EXISTING_CACHE_KEYS:
+        # Don't raise an error if the cache dir isn't set to prevent errors when developing
+        # locally and running code in jupyter notebooks with autoreload set to true.
+        if os.getenv(PICKLE_CACHE_ENV_KEY) and cache_key in _EXISTING_CACHE_KEYS:
             raise ValueError(
                 f"Have already wrapped a function with the key name: {func.__name__}. "
                 "Please specify a different key."
             )
         _EXISTING_CACHE_KEYS.add(cache_key)
 
+        # load cache once per decorator.  If cache dir is not set, this will always be None.
+        _loaded_cache = None
+
+        @functools.wraps(func)
         def f() -> target_dataset_cls:
+            nonlocal _loaded_cache
+
             pickle_cache_dir = os.getenv(PICKLE_CACHE_ENV_KEY)
+
             if not pickle_cache_dir:
                 return func()
+
+            if _loaded_cache is not None:
+                return _loaded_cache
 
             cache_path = pathlib.Path(pickle_cache_dir) / (cache_key + ".pickle")
 
@@ -69,12 +86,15 @@ def cache_dataset_on_disk(
                 modified_time = cache_path.stat().st_mtime
                 cache_age_in_minutes = (time.time() - modified_time) / 60
                 if cache_age_in_minutes < max_age_in_minutes:
-                    return target_dataset_cls(pd.read_pickle(cache_path))
+                    _logger.info(f"Loading {func.__name__} from on disk cache at {cache_path}")
+                    _loaded_cache = target_dataset_cls(pd.read_pickle(cache_path))
+                    return _loaded_cache
                 else:
-                    _logger.debug(f"Cache expired, reloading.")
+                    _logger.info("Cache expired, reloading.")
 
             dataset = func()
             dataset.data.to_pickle(cache_path)
+            _loaded_cache = dataset
             return dataset
 
         return f

--- a/pyseir/cli.py
+++ b/pyseir/cli.py
@@ -57,7 +57,7 @@ def _cache_global_datasets():
 @click.group()
 def entry_point():
     """Basic entrypoint for cortex subcommands"""
-    dataset_cache.set_pickle_cache_tempdir()
+    dataset_cache.set_pickle_cache_dir()
     sentry_sdk.init(os.getenv("SENTRY_DSN"))
 
 

--- a/run.py
+++ b/run.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
     sentry_sdk.init(os.getenv("SENTRY_DSN"))
 
     logging.basicConfig(level=logging.INFO)
-    dataset_cache.set_pickle_cache_tempdir()
+    dataset_cache.set_pickle_cache_dir()
     pandarallel.initialize(progress_bar=False)
     try:
         entry_point()  # pylint: disable=no-value-for-parameter

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-  
+
 #!/bin/bash
 # run.sh - Runs everything necessary to generate our API artifacts (for
 # website, external consumers, etc.) based on our inputs (from

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,4 +4,6 @@ from libs.datasets import dataset_cache
 
 @pytest.fixture(scope="session", autouse=True)
 def set_timeseries_dataset_cache():
-    dataset_cache.set_pickle_cache_tempdir()
+    # Forcing cache to use a new folder to always regenerate cache
+    # during tests.
+    dataset_cache.set_pickle_cache_dir(force=True, cache_dir=None)


### PR DESCRIPTION
Made a few improvements to the dataset cache after getting to use it some more:

- Set the default directory to be `pyseir_data` (where we load other intermediate cached data) - this replaces the tmpdir meaning that users won't have to have the environment variable set to get the effects of the cache on multiple runs.  If people are doing work locally it will be much faster.
- Load the result of the function call instead of reading it from disk every time. I noticed in profiling a lot of the time was spent reading from disk.
- Increase the time to one hour before reloading - reduces the number of times that the cache has to be reloaded
- Added some more clear logging to make it easier to understand if the combined dataset results are being loaded from a cache or not