### PR TITLE
fix ICU/General Bed capacity label in charts

### DIFF
--- a/pyseir/models/seir_model.py
+++ b/pyseir/models/seir_model.py
@@ -607,7 +607,7 @@ class SEIRModel:
             "steelblue",
             alpha=1,
             lw=2,
-            label="ICU Bed Capacity",
+            label="General Bed Capacity",
             linestyle="--",
         )
 
@@ -627,7 +627,7 @@ class SEIRModel:
             "firebrick",
             alpha=1,
             lw=2,
-            label="General Bed Capacity",
+            label="ICU Bed Capacity",
             linestyle="--",
         )
 


### PR DESCRIPTION
Old Charts had ICU and General Bed capacity labels flipped 
### Please Check

- [ better] Are tests passing?
