### PR TITLE
Refactor/remove convert cumulatives to current

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -9,7 +9,7 @@ on:
   schedule:
    - cron: '30 0,12 * * *'
 
-  push:
+  # push:
   # Hook to trigger a manual run.
   # See: https://goobar.io/2019/12/07/manually-trigger-a-github-actions-workflow/
   repository_dispatch:
@@ -17,7 +17,7 @@ on:
 
 env:
   # !!! Change this to your BRANCH if you want to test it
-  COVID_DATA_MODEL_REF: 'refactor/remove-convert-cumulatives-to-current'
+  COVID_DATA_MODEL_REF: 'master'
 
   # To pin to an old data sets, put the branch/tag/commit here:
   COVID_DATA_PUBLIC_REF: 'master'

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -9,7 +9,7 @@ on:
   schedule:
    - cron: '30 0,12 * * *'
 
-  # push:
+  push:
   # Hook to trigger a manual run.
   # See: https://goobar.io/2019/12/07/manually-trigger-a-github-actions-workflow/
   repository_dispatch:
@@ -17,7 +17,7 @@ on:
 
 env:
   # !!! Change this to your BRANCH if you want to test it
-  COVID_DATA_MODEL_REF: 'master'
+  COVID_DATA_MODEL_REF: 'refactor/remove-convert-cumulatives-to-current'
 
   # To pin to an old data sets, put the branch/tag/commit here:
   COVID_DATA_PUBLIC_REF: 'master'

--- a/pyseir/deployment/webui_data_adaptor_v1.py
+++ b/pyseir/deployment/webui_data_adaptor_v1.py
@@ -69,12 +69,12 @@ class WebUIDataAdaptorV1:
         If current data is available, we return that.
         If not, current values are estimated from cumulative.
         """
-        county_hosp = load_data.get_current_hospitalized_for_county(
+        _, county_hosp = load_data.get_current_hospitalized(
             fips, t0_simulation, category=load_data.HospitalizationCategory.HOSPITALIZED,
-        )[1]
-        county_icu = load_data.get_current_hospitalized_for_county(
+        )
+        _, county_icu = load_data.get_current_hospitalized(
             fips, t0_simulation, category=load_data.HospitalizationCategory.ICU
-        )[1]
+        )
 
         return county_hosp, county_icu
 
@@ -105,20 +105,19 @@ class WebUIDataAdaptorV1:
         hosp_rescaling_factor
         icu_rescaling_factor
         """
-        t_latest_hosp_data, current_hosp_count = load_data.get_current_hospitalized_for_state(
-            state=self.state_abbreviation,
+        state_fips = fips[:2]
+
+        t_latest_hosp_data, current_hosp_count = load_data.get_current_hospitalized(
+            fips=state_fips,
             t0=t0_simulation,
             category=load_data.HospitalizationCategory.HOSPITALIZED,
         )
 
-        _, current_state_icu = load_data.get_current_hospitalized_for_state(
-            state=self.state_abbreviation,
-            t0=t0_simulation,
-            category=load_data.HospitalizationCategory.ICU,
+        _, current_state_icu = load_data.get_current_hospitalized(
+            fips=state_fips, t0=t0_simulation, category=load_data.HospitalizationCategory.ICU,
         )
 
         if current_hosp_count is not None:
-            state_fips = fips[:2]
             t_latest_hosp_data_date = t0_simulation + timedelta(days=int(t_latest_hosp_data))
 
             state_hosp_gen = load_data.get_compartment_value_on_date(
@@ -141,7 +140,7 @@ class WebUIDataAdaptorV1:
                 inferred_county_hosp = load_data.get_compartment_value_on_date(
                     fips=fips,
                     compartment="HGen",
-                    date=t_latest_hosp_data_date,
+                    date=t_latest_hosp_data_date,  # this could be off by a day from the hosp data
                     ensemble_results=pyseir_outputs,
                 )
 

--- a/pyseir/load_data.py
+++ b/pyseir/load_data.py
@@ -563,7 +563,7 @@ def get_current_hospitalized(fips, t0, category: HospitalizationCategory):
 
     if len(fips) == 2:
         kwargs = dict(
-            aggregation_level=AggregationLevel.State,
+            aggregation_level=AggregationLevel.STATE,
             country="USA",
             state=us.states.lookup(fips).abbr,
         )

--- a/pyseir/load_data.py
+++ b/pyseir/load_data.py
@@ -1,7 +1,5 @@
 import os
 import logging
-import pandas as pd
-import numpy as np
 import urllib.request
 import requests
 import re
@@ -10,21 +8,25 @@ import us
 import zipfile
 import json
 from datetime import datetime
+from functools import lru_cache
+from enum import Enum
+
+import pandas as pd
+import numpy as np
+
 from libs.datasets import NYTimesDataset
 from libs.datasets import combined_datasets
 from libs.datasets.timeseries import TimeseriesDataset
 from libs.datasets.dataset_utils import AggregationLevel
 from libs.datasets.common_fields import CommonFields
 from pyseir.utils import get_run_artifact_path, RunArtifact, ewma_smoothing
-from functools import lru_cache
-from enum import Enum
 
 log = logging.getLogger(__name__)
 
 DATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "pyseir_data")
-MIN_CUMULATIVE_DATAPOINTS_TO_CONVERT = (
-    3  # We wait until the third datapoint to have 2 deltas to forecast
-)
+# MIN_CUMULATIVE_DATAPOINTS_TO_CONVERT = (
+#     3  # We wait until the third datapoint to have 2 deltas to forecast
+# )
 
 
 class HospitalizationCategory(Enum):
@@ -399,11 +401,16 @@ def load_new_case_data_by_fips(
 
 
 def get_hospitalization_data():
+    """
+    Since we're using this data for hospitalized data only, only returning
+    values with hospitalization data.  I think as the use cases of this data source
+    expand, we may not want to drop. For context, as of 4/8 607/1821 rows contained
+    hospitalization data.
+    Returns
+    -------
+    TimeseriesDataset
+    """
     data = combined_datasets.build_us_timeseries_with_all_fields().data
-    # Since we're using this data for hospitalized data only, only returning
-    # values with hospitalization data.  I think as the use cases of this data source
-    # expand, we may not want to drop. For context, as of 4/8 607/1821 rows contained
-    # hospitalization data.
     has_current_hospital = data[TimeseriesDataset.Fields.CURRENT_HOSPITALIZED].notnull()
     has_cumulative_hospital = data[TimeseriesDataset.Fields.CUMULATIVE_HOSPITALIZED].notnull()
     return TimeseriesDataset(data[has_current_hospital | has_cumulative_hospital])
@@ -553,7 +560,7 @@ def get_current_hospitalized_for_state(state: str, t0: datetime, category: Hospi
     time: float
         Days since t0 for the hospitalization data.
     current estimate: float
-        The most recent estimate for the current occupied in the requested category.
+        The most recent provided value for the current occupied in the requested category.
     """
     abbr = us.states.lookup(state).abbr
     df = combined_datasets.build_us_timeseries_with_all_fields().get_data(
@@ -564,6 +571,26 @@ def get_current_hospitalized_for_state(state: str, t0: datetime, category: Hospi
 
 
 def get_current_hospitalized_for_county(fips: str, t0: datetime, category: HospitalizationCategory):
+    """
+    Return the current observed valuee for the number of people in the given category for
+    a given US county.
+
+    Parameters
+    ----------
+    fips: str
+        US state to lookup.
+    t0: datetime
+        Datetime to offset by.
+    category: HospitalizationCategory
+        'icu' for just ICU or 'hospitalized' for all ICU + Acute.
+
+    Returns
+    -------
+    time: float
+        Days since t0 for the hospitalization data.
+    current estimate: float
+        The most recent provided value for the current occupied in the requested category.
+    """
     df = get_hospitalization_data().get_data(AggregationLevel.COUNTY, country="USA", fips=fips)
     return _get_current_hospitalized(df, t0, category)
 
@@ -572,164 +599,180 @@ def _get_current_hospitalized(
     df: pd.DataFrame,
     t0: datetime,
     category: HospitalizationCategory,
-    min_cumulative_datapoints_to_convert: int = MIN_CUMULATIVE_DATAPOINTS_TO_CONVERT,
+    # min_cumulative_datapoints_to_convert: int = MIN_CUMULATIVE_DATAPOINTS_TO_CONVERT,
 ):
     """
     Given a DataFrame that contains values icu or hospitalization data
     for a single county/state, this function returns the latest value.
 
-    When only cummulative data is available,
-    a small model is used to estimate the latest current value from the cummulative.
-    This conversion only occurs if enough data is available.
+    # When only cumulative data is available,
+    # a small model is used to estimate the latest current value from the cumulative.
+    # This conversion only occurs if enough data is available.
 
     Parameters:
     @param df - dataframe containing either current_ or cumulative_ values for a single county or state
     @param t0 - beggining of observation period
     @param category - the type of current data to be returned
-    @param min_cumulative_datapoints_to_convert - the required number of cummulative data points before conversion to current will be done.
+    # @param min_cumulative_datapoints_to_convert - the required number of cumulative data points before conversion to current will be done.
 
     Returns:
     (times_new_latest, current_latest) - the date and value of the latest data for a given category.
+
+    #TODO: JUST RETURN A DATETIME AND MAKE THEM DEAL WITH IT.
+    #TODO: JUST A SIMPLE GETTER
     """
-    if len(df) == 0:
+    NUM_DAYS_TO_LOOK_BACK = 2  # How many days back to consider. This is for times when a single
+    # value may be not reported. If they stop reporting data, we will continue using that last day
+    # for this number of days going forward.
+
+    # Look back from most recent and find the first (latest) non-null value. If the loop drops out,
+    # that means there were no non-null values in the window of interest, and we return Nones.
+
+    recent_days_index = df.index[-NUM_DAYS_TO_LOOK_BACK::]  # Tail of the dataframe index.
+    for idx in reversed(recent_days_index):  # Iterate from most recent backwards
+        if pd.notnull(df[f"current_{category}"].iloc[idx]):
+            return df["date"].iloc[idx], df[f"current_{category}"].iloc[idx]
+    else:  # No not-null found so return None
         return None, None
 
-    # If data available in current_{} column, then return latest not-null value
-    if (df[f"current_{category}"] > 0).any():
-        df = df[df[f"current_{category}"].notnull()]
-        df_latest = df[f"current_{category}"].values.clip(min=0)[-1]
-
-        times_new = (df["date"].dt.date - t0.date()).dt.days.values
-        times_new_latest = times_new[-1]
-        return times_new_latest, df_latest  # Return current since available
-
-    # If data is available in cumulative, try to convert to current (not just daily)
-    elif (df[f"cumulative_{category}"] > 0).any():
-        log.warning("Attempting to convert cummulative data to current.")
-        # Remove Null & Enforce Monotonically Increasing Cumulatives
-        df = df[df[f"cumulative_{category}"].notnull()]
-        cumulative = df[f"cumulative_{category}"].values.clip(min=0)
-        for i, val in enumerate(cumulative[1:]):
-            if cumulative[i] > cumulative[i + 1]:
-                cumulative[i] = cumulative[i + 1]
-
-        # Estimate Current from Derived Dailies
-        if len(cumulative) >= min_cumulative_datapoints_to_convert:
-            current_latest = estimate_current_from_cumulative(cumulative, category)
-            times_new = (df["date"].dt.date - t0.date()).dt.days.values
-            times_new_latest = times_new[-1]
-            return times_new_latest, current_latest  # Return current estimate from cumulative
-        else:
-            return None, None  # No current, not enough cumulative
-    else:
-        return None, None  # No current nor cumulative
-
-
-def estimate_current_from_cumulative(cumulative, category):
-    """
-    We assume that an agency starts reporting cumulative admissions at a time not related to a
-    particularly abnormal patient admission. So we use the data we have collected so far, and
-    extrapolate backwards to estimate the ICU population at the start of reporting (which is
-    non-zero). This should significantly speed up settling time (and the only
-    movements from then on will be from changing inputs).
-
-    The simple model provided (x_{i+1} = x_{i} + new - x_{i}/avg_length_of_stay
-    has a steady state solution with constant input of new * avg_length_of_stay.
-
-    We initialize the model by taking the first X data points, calculating the average, and then
-    calculating steady state if historical data had matched current data. X is the average
-    length of stay. We then use that as the starting point to step forward in the model. So once we
-    have more than X datapoints, the forecast will shift based on underlying changes in the data.
-    Until we collect significant data, the estimates are sensitive to the inital values reported.
-    E.g. If day 1 shows 10 new ICU patients, we assume that has been happening for the last week
-    too and estimate accordingly. We can choose to wait for multiple points before extrapolating
-    to protect against surfacing noisy initial data to the user.
-
-    Parameters
-    ----------
-    cumulative: array
-        Array like sequence of daily cumulative values (expects, but doesn't enforce monotonic)
-    category: str
-        Either 'hospitalization' or 'icu
-
-    Returns
-    -------
-    current_estimate: float
-        Latest estimate of currently occupied beds.
-    """
-    average_length_of_stay = get_average_dwell_time(category)
-
-    # Calculate new admissions as the differences of daily cumulatives
-    daily_admits = np.diff(cumulative)
-
-    # When reporting starts, we assume there will already be a non-zero number of patients
-    # in the hospital/ICU. We need to estimate that starting value to initialize the model.
-    # If we don't, it takes ~2 times the average length of stay for the value to reach the
-    # expected. So our reported numbers for the first ~14 days would be too low (which we saw in
-    # Utah ICU data).
-
-    # We average over the inputs for up to the same number of days as the average dwell
-    max_window = int(np.floor(average_length_of_stay))
-    initial_daily_estimate = daily_admits[:max_window].mean()
-
-    # And use that steady state solution as if that data had been entered in the past to initialize.
-    t0_patients = initial_daily_estimate * average_length_of_stay
-
-    # Step through the model and generate a output
-    current_pts = []
-    for step, new_day in enumerate(daily_admits):
-        if step == 0:
-            yesterday = t0_patients
-        else:
-            yesterday = current_pts[-1]
-
-        today = yesterday + new_day - yesterday / average_length_of_stay
-        current_pts.append(today)
-    current_pts_latest = current_pts[-1]
-    return current_pts_latest
+    # NUM_DAYS_TO_LOOK_BACK = 2
+    #
+    # # If data available in current_{} column, then return latest not-null value
+    # if (df[f"current_{category}"] > 0).any():
+    #     df = df[df[f"current_{category}"].notnull()]
+    #     df_latest = df[f"current_{category}"].values.clip(min=0)[-1]
+    #
+    #     times_new = (df["date"].dt.date - t0.date()).dt.days.values
+    #     times_new_latest = times_new[-1]
+    #     return times_new_latest, df_latest  # Return current since available
+    #
+    # # If data is available in cumulative, try to convert to current (not just daily)
+    # elif (df[f"cumulative_{category}"] > 0).any():
+    #     log.warning("Attempting to convert cummulative data to current.")
+    #     # Remove Null & Enforce Monotonically Increasing Cumulatives
+    #     df = df[df[f"cumulative_{category}"].notnull()]
+    #     cumulative = df[f"cumulative_{category}"].values.clip(min=0)
+    #     for i, val in enumerate(cumulative[1:]):
+    #         if cumulative[i] > cumulative[i + 1]:
+    #             cumulative[i] = cumulative[i + 1]
+    #
+    #     # Estimate Current from Derived Dailies
+    #     if len(cumulative) >= min_cumulative_datapoints_to_convert:
+    #         current_latest = estimate_current_from_cumulative(cumulative, category)
+    #         times_new = (df["date"].dt.date - t0.date()).dt.days.values
+    #         times_new_latest = times_new[-1]
+    #         return times_new_latest, current_latest  # Return current estimate from cumulative
+    #     else:
+    #         return None, None  # No current, not enough cumulative
+    # else:
+    #     return None, None  # No current nor cumulative
 
 
-def get_average_dwell_time(category):
-    """
-    :parameter
-    category: HospitalizationCategory
-        Whether we are asking for 'hospital' or 'icu'
-
-    :return:
-    average_length_of_stay: float
-        the average length of stay for a given category
-    """
-    # Must be here to avoid circular import. This is required to convert
-    # cumulative hosps to current hosps. We also just use a dummy fips and t_list.
-    from pyseir.parameters.parameter_ensemble_generator import ParameterEnsembleGenerator
-
-    # Surprisingly long load time if initial call (14sec) but then fast (22ms)
-    params = ParameterEnsembleGenerator(
-        fips="06",
-        t_list=[],
-        N_samples=250  # We want close to the ensemble mean.
-        # Eventually replace with constants derived from the mean characteristic.
-        # Then we can revert back to 1.
-    ).get_average_seir_parameters()
-    # TODO: This value is temporarily in this limited scope.
-    # Will be added into the params once I decide on some refactoring.
-    params["hospitalization_length_of_stay_icu_avg"] = 8.6
-    if category == HospitalizationCategory.HOSPITALIZED:
-        average_length_of_stay = (
-            params["hospitalization_rate_general"]
-            * params["hospitalization_length_of_stay_general"]
-            + params["hospitalization_rate_icu"]
-            * (1 - params["fraction_icu_requiring_ventilator"])
-            * params["hospitalization_length_of_stay_icu"]
-            + params["hospitalization_rate_icu"]
-            * params["fraction_icu_requiring_ventilator"]
-            * params["hospitalization_length_of_stay_icu_and_ventilator"]
-        ) / (params["hospitalization_rate_general"] + params["hospitalization_rate_icu"])
-    else:
-        # This value is a weighted average of icu w & w/o ventilator.
-        # It is deterministic. Warning: This param was added in this very local scope.
-        average_length_of_stay = params["hospitalization_length_of_stay_icu_avg"]
-    return average_length_of_stay
+# def estimate_current_from_cumulative(cumulative, category):
+#     """
+#     We assume that an agency starts reporting cumulative admissions at a time not related to a
+#     particularly abnormal patient admission. So we use the data we have collected so far, and
+#     extrapolate backwards to estimate the ICU population at the start of reporting (which is
+#     non-zero). This should significantly speed up settling time (and the only
+#     movements from then on will be from changing inputs).
+#
+#     The simple model provided (x_{i+1} = x_{i} + new - x_{i}/avg_length_of_stay
+#     has a steady state solution with constant input of new * avg_length_of_stay.
+#
+#     We initialize the model by taking the first X data points, calculating the average, and then
+#     calculating steady state if historical data had matched current data. X is the average
+#     length of stay. We then use that as the starting point to step forward in the model. So once we
+#     have more than X datapoints, the forecast will shift based on underlying changes in the data.
+#     Until we collect significant data, the estimates are sensitive to the inital values reported.
+#     E.g. If day 1 shows 10 new ICU patients, we assume that has been happening for the last week
+#     too and estimate accordingly. We can choose to wait for multiple points before extrapolating
+#     to protect against surfacing noisy initial data to the user.
+#
+#     Parameters
+#     ----------
+#     cumulative: array
+#         Array like sequence of daily cumulative values (expects, but doesn't enforce monotonic)
+#     category: str
+#         Either 'hospitalization' or 'icu
+#
+#     Returns
+#     -------
+#     current_estimate: float
+#         Latest estimate of currently occupied beds.
+#     """
+#     average_length_of_stay = get_average_dwell_time(category)
+#
+#     # Calculate new admissions as the differences of daily cumulatives
+#     daily_admits = np.diff(cumulative)
+#
+#     # When reporting starts, we assume there will already be a non-zero number of patients
+#     # in the hospital/ICU. We need to estimate that starting value to initialize the model.
+#     # If we don't, it takes ~2 times the average length of stay for the value to reach the
+#     # expected. So our reported numbers for the first ~14 days would be too low (which we saw in
+#     # Utah ICU data).
+#
+#     # We average over the inputs for up to the same number of days as the average dwell
+#     max_window = int(np.floor(average_length_of_stay))
+#     initial_daily_estimate = daily_admits[:max_window].mean()
+#
+#     # And use that steady state solution as if that data had been entered in the past to initialize.
+#     t0_patients = initial_daily_estimate * average_length_of_stay
+#
+#     # Step through the model and generate a output
+#     current_pts = []
+#     for step, new_day in enumerate(daily_admits):
+#         if step == 0:
+#             yesterday = t0_patients
+#         else:
+#             yesterday = current_pts[-1]
+#
+#         today = yesterday + new_day - yesterday / average_length_of_stay
+#         current_pts.append(today)
+#     current_pts_latest = current_pts[-1]
+#     return current_pts_latest
+#
+#
+# def get_average_dwell_time(category):
+#     """
+#     :parameter
+#     category: HospitalizationCategory
+#         Whether we are asking for 'hospital' or 'icu'
+#
+#     :return:
+#     average_length_of_stay: float
+#         the average length of stay for a given category
+#     """
+#     # Must be here to avoid circular import. This is required to convert
+#     # cumulative hosps to current hosps. We also just use a dummy fips and t_list.
+#     from pyseir.parameters.parameter_ensemble_generator import ParameterEnsembleGenerator
+#
+#     # Surprisingly long load time if initial call (14sec) but then fast (22ms)
+#     params = ParameterEnsembleGenerator(
+#         fips="06",
+#         t_list=[],
+#         N_samples=250  # We want close to the ensemble mean.
+#         # Eventually replace with constants derived from the mean characteristic.
+#         # Then we can revert back to 1.
+#     ).get_average_seir_parameters()
+#     # TODO: This value is temporarily in this limited scope.
+#     # Will be added into the params once I decide on some refactoring.
+#     params["hospitalization_length_of_stay_icu_avg"] = 8.6
+#     if category == HospitalizationCategory.HOSPITALIZED:
+#         average_length_of_stay = (
+#             params["hospitalization_rate_general"]
+#             * params["hospitalization_length_of_stay_general"]
+#             + params["hospitalization_rate_icu"]
+#             * (1 - params["fraction_icu_requiring_ventilator"])
+#             * params["hospitalization_length_of_stay_icu"]
+#             + params["hospitalization_rate_icu"]
+#             * params["fraction_icu_requiring_ventilator"]
+#             * params["hospitalization_length_of_stay_icu_and_ventilator"]
+#         ) / (params["hospitalization_rate_general"] + params["hospitalization_rate_icu"])
+#     else:
+#         # This value is a weighted average of icu w & w/o ventilator.
+#         # It is deterministic. Warning: This param was added in this very local scope.
+#         average_length_of_stay = params["hospitalization_length_of_stay_icu_avg"]
+#     return average_length_of_stay
 
 
 @lru_cache(maxsize=32)


### PR DESCRIPTION
This PR removes a feature that originally was put in to estimate prevalence from cumulatives for acute and icu hospitalizations with the goal of scaling model output to latest observed. Now that more agencies are reporting current, we no longer want to support this conversion. In a few remaining locations, we will no longer scale outputs if we don't have current. This allows us to support one less model with obscure assumptions and effects.

There is also some streamlining of functions around this business logic.