### PR TITLE
fix for timedelta + remove noisy metric

### DIFF
--- a/libs/qa/metrics.py
+++ b/libs/qa/metrics.py
@@ -176,7 +176,7 @@ class HospitalShortageStartDate(QAMetric):
         value2_date = datetime.strptime(value2, "%Y-%m-%d")
 
         delta = value1_date - value1_date
-        return abs(delta.day)
+        return abs(delta.days)
 
 
 CURRENT_METRICS = [
@@ -198,5 +198,4 @@ TIMESERIES_METRICS = [
     CumulativePositiveTestsTS,
     CumulativeNegativeTestsTS,
     CumulativeInfectedTS,
-    CumulativeDeathsTS,
 ]


### PR DESCRIPTION
This PR addresses issue #<insert number>

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [ ] Are tests passing?
