### PR TITLE
Added Jupyter Lab to Requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cycler==0.10.0
 idna==2.9
 isort==4.3.21
 kiwisolver==1.1.0
-lazy-object-proxy==1.3.1
+lazy-object-proxy==1.4.1
 GitPython==3.1.0
 numpy==1.18.2
 matplotlib==3.2.1
@@ -17,7 +17,7 @@ pyshp==2.1.0
 pymc3==3.8
 requests==2.23.0
 jupyter==1.0.0
-jupyterlab
+jupyterlab==2.1.4
 simplejson==3.17.0
 ujson==2.0.3
 boto3==1.12.28

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ pyshp==2.1.0
 pymc3==3.8
 requests==2.23.0
 jupyter==1.0.0
+jupyterlab
 simplejson==3.17.0
 ujson==2.0.3
 boto3==1.12.28


### PR DESCRIPTION
Thought I'd bring up a quick package managing question (everyone's favorite thing).

I added the newer version of jupyter (jupyterlab) to requirements.

If it was a heavier lift I'd say that all the debug tools like jupyter/jupyterlab don't need to be in the remote build, but I don't think it's too bad atm.

Also, @ghop02 did we get burned sometime in the past and decided to pin everything? I don't particularly want to sign up for us using poetry or pipenv. Just curious.

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [YES] Are tests passing?
