### PR TITLE
Sync field name in CmdcDataSource with Cmdc in covid-public-data repo

### DIFF
--- a/libs/datasets/sources/cmdc.py
+++ b/libs/datasets/sources/cmdc.py
@@ -23,6 +23,7 @@ class CmdcDataSource(data_source.DataSource):
         CommonFields.NEGATIVE_TESTS: CommonFields.NEGATIVE_TESTS,
         CommonFields.POSITIVE_TESTS: CommonFields.POSITIVE_TESTS,
         CommonFields.CURRENT_VENTILATED: CommonFields.CURRENT_VENTILATED,
+        CommonFields.CURRENT_HOSPITALIZED: CommonFields.CURRENT_HOSPITALIZED,
     }
 
     @classmethod


### PR DESCRIPTION
* add CmdcDataSource COMMON_FIELD_MAP.CommonFields.CURRENT_HOSPITALIZED

Depends on https://github.com/covid-projections/covid-data-public/pull/57 for tests to pass

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [ ] Are tests passing?
