### PR TITLE
Install covidactnow.datapublic, add save-combined-csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Check It Out in Jupyter
 ### Data Sources
 See [covid-data-public](https://github.com/covid-projections/covid-data-public) for data sources being used or considered.
 
+Some code in the `covid-data-model` repo depends on there being a copy of the `covid-data-public` repo at
+`../covid-data-public`.
+
 
 ## [Setup](./SETUP.md)
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,4 +1,18 @@
-# Setting up python environment covid-data-model
+# Setting up dev environment for covid-data-model
+
+## Copy the source data
+
+Copy the source data from the `covid-data-public` repo to a sibling of your local `covid-data-model` directory. git-lfs must be
+installed to checkout a copy of `covid-data-public`.
+
+1. Install git-lfs
+  On mac, `brew install git-lfs`
+
+2. Clone the `covid-data-public` repo
+  ```
+  $ cd ..
+  $ git clone git@github.com:covid-projections/covid-data-public.git
+  $ cd -
 
 ## Install Virtualenv
 
@@ -30,9 +44,6 @@ These instructions use `pyenv` to install python `3.7.7` and create a virtualenv
 
   Optional: Add a `.python-version` file with the name of your virtualenv to the `covid-data-model/` root.
   This will automatically activate the virtualenv when you enter the directory.
-
-4. Install git-lfs
-  On mac, `brew install git-lfs`
 
 ## Install Requirements and pre-commit
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -9,10 +9,12 @@ installed to checkout a copy of `covid-data-public`.
   On mac, `brew install git-lfs`
 
 2. Clone the `covid-data-public` repo
-  ```
-  $ cd ..
-  $ git clone git@github.com:covid-projections/covid-data-public.git
-  $ cd -
+    ```
+    $ cd ..
+    $ git clone git@github.com:covid-projections/covid-data-public.git
+    $ cd -
+    ```
+If you clone the repo before installing git-lfs run `git lfs pull`[*](https://github.com/git-lfs/git-lfs/issues/325#issuecomment-149713215) to fetch the large data files.
 
 ## Install Virtualenv
 

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -7,8 +7,12 @@ import click
 import structlog
 
 from covidactnow.datapublic import common_df
+from covidactnow.datapublic.common_fields import CommonFields
 from libs import github_utils
 from libs.datasets import combined_datasets
+import pandas as pd
+import numpy as np
+
 
 _logger = logging.getLogger(__name__)
 
@@ -42,13 +46,40 @@ def download_model_artifact(github_token, run_number, output_dir):
 @click.option("--output-dir", "-o", type=pathlib.Path, default=pathlib.Path("."))
 def save_combined_csv(csv_path_format, output_dir):
     """Save the combined datasets DataFrame, cleaned up for easier comparisons."""
+    csv_path = form_path_name(csv_path_format, output_dir)
+
+    timeseries = combined_datasets.build_us_timeseries_with_all_fields()
+    timeseries_data = timeseries.data
+
+    common_df.write_csv(timeseries_data, csv_path, structlog.get_logger())
+
+
+@main.command()
+@click.option(
+    "--csv-path-format",
+    default="latest-{git_branch}-{git_sha}-{timestamp}.csv",
+    show_default=True,
+    help="Filename template where CSV is written",
+)
+@click.option("--output-dir", "-o", type=pathlib.Path, default=pathlib.Path("."))
+def save_combined_latest_csv(csv_path_format, output_dir):
+    """Save the combined datasets latest DataFrame, cleaned up for easier comparisons."""
+    csv_path = form_path_name(csv_path_format, output_dir)
+
+    latest = combined_datasets.build_us_latest_with_all_fields()
+    # This is a hacky modification of common_df.write_csv because it requires a date index.
+    latest_data = latest.data.set_index(CommonFields.FIPS).replace({pd.NA: np.nan}).convert_dtypes()
+    latest_data.to_csv(csv_path, date_format="%Y-%m-%d", index=True, float_format="%.12g")
+
+
+def form_path_name(csv_path_format, output_dir):
+    """Create a path from a format string that may contain `{git_sha}` etc and output_dir."""
     try:
         git_branch = subprocess.check_output(
             ["git", "symbolic-ref", "--short", "HEAD"], text=True
         ).strip()
     except subprocess.CalledProcessError:
         git_branch = "no-HEAD-branch"
-
     csv_path = pathlib.Path(output_dir) / csv_path_format.format(
         git_sha=subprocess.check_output(
             ["git", "describe", "--dirty", "--always", "--long"], text=True
@@ -56,8 +87,4 @@ def save_combined_csv(csv_path_format, output_dir):
         git_branch=git_branch,
         timestamp=datetime.now().strftime("%Y%m%dT%H%M%S"),
     )
-
-    timeseries = combined_datasets.build_us_timeseries_with_all_fields()
-    timeseries_data = timeseries.data
-
-    common_df.write_csv(timeseries_data, csv_path, structlog.get_logger())
+    return csv_path

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -2,13 +2,11 @@ import logging
 import pathlib
 import subprocess
 from datetime import datetime
-import pandas as pd
-import numpy as np
 
 import click
 import structlog
 
-from covidactnow.datapublic.common_df import write_df_as_csv, sort_common_field_columns
+from covidactnow.datapublic import common_df
 from libs import github_utils
 from libs.datasets import combined_datasets
 
@@ -62,4 +60,4 @@ def save_combined_csv(csv_path_format, output_dir):
     timeseries = combined_datasets.build_us_timeseries_with_all_fields()
     timeseries_data = timeseries.data
 
-    write_df_as_csv(timeseries_data, csv_path, structlog.get_logger())
+    common_df.write_csv(timeseries_data, csv_path, structlog.get_logger())

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -41,9 +41,10 @@ def download_model_artifact(github_token, run_number, output_dir):
     show_default=True,
     help="Filename template where CSV is written",
 )
-def save_combined_csv(csv_path_format):
+@click.option("--output-dir", "-o", type=pathlib.Path, default=pathlib.Path("."))
+def save_combined_csv(csv_path_format, output_dir):
     """Save the combined datasets DataFrame, cleaned up for easier comparisons."""
-    csv_path = csv_path_format.format(
+    csv_path = pathlib.Path(output_dir) / csv_path_format.format(
         git_sha=subprocess.check_output(
             ["git", "describe", "--dirty", "--always", "--long"], text=True
         ).strip(),

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -44,13 +44,18 @@ def download_model_artifact(github_token, run_number, output_dir):
 @click.option("--output-dir", "-o", type=pathlib.Path, default=pathlib.Path("."))
 def save_combined_csv(csv_path_format, output_dir):
     """Save the combined datasets DataFrame, cleaned up for easier comparisons."""
+    try:
+        git_branch = subprocess.check_output(
+            ["git", "symbolic-ref", "--short", "HEAD"], text=True
+        ).strip()
+    except subprocess.CalledProcessError:
+        git_branch = "no-HEAD-branch"
+
     csv_path = pathlib.Path(output_dir) / csv_path_format.format(
         git_sha=subprocess.check_output(
             ["git", "describe", "--dirty", "--always", "--long"], text=True
         ).strip(),
-        git_branch=subprocess.check_output(
-            ["git", "symbolic-ref", "--short", "HEAD"], text=True
-        ).strip(),
+        git_branch=git_branch,
         timestamp=datetime.now().strftime("%Y%m%dT%H%M%S"),
     )
 

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -1,7 +1,16 @@
 import logging
 import pathlib
+import subprocess
+from datetime import datetime
+import pandas as pd
+import numpy as np
+
 import click
+import structlog
+
+from covidactnow.datapublic.common_df import write_df_as_csv, sort_common_field_columns
 from libs import github_utils
+from libs.datasets import combined_datasets
 
 _logger = logging.getLogger(__name__)
 
@@ -23,3 +32,48 @@ def main():
 def download_model_artifact(github_token, run_number, output_dir):
     """Download model output from github action publish and deploy workflow. """
     github_utils.download_model_artifact(github_token, output_dir, run_number=run_number)
+
+
+@main.command()
+@click.option(
+    "--csv-path-format",
+    default="combined-{git_branch}-{git_sha}-{timestamp}.csv",
+    show_default=True,
+    help="Filename template where CSV is written",
+)
+def save_combined_csv(csv_path_format):
+    """Save the combined datasets DataFrame, cleaned up for easier comparisons."""
+    csv_path = csv_path_format.format(
+        git_sha=subprocess.check_output(
+            ["git", "describe", "--dirty", "--always", "--long"], text=True
+        ).strip(),
+        git_branch=subprocess.check_output(
+            ["git", "symbolic-ref", "--short", "HEAD"], text=True
+        ).strip(),
+        timestamp=datetime.now().strftime("%Y%m%dT%H%M%S"),
+    )
+
+    timeseries = combined_datasets.build_us_timeseries_with_all_fields()
+    timeseries_data = timeseries.data
+
+    timeseries_data = cleanup_df(timeseries_data)
+    timeseries_data.info()
+
+    write_df_as_csv(timeseries_data, csv_path, structlog.get_logger())
+
+
+def cleanup_df(df):
+    col_to_drop = [c for c in ["index"] if c in df.columns]
+    # Replace experimental NA object with conventional `nan`. Without this `convert_dtypes` leaves the
+    # negative_tests column with dtype=object and it is output as a mix of floats and ints, which makes
+    # diff-ing harder.
+    df = df.replace({pd.NA: np.nan})
+    df = df.drop(columns=col_to_drop).convert_dtypes()
+    # Make sure that columns that can be represented as an integer are converted to `Int64`. `int64` won't work
+    # because many of our columns have missing values.
+    for col in df.select_dtypes(include="number").columns:
+        as_ints = df[col].astype("Int64", copy=False)
+        error = (df[col] - as_ints).abs().sum()
+        if error < 0.001:
+            df[col] = as_ints
+    return sort_common_field_columns(df)

--- a/libs/pipelines/api_pipeline.py
+++ b/libs/pipelines/api_pipeline.py
@@ -215,6 +215,9 @@ def deploy_results(results: List[APIOutput], output: str, write_csv=False):
         data = remove_root_wrapper(api_row.data.dict())
         # Encoding approach based on Pydantic's implementation of .json():
         # https://github.com/samuelcolvin/pydantic/pull/210/files
+        # `json` isn't in `pydantic/__init__py` which I think means it doesn't intend to export
+        # it. We use it anyway and pylint started complaining.
+        # pylint: disable=no-member
         data_as_json = simplejson.dumps(
             data, ignore_nan=True, default=pydantic.json.pydantic_encoder
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,4 @@ dictdiffer==0.8.1
 structlog==20.1.0
 structlog-sentry==1.2.2
 more_itertools==8.3.0
+-e ../covid-data-public


### PR DESCRIPTION
## This PR

* depends on https://github.com/covid-projections/covid-data-public/pull/62
* adds ../covid-data-public to requirements
* adds a tool that dumps the combined datasets to disk


### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [ ] Are tests passing?

## Tested

I ran `python run.py utils save-combined-csv` and looked at `combined-tgb-save-combined-de01959-20200612T134549.csv`. Also `python run.py utils save-combined-csv --help` looks reasonable:

```
Usage: run.py utils save-combined-csv [OPTIONS]

  Save the combined datasets DataFrame, cleaned up for easier comparisons.

Options:
  --csv-path-format TEXT  Filename template where CSV is written  [default:
                          combined-{git_branch}-{git_sha}-{timestamp}.csv]

  -o, --output-dir PATH
  --help                  Show this message and exit.
```