### PR TITLE
Move run.py and cli.py to common_init.configure_logging

### DIFF
--- a/libs/build_processed_dataset.py
+++ b/libs/build_processed_dataset.py
@@ -1,7 +1,6 @@
 import pandas as pd
 import requests
 import logging
-import sentry_sdk
 from functools import lru_cache
 
 from libs.datasets.combined_datasets import build_us_timeseries_with_all_fields

--- a/pyseir/inference/infer_rt.py
+++ b/pyseir/inference/infer_rt.py
@@ -1,7 +1,6 @@
 import math
 from datetime import datetime, timedelta
 import numpy as np
-import sentry_sdk
 import logging
 import pandas as pd
 from scipy import stats as sps
@@ -692,8 +691,8 @@ class RtInferenceEngine:
         try:
             engine = cls(fips)
             return engine.infer_all()
-        except Exception as e:
-            sentry_sdk.capture_exception(e)
+        except Exception:
+            logging.exception("run_for_fips failed")
             return None
 
 


### PR DESCRIPTION
https://trello.com/c/dQDAHHIH/239-ensure-loginfo-doesnt-log-to-sentry

* replace run and cli logging init with calls to common_init.configure_logging
* replace most direct use of sentry_sdk with calls to stdlib logging.


### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [ ] Are tests passing?
