### PR TITLE
Test/snapshot timeout

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -17,10 +17,10 @@ on:
 
 env:
   # !!! Change this to your BRANCH if you want to test it
-  COVID_DATA_MODEL_REF: 'master'
+  COVID_DATA_MODEL_REF: 'test/snapshot-timeout'
 
   # To pin to an old data sets, put the branch/tag/commit here:
-  COVID_DATA_PUBLIC_REF: '1d5ea08606c6d0c5e9ad29493a19baa6d5279a39'
+  COVID_DATA_PUBLIC_REF: 'master'
 
   # S3 Bucket (used by s3-sync-action tasks) to store final API snapshot.
   AWS_S3_BUCKET: 'data.covidactnow.org'

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -20,7 +20,7 @@ env:
   COVID_DATA_MODEL_REF: 'test/snapshot-timeout'
 
   # To pin to an old data sets, put the branch/tag/commit here:
-  COVID_DATA_PUBLIC_REF: 'master'
+  COVID_DATA_PUBLIC_REF: '6351ef4b2533d99f08625663fc729cf98f122da0'
 
   # S3 Bucket (used by s3-sync-action tasks) to store final API snapshot.
   AWS_S3_BUCKET: 'data.covidactnow.org'

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -9,7 +9,7 @@ on:
   schedule:
    - cron: '30 0,12 * * *'
 
-  # push:
+  push:
   # Hook to trigger a manual run.
   # See: https://goobar.io/2019/12/07/manually-trigger-a-github-actions-workflow/
   repository_dispatch:
@@ -17,7 +17,7 @@ on:
 
 env:
   # !!! Change this to your BRANCH if you want to test it
-  COVID_DATA_MODEL_REF: 'master'
+  COVID_DATA_MODEL_REF: 'test/snapshot-timeout'
 
   # To pin to an old data sets, put the branch/tag/commit here:
   COVID_DATA_PUBLIC_REF: 'master'

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -9,7 +9,7 @@ on:
   schedule:
    - cron: '30 0,12 * * *'
 
-  push:
+  # push:
   # Hook to trigger a manual run.
   # See: https://goobar.io/2019/12/07/manually-trigger-a-github-actions-workflow/
   repository_dispatch:
@@ -34,7 +34,7 @@ env:
 
   # Used by execute-model (for now) to optimize parallelization on self-hosted
   # runner.
-  COVID_MODEL_CORES: 48
+  COVID_MODEL_CORES: 96
 
   # Used by python code that reports errors to sentry.
   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -20,7 +20,7 @@ env:
   COVID_DATA_MODEL_REF: 'test/snapshot-timeout'
 
   # To pin to an old data sets, put the branch/tag/commit here:
-  COVID_DATA_PUBLIC_REF: '6351ef4b2533d99f08625663fc729cf98f122da0'
+  COVID_DATA_PUBLIC_REF: 'master'
 
   # S3 Bucket (used by s3-sync-action tasks) to store final API snapshot.
   AWS_S3_BUCKET: 'data.covidactnow.org'

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -9,7 +9,7 @@ on:
   schedule:
    - cron: '30 0,12 * * *'
 
-  # push:
+  push:
   # Hook to trigger a manual run.
   # See: https://goobar.io/2019/12/07/manually-trigger-a-github-actions-workflow/
   repository_dispatch:
@@ -20,7 +20,7 @@ env:
   COVID_DATA_MODEL_REF: 'master'
 
   # To pin to an old data sets, put the branch/tag/commit here:
-  COVID_DATA_PUBLIC_REF: 'master'
+  COVID_DATA_PUBLIC_REF: '1d5ea08606c6d0c5e9ad29493a19baa6d5279a39'
 
   # S3 Bucket (used by s3-sync-action tasks) to store final API snapshot.
   AWS_S3_BUCKET: 'data.covidactnow.org'

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -9,7 +9,7 @@ on:
   schedule:
    - cron: '30 0,12 * * *'
 
-  # push:
+  push:
   # Hook to trigger a manual run.
   # See: https://goobar.io/2019/12/07/manually-trigger-a-github-actions-workflow/
   repository_dispatch:
@@ -34,7 +34,7 @@ env:
 
   # Used by execute-model (for now) to optimize parallelization on self-hosted
   # runner.
-  COVID_MODEL_CORES: 96
+  COVID_MODEL_CORES: 48
 
   # Used by python code that reports errors to sentry.
   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -9,7 +9,7 @@ on:
   schedule:
    - cron: '30 0,12 * * *'
 
-  push:
+  # push:
   # Hook to trigger a manual run.
   # See: https://goobar.io/2019/12/07/manually-trigger-a-github-actions-workflow/
   repository_dispatch:
@@ -17,7 +17,7 @@ on:
 
 env:
   # !!! Change this to your BRANCH if you want to test it
-  COVID_DATA_MODEL_REF: 'test/snapshot-timeout'
+  COVID_DATA_MODEL_REF: 'master'
 
   # To pin to an old data sets, put the branch/tag/commit here:
   COVID_DATA_PUBLIC_REF: 'master'

--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -1,6 +1,5 @@
 from typing import Dict, Type, List, NewType
 import logging
-import functools
 import pandas as pd
 import structlog
 from structlog.threadlocal import tmp_bind

--- a/libs/datasets/dataset_utils.py
+++ b/libs/datasets/dataset_utils.py
@@ -210,7 +210,7 @@ def add_county_using_fips(data, fips_data):
     if len(non_matching):
         unique_fips = sorted(non_matching.fips.unique())
         _logger.warning(f"Did not match {len(unique_fips)} codes to county data.")
-        _logger.warning(f"{unique_fips}")
+        _logger.debug(f"{unique_fips}")
 
     if "county_r" in data.columns:
         data = data.drop(columns="county").rename({"county_r": "county"}, axis=1)

--- a/pyseir/backtest/backtester.py
+++ b/pyseir/backtest/backtester.py
@@ -581,5 +581,5 @@ def run_for_fips_list(
     """
 
     kwargs = kwargs or {}
-    with Pool() as p:
+    with Pool(maxtasksperchild=1) as p:
         p.map(partial(Backtester.run_for_fips, kwargs), fips)

--- a/pyseir/backtest/backtester.py
+++ b/pyseir/backtest/backtester.py
@@ -569,7 +569,7 @@ def run_for_fips_list(
           for defails, check: https://pandas.pydata.org/pandas-docs/version/0
           .23.4/generated/pandas.Series.rolling.html
         - ts_rolling_kernel_args:  dict, parameters for
-          pandas.Series.rolling window kernel, for defails, check description
+          pandas.Series.rolling window kernel, for details, check description
           of win_type in: https://pandas.pydata.org/pandas-docs/version/0.23
           .4/generated/pandas.Series.rolling.html
         - prediction_window_size
@@ -581,6 +581,5 @@ def run_for_fips_list(
     """
 
     kwargs = kwargs or {}
-    p = Pool()
-    p.map(partial(Backtester.run_for_fips, kwargs), fips)
-    p.close()
+    with Pool() as p:
+        p.map(partial(Backtester.run_for_fips, kwargs), fips)

--- a/pyseir/backtest/backtester.py
+++ b/pyseir/backtest/backtester.py
@@ -581,5 +581,5 @@ def run_for_fips_list(
     """
 
     kwargs = kwargs or {}
-    with Pool(maxtasksperchild=1) as p:
+    with Pool() as p:
         p.map(partial(Backtester.run_for_fips, kwargs), fips)

--- a/pyseir/cli.py
+++ b/pyseir/cli.py
@@ -208,7 +208,7 @@ def _build_all_for_states(
         _generate_whitelist()
 
     # do everything for just states in parallel
-    with Pool(maxtasksperchild=1) as p:
+    with Pool() as p:
         states_only_func = partial(
             _state_only_pipeline,
             run_mode=run_mode,
@@ -229,11 +229,11 @@ def _build_all_for_states(
         county_fips_per_state = {fips: state for fips in state_county_fips}
         all_county_fips.update(county_fips_per_state)
 
-    with Pool(maxtasksperchild=1) as p:
+    with Pool() as p:
         # calculate calculate county inference
         p.map(infer_rt_module.run_county, all_county_fips.keys())
 
-    with Pool(maxtasksperchild=1) as p:
+    with Pool() as p:
         # calculate model fit
         root.info(f"executing model for {len(all_county_fips)} counties")
         fitters = p.map(model_fitter._execute_model_for_fips, all_county_fips.keys())
@@ -243,7 +243,7 @@ def _build_all_for_states(
     df["mle_model"] = [fit.mle_model for fit in fitters if fit]
     df.index = df.fips
 
-    with Pool(maxtasksperchild=1) as p:
+    with Pool() as p:
         state_dfs = [state_df for name, state_df in df.groupby("state")]
         p.map(model_fitter._persist_results_per_state, state_dfs)
 
@@ -253,7 +253,7 @@ def _build_all_for_states(
         ensemble_runner._run_county,
         ensemble_kwargs=dict(run_mode=run_mode, generate_report=generate_reports),
     )
-    with Pool(maxtasksperchild=1) as p:
+    with Pool() as p:
         p.map(ensemble_func, all_county_fips.keys())
 
     # output it all

--- a/pyseir/cli.py
+++ b/pyseir/cli.py
@@ -208,7 +208,7 @@ def _build_all_for_states(
         _generate_whitelist()
 
     # do everything for just states in parallel
-    with Pool() as p:
+    with Pool(maxtasksperchild=1) as p:
         states_only_func = partial(
             _state_only_pipeline,
             run_mode=run_mode,
@@ -229,11 +229,11 @@ def _build_all_for_states(
         county_fips_per_state = {fips: state for fips in state_county_fips}
         all_county_fips.update(county_fips_per_state)
 
-    with Pool() as p:
+    with Pool(maxtasksperchild=1) as p:
         # calculate calculate county inference
         p.map(infer_rt_module.run_county, all_county_fips.keys())
 
-    with Pool() as p:
+    with Pool(maxtasksperchild=1) as p:
         # calculate model fit
         root.info(f"executing model for {len(all_county_fips)} counties")
         fitters = p.map(model_fitter._execute_model_for_fips, all_county_fips.keys())
@@ -243,7 +243,7 @@ def _build_all_for_states(
     df["mle_model"] = [fit.mle_model for fit in fitters if fit]
     df.index = df.fips
 
-    with Pool() as p:
+    with Pool(maxtasksperchild=1) as p:
         state_dfs = [state_df for name, state_df in df.groupby("state")]
         p.map(model_fitter._persist_results_per_state, state_dfs)
 
@@ -253,7 +253,7 @@ def _build_all_for_states(
         ensemble_runner._run_county,
         ensemble_kwargs=dict(run_mode=run_mode, generate_report=generate_reports),
     )
-    with Pool() as p:
+    with Pool(maxtasksperchild=1) as p:
         p.map(ensemble_func, all_county_fips.keys())
 
     # output it all

--- a/pyseir/cli.py
+++ b/pyseir/cli.py
@@ -204,7 +204,7 @@ def _build_all_for_states(
         _generate_whitelist()
 
     # do everything for just states in parallel
-    with Pool() as p:
+    with Pool(maxtasksperchild=1) as p:
         states_only_func = partial(
             _state_only_pipeline,
             run_mode=run_mode,
@@ -225,11 +225,11 @@ def _build_all_for_states(
         county_fips_per_state = {fips: state for fips in state_county_fips}
         all_county_fips.update(county_fips_per_state)
 
-    with Pool() as p:
+    with Pool(maxtasksperchild=1) as p:
         # calculate calculate county inference
         p.map(infer_rt_module.run_county, all_county_fips.keys())
 
-    with Pool() as p:
+    with Pool(maxtasksperchild=1) as p:
         # calculate model fit
         root.info(f"executing model for {len(all_county_fips)} counties")
         fitters = p.map(model_fitter._execute_model_for_fips, all_county_fips.keys())
@@ -239,7 +239,7 @@ def _build_all_for_states(
     df["mle_model"] = [fit.mle_model for fit in fitters if fit]
     df.index = df.fips
 
-    with Pool() as p:
+    with Pool(maxtasksperchild=1) as p:
         state_dfs = [state_df for name, state_df in df.groupby("state")]
         p.map(model_fitter._persist_results_per_state, state_dfs)
 
@@ -248,7 +248,7 @@ def _build_all_for_states(
     ensemble_func = partial(
         _run_county, ensemble_kwargs=dict(run_mode=run_mode, generate_report=generate_reports),
     )
-    with Pool() as p:
+    with Pool(maxtasksperchild=1) as p:
         p.map(ensemble_func, all_county_fips.keys())
 
     # output it all

--- a/pyseir/deployment/webui_data_adaptor_v1.py
+++ b/pyseir/deployment/webui_data_adaptor_v1.py
@@ -409,7 +409,7 @@ class WebUIDataAdaptorV1:
         if states_only:
             return
         else:
-            with Pool() as p:
+            with Pool(maxtasksperchild=1) as p:
                 p.map(self.map_fips, whitelisted_county_fips)
 
             return

--- a/pyseir/deployment/webui_data_adaptor_v1.py
+++ b/pyseir/deployment/webui_data_adaptor_v1.py
@@ -409,7 +409,7 @@ class WebUIDataAdaptorV1:
         if states_only:
             return
         else:
-            with Pool(maxtasksperchild=1) as p:
+            with Pool(maxtasksperchild=1, processes=2) as p:
                 p.map(self.map_fips, whitelisted_county_fips)
 
             return

--- a/pyseir/deployment/webui_data_adaptor_v1.py
+++ b/pyseir/deployment/webui_data_adaptor_v1.py
@@ -409,7 +409,7 @@ class WebUIDataAdaptorV1:
         if states_only:
             return
         else:
-            with Pool(maxtasksperchild=1, processes=2) as p:
+            with Pool() as p:
                 p.map(self.map_fips, whitelisted_county_fips)
 
             return

--- a/pyseir/deployment/webui_data_adaptor_v1.py
+++ b/pyseir/deployment/webui_data_adaptor_v1.py
@@ -409,10 +409,9 @@ class WebUIDataAdaptorV1:
         if states_only:
             return
         else:
-            p = Pool()
-            p.map(self.map_fips, whitelisted_county_fips)
-            p.close()
-            p.join()
+            with Pool() as p:
+                p.map(self.map_fips, whitelisted_county_fips)
+
             return
 
 

--- a/pyseir/ensembles/ensemble_runner.py
+++ b/pyseir/ensembles/ensemble_runner.py
@@ -478,6 +478,6 @@ def run_state(state, ensemble_kwargs, states_only=False):
     if not states_only:
         # Run county level
         all_fips = load_data.get_all_fips_codes_for_a_state(state)
-        with Pool(maxtasksperchild=1, processes=2) as p:
+        with Pool() as p:
             f = partial(_run_county, ensemble_kwargs=ensemble_kwargs)
             p.map(f, all_fips)

--- a/pyseir/ensembles/ensemble_runner.py
+++ b/pyseir/ensembles/ensemble_runner.py
@@ -478,6 +478,6 @@ def run_state(state, ensemble_kwargs, states_only=False):
     if not states_only:
         # Run county level
         all_fips = load_data.get_all_fips_codes_for_a_state(state)
-        with Pool(maxtasksperchild=1) as p:
+        with Pool(maxtasksperchild=1, processes=2) as p:
             f = partial(_run_county, ensemble_kwargs=ensemble_kwargs)
             p.map(f, all_fips)

--- a/pyseir/ensembles/ensemble_runner.py
+++ b/pyseir/ensembles/ensemble_runner.py
@@ -17,7 +17,6 @@ from pyseir.reports.county_report import CountyReport
 from pyseir.utils import get_run_artifact_path, RunArtifact, RunMode
 from pyseir.inference import fit_results
 from libs.datasets.dataset_utils import AggregationLevel
-from libs.datasets import JHUDataset
 
 
 _logger = logging.getLogger(__name__)
@@ -99,19 +98,6 @@ class EnsembleRunner:
 
             self.output_file_report = None
             self.output_file_data = get_run_artifact_path(self.fips, RunArtifact.ENSEMBLE_RESULT)
-
-        county_fips = None if self.agg_level is AggregationLevel.STATE else self.fips
-
-        # if not covid_timeseries:
-        #     # TODO(tom): deprecate all code paths that get here. I'm trying to move towards loading all data
-        #     # once and passing it around in parameters.
-        #     covid_timeseries = JHUDataset.local().timeseries()
-        # else:
-        #     covid_timeseries = covid_timeseries.timeseries()
-        #
-        # self.covid_data = covid_timeseries.get_data(
-        #     aggregation_level=self.agg_level, country="USA", state=self.state_abbr, fips=county_fips
-        # ).sort_values("date")
 
         os.makedirs(os.path.dirname(self.output_file_data), exist_ok=True)
         if self.output_file_report:

--- a/pyseir/ensembles/ensemble_runner.py
+++ b/pyseir/ensembles/ensemble_runner.py
@@ -478,6 +478,6 @@ def run_state(state, ensemble_kwargs, states_only=False):
     if not states_only:
         # Run county level
         all_fips = load_data.get_all_fips_codes_for_a_state(state)
-        with Pool() as p:
+        with Pool(maxtasksperchild=1) as p:
             f = partial(_run_county, ensemble_kwargs=ensemble_kwargs)
             p.map(f, all_fips)

--- a/pyseir/ensembles/ensemble_runner.py
+++ b/pyseir/ensembles/ensemble_runner.py
@@ -464,6 +464,6 @@ def run_state(state, ensemble_kwargs, states_only=False):
     if not states_only:
         # Run county level
         all_fips = load_data.get_all_fips_codes_for_a_state(state)
-        with Pool() as p:
+        with Pool(maxtasksperchild=1) as p:
             f = partial(_run_county, ensemble_kwargs=ensemble_kwargs)
             p.map(f, all_fips)

--- a/pyseir/ensembles/ensemble_runner.py
+++ b/pyseir/ensembles/ensemble_runner.py
@@ -478,7 +478,6 @@ def run_state(state, ensemble_kwargs, states_only=False):
     if not states_only:
         # Run county level
         all_fips = load_data.get_all_fips_codes_for_a_state(state)
-        p = Pool()
-        f = partial(_run_county, ensemble_kwargs=ensemble_kwargs)
-        p.map(f, all_fips)
-        p.close()
+        with Pool() as p:
+            f = partial(_run_county, ensemble_kwargs=ensemble_kwargs)
+            p.map(f, all_fips)

--- a/pyseir/ensembles/ensemble_runner.py
+++ b/pyseir/ensembles/ensemble_runner.py
@@ -102,16 +102,16 @@ class EnsembleRunner:
 
         county_fips = None if self.agg_level is AggregationLevel.STATE else self.fips
 
-        if not covid_timeseries:
-            # TODO(tom): deprecate all code paths that get here. I'm trying to move towards loading all data
-            # once and passing it around in parameters.
-            covid_timeseries = JHUDataset.local().timeseries()
-        else:
-            covid_timeseries = covid_timeseries.timeseries()
-
-        self.covid_data = covid_timeseries.get_data(
-            aggregation_level=self.agg_level, country="USA", state=self.state_abbr, fips=county_fips
-        ).sort_values("date")
+        # if not covid_timeseries:
+        #     # TODO(tom): deprecate all code paths that get here. I'm trying to move towards loading all data
+        #     # once and passing it around in parameters.
+        #     covid_timeseries = JHUDataset.local().timeseries()
+        # else:
+        #     covid_timeseries = covid_timeseries.timeseries()
+        #
+        # self.covid_data = covid_timeseries.get_data(
+        #     aggregation_level=self.agg_level, country="USA", state=self.state_abbr, fips=county_fips
+        # ).sort_values("date")
 
         os.makedirs(os.path.dirname(self.output_file_data), exist_ok=True)
         if self.output_file_report:

--- a/pyseir/inference/initial_conditions_fitter.py
+++ b/pyseir/inference/initial_conditions_fitter.py
@@ -252,7 +252,7 @@ def generate_start_times_for_state(state, generate_report=False):
 
     # Fit exponential model to extract T0.
     f = partial(_fit_fips, generate_report=generate_report)
-    with Pool(maxtasksperchild=1) as p:
+    with Pool(maxtasksperchild=1, processes=2) as p:
         fips_to_fit_map = {
             fips: val for fips, val in zip(counties.values, p.map(f, counties.values))
         }

--- a/pyseir/inference/initial_conditions_fitter.py
+++ b/pyseir/inference/initial_conditions_fitter.py
@@ -252,9 +252,10 @@ def generate_start_times_for_state(state, generate_report=False):
 
     # Fit exponential model to extract T0.
     f = partial(_fit_fips, generate_report=generate_report)
-    p = Pool()
-    fips_to_fit_map = {fips: val for fips, val in zip(counties.values, p.map(f, counties.values))}
-    p.close()
+    with Pool() as p:
+        fips_to_fit_map = {
+            fips: val for fips, val in zip(counties.values, p.map(f, counties.values))
+        }
 
     # --------------------------------
     # ML to Impute start time for counties with no data based on pop. density

--- a/pyseir/inference/initial_conditions_fitter.py
+++ b/pyseir/inference/initial_conditions_fitter.py
@@ -252,7 +252,7 @@ def generate_start_times_for_state(state, generate_report=False):
 
     # Fit exponential model to extract T0.
     f = partial(_fit_fips, generate_report=generate_report)
-    with Pool(maxtasksperchild=1, processes=2) as p:
+    with Pool() as p:
         fips_to_fit_map = {
             fips: val for fips, val in zip(counties.values, p.map(f, counties.values))
         }

--- a/pyseir/inference/initial_conditions_fitter.py
+++ b/pyseir/inference/initial_conditions_fitter.py
@@ -252,7 +252,7 @@ def generate_start_times_for_state(state, generate_report=False):
 
     # Fit exponential model to extract T0.
     f = partial(_fit_fips, generate_report=generate_report)
-    with Pool() as p:
+    with Pool(maxtasksperchild=1) as p:
         fips_to_fit_map = {
             fips: val for fips, val in zip(counties.values, p.map(f, counties.values))
         }

--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -1081,9 +1081,8 @@ def run_state(state, states_only=False, with_age_structure=False):
         ].fips.values
 
         if len(all_fips) > 0:
-            p = Pool()
-            fitters = p.map(ModelFitter.run_for_fips, all_fips)
-            p.close()
+            with Pool() as p:
+                fitters = p.map(ModelFitter.run_for_fips, all_fips)
 
             county_output_file = get_run_artifact_path(all_fips[0], RunArtifact.MLE_FIT_RESULT)
             data = pd.DataFrame([fit.fit_results for fit in fitters if fit])

--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -1081,7 +1081,7 @@ def run_state(state, states_only=False, with_age_structure=False):
         ].fips.values
 
         if len(all_fips) > 0:
-            with Pool() as p:
+            with Pool(maxtasksperchild=1) as p:
                 fitters = p.map(ModelFitter.run_for_fips, all_fips)
 
             county_output_file = get_run_artifact_path(all_fips[0], RunArtifact.MLE_FIT_RESULT)

--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -1081,7 +1081,7 @@ def run_state(state, states_only=False, with_age_structure=False):
         ].fips.values
 
         if len(all_fips) > 0:
-            with Pool(maxtasksperchild=1, processes=2) as p:
+            with Pool() as p:
                 fitters = p.map(ModelFitter.run_for_fips, all_fips)
 
             county_output_file = get_run_artifact_path(all_fips[0], RunArtifact.MLE_FIT_RESULT)

--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -1081,7 +1081,7 @@ def run_state(state, states_only=False, with_age_structure=False):
         ].fips.values
 
         if len(all_fips) > 0:
-            with Pool(maxtasksperchild=1) as p:
+            with Pool(maxtasksperchild=1, processes=2) as p:
                 fitters = p.map(ModelFitter.run_for_fips, all_fips)
 
             county_output_file = get_run_artifact_path(all_fips[0], RunArtifact.MLE_FIT_RESULT)


### PR DESCRIPTION
This PR addresses issue https://trello.com/c/m7jfBoUo/254-covid-data-model-snapshots-timing-out.

The snapshot builds started to slow down over the week of 14 June 2020 and by Saturday evening the build had timed out (6 hours). Watching the build machine during a build (see htop screenshots in trello) shows a large ramp up of reserved RAM during the ensemble_runner code to the point that all RAM is assigned. There is no paging, so the machine essentially just stalls until a 6 hour watchdog timer in github kicks us out.

During the initial troubleshooting, I wrapped all the map calls in the appropriate context loops to ensure they were closed. Then I limited the nested pool calls to limit the children processes of the inner loop. Finally, I realized that each ensemble_runner.EnsembleRunner instance was load the JHU dataset and then not using it. The hypothesis is that our profligate loading didn't become a problem until the JHU dataset became large enough that having 100s of copies finally ran into our memory limits.

There are no usages of the class outside of that module. By removing that call in the init, the memory overload has been fixed and we've removed another path that accesses individual datasets instead of combined_dataset.

I removed the limits of the pools (maxtasksperchild), although these didn't significantly slow down runtime. It's clear we aren't memory-bound in normal usage, but the 186GB comes with the cores.

It's also worth nothing that the first couple minutes of execute-model, all of execute-api and all of push-snapshot-to-s3 are sequential and using a single core at the moment. I've talked with Simon and agree that removing WebUI while combining it with execute-api is the lowest hanging fruit going forward for simplicity, readability, and speed.

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [ ] Are tests passing?
