### PR TITLE
Revert "Added Jupyter Lab to Requirements.txt"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cycler==0.10.0
 idna==2.9
 isort==4.3.21
 kiwisolver==1.1.0
-lazy-object-proxy==1.4.1
+lazy-object-proxy==1.3.1
 GitPython==3.1.0
 numpy==1.18.2
 matplotlib==3.2.1
@@ -17,7 +17,6 @@ pyshp==2.1.0
 pymc3==3.8
 requests==2.23.0
 jupyter==1.0.0
-jupyterlab==2.1.4
 simplejson==3.17.0
 ujson==2.0.3
 boto3==1.12.28


### PR DESCRIPTION
This is the only commit between scheduled snapshot builds 400 and 401. Build 401 broke in a pandas dataframe merge. It's not clear why it broke now. but more debug on a branch is warranted.