### PR TITLE
Adding flag to fill specify whether or not to fill state level data by data source

### DIFF
--- a/libs/datasets/data_source.py
+++ b/libs/datasets/data_source.py
@@ -23,6 +23,13 @@ class DataSource(object):
     # Indicates if NYC data is aggregated into one NYC county or not.
     HAS_AGGREGATED_NYC_BOROUGH = False
 
+    # Flag to indicate whether or not to fill missing state level data with county data
+    # when converting to either a TimeseriesDataset or LatestValuesDataset.
+    # Some data sources provide state level data, while others don't, however, due to how
+    # some data sources report data, aggregating on the county level data may lead to incorrect
+    # assumptions about missing vs data that is just zero.
+    FILL_MISSING_STATE_LEVEL_DATA = True
+
     def __init__(self, data: pd.DataFrame):
         self.data = data
 

--- a/libs/datasets/latest_values_dataset.py
+++ b/libs/datasets/latest_values_dataset.py
@@ -83,7 +83,7 @@ class LatestValuesDataset(dataset_base.DatasetBase):
         if set(source.INDEX_FIELD_MAP.keys()) != set(cls.INDEX_FIELDS):
             raise ValueError("Index fields must match")
 
-        return cls.from_source(source)
+        return cls.from_source(source, fill_missing_state=source.FILL_MISSING_STATE_LEVEL_DATA)
 
     def get_subset(
         self,

--- a/libs/datasets/sources/cmdc.py
+++ b/libs/datasets/sources/cmdc.py
@@ -9,6 +9,12 @@ class CmdcDataSource(data_source.DataSource):
     DATA_PATH = "data/cases-cmdc/timeseries-common.csv"
     SOURCE_NAME = "CMDC"
 
+    # CMDC data reports values at both the state and county level. However, state values
+    # are not reported until complete values from states are received.  The latest
+    # row may contain some county data but not state data - instead of aggregating and returning
+    # incomplete state data, we are choosing to not aggregate.
+    FILL_MISSING_STATE_LEVEL_DATA = False
+
     INDEX_FIELD_MAP = {
         CommonFields.DATE: CommonFields.DATE,
         CommonFields.AGGREGATE_LEVEL: CommonFields.AGGREGATE_LEVEL,

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -225,7 +225,7 @@ class TimeseriesDataset(dataset_base.DatasetBase):
         if set(source.INDEX_FIELD_MAP.keys()) != set(cls.INDEX_FIELDS):
             raise ValueError("Index fields must match")
 
-        return cls.from_source(source)
+        return cls.from_source(source, fill_missing_state=source.FILL_MISSING_STATE_LEVEL_DATA)
 
     def to_latest_values_dataset(self):
         from libs.datasets.latest_values_dataset import LatestValuesDataset


### PR DESCRIPTION
The bug with CMDC data is that they report county data as they receive it, but state data is not reported until they receive a complete days worth of data. We were aggregating any missing state rows, so for an incomplete day we were rolling up aggregates, which would return a zero or incomplete data as the latest value for a state.  

Addresses https://trello.com/c/ib7jY6Fx/236-combined-dataset-timeseries-has-incorrect-rows-for-latest-day
