### PR TITLE
Updates kinsa notebook with better visualizations, timelag analysis.

### DIFF
--- a/notebooks/data_loading/kinsa_api_rt_comparison.ipynb
+++ b/notebooks/data_loading/kinsa_api_rt_comparison.ipynb
@@ -11,8 +11,7 @@
     "import pandas as pd\n",
     "import pathlib\n",
     "import requests\n",
-    "import us\n",
-    "%matplotlib inline"
+    "import us\n"
    ]
   },
   {
@@ -37,8 +36,7 @@
     "        records = r.json()\n",
     "        df = pd.DataFrame.from_records(data=records['data'], columns=records['columns'])\n",
     "        df['date']= pd.to_datetime(df['date'])\n",
-    "        return df\n",
-    "\n"
+    "        return df"
    ]
   },
   {
@@ -65,13 +63,6 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "def plot_kinsa_vs_rt(state_identifier: str, rt_df: pd.DataFrame, ax=None):\n",
     "        state = us.states.lookup(state_identifier)\n",
@@ -80,7 +71,8 @@
     "            kwargs = dict(use_index=True, title=state.name)\n",
     "            if ax:\n",
     "                kwargs[\"ax\"] = ax\n",
-    "            combined_df.plot(x='date', y=[\"atypical_ili\", \"RtIndicator\"], **kwargs )\n",
+    "            combined_df.plot(x='date', y=[\"atypical_ili\"], **kwargs )\n",
+    "            combined_df.plot(x=\"date\", y=[\"RtIndicator\"], secondary_y=True, **kwargs)\n",
     "    \n",
     "def get_combined_kinsa_rt_df(state_identifier: str, rt_df: pd.DataFrame):\n",
     "    state = us.states.lookup(state_identifier)\n",
@@ -95,14 +87,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "state_abreviation='NY'\n",
-    "df = get_kinsa_state_data(state_abreviation)\n",
-    "kinsa_ny_df = df.dropna().groupby(\"date\").mean()"
+    "# Plot atypical_ili against daily cases, all 50 states: "
    ]
   },
   {
@@ -111,73 +99,32 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_kinsa_vs_rt(\"Wisconsin\", rt_df)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig, ax = plt.subplots(nrows=10, ncols=5)\n",
+    "fig, ax = plt.subplots(nrows=11, ncols=5)\n",
     "states_to_correlation_coefficients = dict()\n",
-    "for i in range(10):\n",
-    "    for j in range(5):\n",
-    "        idx = int(i*(i+1)/2 + j)\n",
-    "        state = us.STATES[idx]\n",
-    "        axij = ax[i,j]\n",
-    "        axij.set_title(state.name)\n",
-    "        combined_df = get_combined_kinsa_rt_df(state.abbr, rt_df)\n",
-    "        if combined_df is not None:\n",
-    "            combined_df.plot(x='date', y=[\"atypical_ili\",], ax=axij)\n",
-    "            combined_df.plot(x='date', y=[\"RtIndicator\"],secondary_y=True, ax=axij)\n",
-    "\n",
-    "            axij.legend().remove()\n",
+    "i=0\n",
+    "for j, state in enumerate(us.STATES):\n",
+    "    if  j > 0 and not j % 5:\n",
+    "        i+=1\n",
+    "    axij = ax[i, j % 5]\n",
+    "    axij.set_title(state.name)\n",
+    "    combined_df = get_combined_kinsa_rt_df(state.abbr, rt_df)\n",
+    "    if combined_df is not None:\n",
+    "        combined_df.plot(x='date', y=[\"atypical_ili\",], ax=axij, )\n",
+    "        combined_df.groupby(\"date\").sum()[['cumulativeInfected']].diff(1).plot(y=\"cumulativeInfected\", \n",
+    "                                                                               label='dailyCases',\n",
+    "                                                                               secondary_y=True, ax=axij)\n",
+    "        axij.legend().remove()\n",
     "\n",
     "\n",
     "fig.set_size_inches(18.5, 30.5, forward=True)\n",
-    "fig.subplots_adjust(hspace=1.7)\n",
-    "fig"
+    "fig.subplots_adjust(hspace=1.7)\n"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
-    "fig, ax = plt.subplots()\n",
-    "ny_df.plot(ax=ax, x=\"date\", y=\"atypical_ili\")\n",
-    "ny_df.plot(ax=ax, x=\"date\", y=\"dailyInfected\", secondary_y=True)"
+    "# Plot atypical_ili against rt values, all 50 states"
    ]
   },
   {
@@ -186,9 +133,79 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ny_df[\"dailyInfected\"] = ny_df.cumulativeInfected.diff(1).apply(lambda x:  0 if x < 0 else x )\n",
-    "ny_df[\"dailyDeaths\"] = ny_df.cumulativeDeaths.diff(1).apply(lambda x:  0 if x < 0 else x )\n"
+    "fig, ax = plt.subplots(nrows=11, ncols=5)\n",
+    "states_to_correlation_coefficients = dict()\n",
+    "i=0\n",
+    "for j, state in enumerate(us.STATES):\n",
+    "    if  j > 0 and not j % 5:\n",
+    "        i+=1\n",
+    "    axij = ax[i, j % 5]\n",
+    "    axij.set_title(state.name)\n",
+    "    combined_df = get_combined_kinsa_rt_df(state.abbr, rt_df)\n",
+    "    if combined_df is not None:\n",
+    "        combined_df.plot(x='date', y=[\"atypical_ili\",], ax=axij)\n",
+    "        combined_df.plot(x='date', y=[\"RtIndicator\"],secondary_y=True, ax=axij)\n",
+    "        axij.legend().remove()\n",
+    "\n",
+    "\n",
+    "fig.set_size_inches(18.5, 30.5, forward=True)\n",
+    "fig.subplots_adjust(hspace=1.7)\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Find timeshift needed to align series for rt and atypcal_ili"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyseir.inference.infer_rt import RtInferenceEngine "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "timeshifts=[]\n",
+    "for state in us.STATES:\n",
+    "    combined_df = get_combined_kinsa_rt_df(state.abbr, rt_df)\n",
+    "    shift_in_days=None\n",
+    "    if combined_df is not None and not combined_df.empty: \n",
+    "        shift_in_days = RtInferenceEngine.align_time_series(series_a=combined_df[\"atypical_ili\"], series_b=combined_df[\"RtIndicator\"],)\n",
+    "    timeshifts.append((state.name, shift_in_days))\n",
+    "timeshifts = pd.DataFrame(data=timeshifts, columns = [\"stateName\", \"rt_atypical_ili_shift_days\"] )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "timeshifts.hist()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -202,6 +219,14 @@
    "metadata": {},
    "source": [
     "# Analysis with State-level aggregation kinsa data (one-off)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A csv file was provided by kinsa with state-level data and that is shown below. Preliminary analysis indicates this data does not significantly deviate \n",
+    "from an aggregation of the county level data (aggregated) from the kinsa api. "
    ]
   },
   {
@@ -221,7 +246,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "kinsa_state_df"
+    "kinsa_state_df.head()"
    ]
   },
   {
@@ -240,7 +265,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "combined_state_df"
+   ]
   },
   {
    "cell_type": "code",
@@ -248,20 +275,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(nrows=10, ncols=5)\n",
+    "fig, ax = plt.subplots(nrows=11, ncols=5)\n",
     "states_to_correlation_coefficients = dict()\n",
-    "for i in range(10):\n",
-    "    for j in range(5):\n",
-    "        idx = int(i*(i+1)/2 + j)\n",
-    "        state = us.STATES[idx]\n",
-    "        axij = ax[i,j]\n",
-    "        axij.set_title(state.name)\n",
-    "        state_df = combined_state_df[combined_state_df.state_abbr==state.abbr]\n",
-    "        if state_df is not None:\n",
-    "            state_df.plot(x='date', y=[\"percent_ill\",], ax=axij)\n",
-    "            state_df.plot(x='date', y=[ \"RtIndicator\"], ax=axij, secondary_y=True)\n",
+    "i=0\n",
+    "for j, state in enumerate(us.STATES):\n",
+    "    if  j > 0 and not j % 5:\n",
+    "        i+=1\n",
+    "    axij = ax[i, j % 5]\n",
+    "    axij.set_title(state.name)\n",
+    "    state_df = combined_state_df[combined_state_df.state_abbr==state.abbr]\n",
+    "    if state_df is not None:\n",
+    "        state_df.plot(x='date', y=[\"atypical_ili_median\",], ax=axij)\n",
+    "        state_df.plot(x='date', y=[ \"RtIndicator\"], ax=axij, secondary_y=True)\n",
     "\n",
-    "            axij.legend().remove()\n",
+    "        axij.legend().remove()\n",
     "\n",
     "\n",
     "fig.set_size_inches(18.5, 30.5, forward=True)\n",
@@ -270,15 +297,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "Next steps: \n",
-    "    * calcualte delay per state and look at average trend -- hard to do given lack of historical - we could compare peaks though\n",
-    "    * "
-   ]
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This PR contains a few improvements to the kinsa investigation notebook: 
* deduplicates graphs across states 
* standardizes on atypical_ili across the board
* adds plots of atypical_ili against daily cases (not smoothed)
* preliminary time lag analysis with rt values. 
