### PR TITLE
For Future Projections, Cap All Scenarios at R=2.5

### DIFF
--- a/pyseir/ensembles/ensemble_runner.py
+++ b/pyseir/ensembles/ensemble_runner.py
@@ -228,10 +228,8 @@ class EnsembleRunner:
 
         # Determine the appropriate future suppression policy based on the
         # scenario of interest.
-        if scenario == "inferred":
-            eps_final = inferred_params["eps2"]
-        else:
-            eps_final = sp.get_future_suppression_from_r0(inferred_params["R0"], scenario=scenario)
+
+        eps_final = sp.estimate_future_suppression_from_fits(inferred_params, scenario=scenario)
 
         model.suppression_policy = sp.get_epsilon_interpolator(
             eps=inferred_params["eps"],

--- a/pyseir/models/suppression_policies.py
+++ b/pyseir/models/suppression_policies.py
@@ -24,7 +24,9 @@ distancing_measure_suppression = {
 
 def get_future_suppression_from_r0(R0, scenario):
     """
-    Returns the future suppression level for a given R0 and a "future scenario".
+    Returns the future suppression level for a given R0 and a "future scenario". The
+    "no_intervention" scenario is capped at an effective R rate of 2.5 as suggested by the CDC
+    planning scenarios (https://www.cdc.gov/coronavirus/2019-ncov/hcp/planning-scenarios.html).
 
     Parameters
     ----------
@@ -36,10 +38,14 @@ def get_future_suppression_from_r0(R0, scenario):
     Returns
     -------
     epsilon: float
-        Suppression fraction.
+        Suppression fraction compared to R0.
     """
     if scenario == "no_intervention":
-        return 1
+        # Return either 2.5 (https://www.cdc.gov/coronavirus/2019-ncov/hcp/planning-scenarios.html)
+        # or R0 (converted to epsilon) whichever is lower
+        fitted_r0 = 1.0
+        cdc_recommended_max = 2.5 / R0
+        return min(fitted_r0, cdc_recommended_max)
     elif scenario == "flatten_the_curve":
         return 0.97 / R0
     elif scenario == "social_distancing":


### PR DESCRIPTION
This PR addresses stability in our hospitalization forecasts. The no intervention value is currently drawn from the daily pyseir model's first stage fit R value. This model is almost always higher than the 2.5 estimate provided by the CDC for scenario planning (https://www.cdc.gov/coronavirus/2019-ncov/hcp/planning-scenarios.html). Our visualization currently goes out 3 months forward. Small changes in fitter R0 cause large changes in the worst case scenario line. We believe those small changes in R0 are in the noise, especially for a forecast that assumes that we go 3 months without change. Therefore, we cap those values at a minimum of either 2.5 or fit R0.

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [ ] Are tests passing?
