### PR TITLE
Disable post-fit eps posterior updating

### DIFF
--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -123,7 +123,7 @@ class ModelFitter:
 
         self.fips = fips
         self.ref_date = ref_date
-        self.days_since_ref_date = (dt.date.today() - ref_date.date() - timedelta(days=14)).days
+        self.days_since_ref_date = (dt.date.today() - ref_date.date() - timedelta(days=7)).days
         # ndays end of 2nd ramp may extend past days_since_ref_date w/o  penalty on chi2 score
         self.days_allowed_beyond_ref = 0
         self.min_deaths = min_deaths
@@ -822,7 +822,7 @@ class ModelFitter:
         start_intervention_date = self.ref_date + timedelta(
             days=self.fit_results["t_break"] + self.fit_results["t0"]
         )
-        stop_intervention_date = start_intervention_date + timedelta(days=7)
+        stop_intervention_date = start_intervention_date + timedelta(days=14)
 
         plt.fill_betweenx(
             [y_lim[0], y_lim[1]],

--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -123,7 +123,7 @@ class ModelFitter:
 
         self.fips = fips
         self.ref_date = ref_date
-        self.days_since_ref_date = (dt.date.today() - ref_date.date() - timedelta(days=7)).days
+        self.days_since_ref_date = (dt.date.today() - ref_date.date() - timedelta(days=14)).days
         # ndays end of 2nd ramp may extend past days_since_ref_date w/o  penalty on chi2 score
         self.days_allowed_beyond_ref = 0
         self.min_deaths = min_deaths
@@ -632,20 +632,18 @@ class ModelFitter:
             )
 
         # For now we are not applying posterior updating after the fit, but trust the fit to find the best R values
-        """
         # Most naive constraints: apply the same constraint to both epsilon 2 and epsilon 3
-        for epsilon in ["eps", "eps2"]:
-            adjusted_epsilon = ModelFitter.get_posterior_estimate_eps(
-                R0=self.fit_results["R0"],
-                eps=self.fit_results[epsilon],
-                eps_error=self.fit_results[f"{epsilon}_error"],
-                lower_bound_reff=ModelFitter.REFF_LOWER_BOUND,
-            )
-            log.info(
-                f"FIPS: {self.fips} epsilon: {self.fit_results[epsilon]} adjusted: {adjusted_epsilon}"
-            )
-            self.fit_results[epsilon] = adjusted_epsilon
-        """
+        # for epsilon in ["eps", "eps2"]:
+        #    adjusted_epsilon = ModelFitter.get_posterior_estimate_eps(
+        #        R0=self.fit_results["R0"],
+        #        eps=self.fit_results[epsilon],
+        #        eps_error=self.fit_results[f"{epsilon}_error"],
+        #        lower_bound_reff=ModelFitter.REFF_LOWER_BOUND,
+        #    )
+        #    log.info(
+        #        f"FIPS: {self.fips} epsilon: {self.fit_results[epsilon]} adjusted: {adjusted_epsilon}"
+        #    )
+        #    self.fit_results[epsilon] = adjusted_epsilon
         if np.isnan(self.fit_results["t0"]):
             logging.error(f"Could not compute MLE values for {self.display_name}")
             self.fit_results["t0_date"] = (
@@ -824,7 +822,7 @@ class ModelFitter:
         start_intervention_date = self.ref_date + timedelta(
             days=self.fit_results["t_break"] + self.fit_results["t0"]
         )
-        stop_intervention_date = start_intervention_date + timedelta(days=14)
+        stop_intervention_date = start_intervention_date + timedelta(days=7)
 
         plt.fill_betweenx(
             [y_lim[0], y_lim[1]],

--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -631,6 +631,8 @@ class ModelFitter:
                 f"Epsilon == 0 which implies lack of convergence."
             )
 
+        # For now we are not applying posterior updating after the fit, but trust the fit to find the best R values
+        """
         # Most naive constraints: apply the same constraint to both epsilon 2 and epsilon 3
         for epsilon in ["eps", "eps2"]:
             adjusted_epsilon = ModelFitter.get_posterior_estimate_eps(
@@ -643,7 +645,7 @@ class ModelFitter:
                 f"FIPS: {self.fips} epsilon: {self.fit_results[epsilon]} adjusted: {adjusted_epsilon}"
             )
             self.fit_results[epsilon] = adjusted_epsilon
-
+        """
         if np.isnan(self.fit_results["t0"]):
             logging.error(f"Could not compute MLE values for {self.display_name}")
             self.fit_results["t0_date"] = (


### PR DESCRIPTION
This PR removes the epsilon posterior updating after the fit that was previously applied. Now we trust the fit to find the best epsilon fit values. 

### Please Check
- [ running] Are tests passing?
