### PR TITLE
use covid tracking date column, revert data pins

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -20,8 +20,7 @@ env:
   COVID_DATA_MODEL_REF: 'master'
 
   # To pin to an old data sets, put the branch/tag/commit here:
-  #TODO(tom): Put back to master once latest breakage addressed.
-  COVID_DATA_PUBLIC_REF: '1c7ae4c874debe48d31af281a4611a1f72a552b4'
+  COVID_DATA_PUBLIC_REF: 'master'
 
   # S3 Bucket (used by s3-sync-action tasks) to store final API snapshot.
   AWS_S3_BUCKET: 'data.covidactnow.org'

--- a/.github/workflows/python_unit_tests.yml
+++ b/.github/workflows/python_unit_tests.yml
@@ -16,8 +16,7 @@ jobs:
 
   build:
     env:
-      #TODO(tom): Put back to master once latest breakage addressed.
-      COVID_DATA_PUBLIC_REF: '1c7ae4c874debe48d31af281a4611a1f72a552b4'
+      COVID_DATA_PUBLIC_REF: 'master'
 
     runs-on: ubuntu-latest
     strategy:

--- a/libs/datasets/sources/covid_tracking_source.py
+++ b/libs/datasets/sources/covid_tracking_source.py
@@ -111,9 +111,7 @@ class CovidTrackingDataSource(data_source.DataSource):
         data[cls.Fields.COUNTY] = None
         data[cls.Fields.COUNTRY] = "USA"
         data[cls.Fields.AGGREGATE_LEVEL] = AggregationLevel.STATE.value
-        # Date checked is the time that the data is actually updated.
-        # assigning the date field as the date floor of that day.
-        data[cls.Fields.DATE] = data[cls.Fields.DATE_CHECKED].dt.tz_localize(None).dt.floor("D")
+        data[cls.Fields.DATE] = pd.to_datetime(data[cls.Fields.DATE], format="%Y%m%d")
 
         dtypes = {
             cls.Fields.POSITIVE_TESTS: "Int64",

--- a/libs/datasets/sources/covid_tracking_source.py
+++ b/libs/datasets/sources/covid_tracking_source.py
@@ -96,7 +96,10 @@ class CovidTrackingDataSource(data_source.DataSource):
 
     def __init__(self, input_path):
         data = pd.read_csv(
-            input_path, parse_dates=[self.Fields.DATE_CHECKED], dtype={self.Fields.FIPS: str},
+            input_path,
+            parse_dates=[self.Fields.DATE],
+            dtype={self.Fields.FIPS: str},
+            date_parser=lambda col: pd.to_datetime(col, format="%Y%m%d"),
         )
         data = self.standardize_data(data)
         super().__init__(data)
@@ -111,7 +114,6 @@ class CovidTrackingDataSource(data_source.DataSource):
         data[cls.Fields.COUNTY] = None
         data[cls.Fields.COUNTRY] = "USA"
         data[cls.Fields.AGGREGATE_LEVEL] = AggregationLevel.STATE.value
-        data[cls.Fields.DATE] = pd.to_datetime(data[cls.Fields.DATE], format="%Y%m%d")
 
         dtypes = {
             cls.Fields.POSITIVE_TESTS: "Int64",

--- a/test/combined_dataset_test.py
+++ b/test/combined_dataset_test.py
@@ -59,7 +59,9 @@ def test_unique_timeseries(data_source_cls):
     data_source = data_source_cls.local()
     timeseries = TimeseriesDataset.build_from_data_source(data_source)
     timeseries = combined_datasets.US_STATES_FILTER.apply(timeseries)
-    timeseries_data = timeseries.data.set_index(timeseries.INDEX_FIELDS)
+    # Check for duplicate rows with the same INDEX_FIELDS. Sort by index so duplicates are next to
+    # each other in the output.
+    timeseries_data = timeseries.data.set_index(timeseries.INDEX_FIELDS).sort_index()
     duplicates = timeseries_data.index.duplicated(keep=False)
     assert not sum(duplicates), str(timeseries_data.loc[duplicates])
 

--- a/test/combined_dataset_test.py
+++ b/test/combined_dataset_test.py
@@ -60,7 +60,7 @@ def test_unique_timeseries(data_source_cls):
     timeseries = TimeseriesDataset.build_from_data_source(data_source)
     timeseries = combined_datasets.US_STATES_FILTER.apply(timeseries)
     # Check for duplicate rows with the same INDEX_FIELDS. Sort by index so duplicates are next to
-    # each other in the output.
+    # each other in the message if the assert fails.
     timeseries_data = timeseries.data.set_index(timeseries.INDEX_FIELDS).sort_index()
     duplicates = timeseries_data.index.duplicated(keep=False)
     assert not sum(duplicates), str(timeseries_data.loc[duplicates])


### PR DESCRIPTION
## Background

See https://trello.com/c/1HA3Egdm/189-adding-jupyterlab-appears-to-break-build-all-at-the-moment and https://covidactnow.slack.com/archives/C0110QQAPJA/p1591105732043200

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [ ] Are tests passing?
