### PR TITLE
Apply Shim to Cumulative Death s.t. Latest Observed Equals Latest Model

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -9,7 +9,7 @@ on:
   schedule:
    - cron: '30 0,12 * * *'
 
-  # push:
+  push:
   # Hook to trigger a manual run.
   # See: https://goobar.io/2019/12/07/manually-trigger-a-github-actions-workflow/
   repository_dispatch:
@@ -17,7 +17,7 @@ on:
 
 env:
   # !!! Change this to your BRANCH if you want to test it
-  COVID_DATA_MODEL_REF: 'master'
+  COVID_DATA_MODEL_REF: 'feature/shim-cumulative-deaths'
 
   # To pin to an old data sets, put the branch/tag/commit here:
   COVID_DATA_PUBLIC_REF: 'master'

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -9,7 +9,7 @@ on:
   schedule:
    - cron: '30 0,12 * * *'
 
-  push:
+  # push:
   # Hook to trigger a manual run.
   # See: https://goobar.io/2019/12/07/manually-trigger-a-github-actions-workflow/
   repository_dispatch:
@@ -17,7 +17,7 @@ on:
 
 env:
   # !!! Change this to your BRANCH if you want to test it
-  COVID_DATA_MODEL_REF: 'feature/shim-cumulative-deaths'
+  COVID_DATA_MODEL_REF: 'master'
 
   # To pin to an old data sets, put the branch/tag/commit here:
   COVID_DATA_PUBLIC_REF: 'master'

--- a/libs/datasets/dataset_utils.py
+++ b/libs/datasets/dataset_utils.py
@@ -247,7 +247,7 @@ def add_fips_using_county(data, fips_data) -> pd.Series:
     if len(non_matching):
         unique_counties = sorted(non_matching.county.unique())
         _logger.warning(f"Did not match {len(unique_counties)} counties to fips data.")
-        _logger.warning(f"{non_matching}")
+        # _logger.warning(f"{non_matching}")  # This is debugging info and crowding out the stdout
         # TODO: Make this an error?
 
     # Handles if a fips column already in the dataframe.

--- a/libs/datasets/sources/cds_dataset.py
+++ b/libs/datasets/sources/cds_dataset.py
@@ -137,13 +137,14 @@ class CDSDataset(data_source.DataSource):
         data = dataset_utils.add_fips_using_county(data, fips_data)
         no_fips = data[CommonFields.FIPS].isna()
         if no_fips.sum() > 0:
-            logging.error(f"Removing rows without fips id: {str(data.loc[no_fips])}")
+            logging.error(f"Removing {len(data.loc[no_fips])} rows without fips id")
+            # logging.error(f"Removing rows without fips id: {str(data.loc[no_fips])}")
             data = data.loc[~no_fips]
 
         data.set_index(["date", "fips"], inplace=True)
         if data.index.has_duplicates:
-            # Use keep=False when logging so the output contains all duplicated rows, not just the first or last
-            # instance of each duplicate.
+            # Use keep=False when logging so the output contains all duplicated rows, not just the
+            # first or last instance of each duplicate.
             logging.error(f"Removing duplicates: {str(data.index.duplicated(keep=False))}")
             data = data.loc[~data.index.duplicated(keep=False)]
         data.reset_index(inplace=True)

--- a/pyseir/deployment/model_to_observed_shim.py
+++ b/pyseir/deployment/model_to_observed_shim.py
@@ -6,9 +6,10 @@ import numpy as np
 def shim_deaths_model_to_observations(
     model_death_ts: Sequence, idx: int, observed_latest: dict, log
 ):
-    """Enforce the constraint that cumulative model deaths up to today equals cumulative observed
-    deaths up to today. Take model outputs and shim them s.t. the latest observed value matches the
-    same value for the outputted model.
+    """
+    Take model outputs and calculate a "shim" value that can be added to the entire modeled
+    cumulative deaths series to make them match the latest (i.e. today's) actual cumulative deaths.
+    As a consequence, this will shift the future values by the same amount.
 
     Parameters
     ----------
@@ -36,11 +37,11 @@ def shim_deaths_model_to_observations(
     if np.isnan(observed_latest_cum_deaths):
         death_shim = 0
     elif observed_latest_cum_deaths == 0:
+        # As of 19 June 2020, the observed dataset is still being validated for erroneous inputs.
+        # This includes cases of returning a 0 when we should be returning a np.nan/None.
+        # For now, we will not apply a shim if the result returned is 0.
         death_shim = 0
     else:
-        # To be consistent with the other shims coming, I will shim all values by the same amount
-        # so that the cumulative model today equals cumulative observed today. This will shift the
-        # future values by the same amount.
         death_shim = observed_latest_cum_deaths - model_latest_cum_deaths
 
     log.info(

--- a/pyseir/deployment/model_to_observed_shim.py
+++ b/pyseir/deployment/model_to_observed_shim.py
@@ -1,0 +1,53 @@
+from typing import Sequence
+
+import numpy as np
+
+
+def shim_deaths_model_to_observations(
+    model_death_ts: Sequence, idx: int, observed_latest: dict, log
+):
+    """Enforce the constraint that cumulative model deaths up to today equals cumulative observed
+    deaths up to today. Take model outputs and shim them s.t. the latest observed value matches the
+    same value for the outputted model.
+
+    Parameters
+    ----------
+    model_death_ts
+        Model array sequence for cumulative deaths
+    idx
+        Index on which to align
+    observed_latest
+        Dictionary of latest values taken from combined dataset for the fips of interest.
+    log
+        Log Instance
+    Return
+    ------
+    shimmed_death: float
+        Value to shim the timeseries by
+    """
+    observed_latest_cum_deaths = observed_latest["deaths"]
+
+    # There are inconsistent None/"NaN" -> force all to np.nan for this scope.
+    if observed_latest_cum_deaths is None:
+        observed_latest_cum_deaths = np.nan
+
+    model_latest_cum_deaths = model_death_ts[idx]
+
+    if np.isnan(observed_latest_cum_deaths):
+        death_shim = 0
+    elif observed_latest_cum_deaths == 0:
+        death_shim = 0
+    else:
+        # To be consistent with the other shims coming, I will shim all values by the same amount
+        # so that the cumulative model today equals cumulative observed today. This will shift the
+        # future values by the same amount.
+        death_shim = observed_latest_cum_deaths - model_latest_cum_deaths
+
+    log.info(
+        event="Death Shim Applied:",
+        death_shim=np.round(death_shim),
+        observed_latest_cum_deaths=np.round(observed_latest_cum_deaths),
+        model_latest_cum_deaths=np.round(model_latest_cum_deaths),
+    )
+
+    return death_shim

--- a/pyseir/deployment/webui_data_adaptor_v1.py
+++ b/pyseir/deployment/webui_data_adaptor_v1.py
@@ -1,21 +1,22 @@
-import numpy as np
-import pandas as pd
 import ujson as json
 import structlog
 import us
+from typing import Tuple
 from datetime import timedelta, datetime
+import numpy as np
+import pandas as pd
 from multiprocessing import Pool
 from pyseir import load_data
 from pyseir.inference.fit_results import load_inference_result, load_Rt_result
 from pyseir.utils import get_run_artifact_path, RunArtifact, RunMode
 from libs.enums import Intervention
 from libs.datasets import CommonFields
-from libs.datasets import FIPSPopulation, JHUDataset, CDSDataset
+from libs.datasets import FIPSPopulation, JHUDataset, CDSDataset, combined_datasets, dataset_cache
 from libs.datasets.dataset_utils import build_aggregate_county_data_frame
 from libs.datasets.dataset_utils import AggregationLevel
 import libs.datasets.can_model_output_schema as schema
+import pyseir.deployment.model_to_observed_shim as shim
 
-from typing import Tuple
 
 log = structlog.get_logger()
 
@@ -211,6 +212,24 @@ class WebUIDataAdaptorV1:
             t0_simulation=t0_simulation, fips=fips, pyseir_outputs=pyseir_outputs,
         )
 
+        # Here is where we shimmy just for cumulative death right now.
+        # We will shim all suppression policies by the same amount (since historical tracking error
+        # for all policies is the same).
+        baseline_policy = "suppression_policy__inferred"  # This could be any valid policy
+        model_death_ts = pyseir_outputs[baseline_policy]["total_deaths"]["ci_50"]
+        # We need the index in the model's temporal frame.
+        idx_offset = int(fit_results["t_today"] - fit_results["t0"])
+        # Get the latest observed values to shim to.
+        observed_latest_dict = combined_datasets.get_us_latest_for_fips(fips)
+        shim_log = structlog.getLogger(fips=fips)
+
+        death_shim = shim.shim_deaths_model_to_observations(
+            model_death_ts=model_death_ts,
+            idx=idx_offset,
+            observed_latest=observed_latest_dict,
+            log=shim_log,
+        )
+
         # Iterate through each suppression policy.
         # Model output is interpolated to the dates desired for the API.
         suppression_policies = [
@@ -256,9 +275,15 @@ class WebUIDataAdaptorV1:
                 output_model[schema.INFECTED_B], output_model[schema.INFECTED_C]
             )
             output_model[schema.ALL_INFECTED] = output_model[schema.INFECTED]
-            output_model[schema.DEAD] = np.interp(
-                t_list_downsampled, t_list, output_for_policy["total_deaths"]["ci_50"]
+
+            # Shim Deaths to Match Observed
+            raw_model_deaths_values = output_for_policy["total_deaths"]["ci_50"]
+            interp_model_deaths_values = np.interp(
+                t_list_downsampled, t_list, raw_model_deaths_values
             )
+            output_model[schema.DEAD] = (interp_model_deaths_values + death_shim).clip(min=0)
+
+            # Continue mapping
             final_beds = np.mean(output_for_policy["HGen"]["capacity"])
             output_model[schema.BEDS] = final_beds
             output_model[schema.CUMULATIVE_INFECTED] = np.interp(
@@ -393,9 +418,10 @@ class WebUIDataAdaptorV1:
 
 
 if __name__ == "__main__":
+    dataset_cache.set_pickle_cache_dir()
     # Need to have a whitelist pre-generated
     # Need to have state output already built
     mapper = WebUIDataAdaptorV1(
-        state="California", output_interval_days=4, run_mode="can-inference-derived"
+        state="California", output_interval_days=1, run_mode="can-inference-derived"
     )
     mapper.generate_state(whitelisted_county_fips=["06037", "06075", "06059"], states_only=False)

--- a/pyseir/deployment/webui_data_adaptor_v1.py
+++ b/pyseir/deployment/webui_data_adaptor_v1.py
@@ -212,7 +212,6 @@ class WebUIDataAdaptorV1:
             t0_simulation=t0_simulation, fips=fips, pyseir_outputs=pyseir_outputs,
         )
 
-        # Here is where we shimmy just for cumulative death right now.
         # We will shim all suppression policies by the same amount (since historical tracking error
         # for all policies is the same).
         baseline_policy = "suppression_policy__inferred"  # This could be any valid policy


### PR DESCRIPTION
This code shims the cumulative deaths timeseries in the API so that the cumulative deaths from the model agrees with the cumulative deaths from outside observed sources.

This PR addresses issue https://trello.com/c/ZDNt3or6/247-shim-model-cumulative-deaths-to-observed.

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [ ] Are tests passing?
