### PR TITLE
GitHub Self-Hosted Runner Queue

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -44,15 +44,17 @@ env:
 
 
 jobs:
-  execute-model:
+  build-entire-job:
     runs-on: self-hosted
     steps:
+
     - name: Checkout covid-data-model
       uses: actions/checkout@v2
       with:
         repository: covid-projections/covid-data-model
         path: covid-data-model
         ref: '${{env.COVID_DATA_MODEL_REF}}'
+
     - name: Checkout covid-data-public
       uses: actions/checkout@v2
       with:
@@ -60,11 +62,13 @@ jobs:
         path: covid-data-public
         lfs: true
         ref: '${{env.COVID_DATA_PUBLIC_REF}}'
+
     - name: Setup Python
       uses: actions/setup-python@v1
       with:
         python-version: '3.7.6'
         architecture: 'x64'
+
     - name: Cache Pip
       uses: actions/cache@v1
       with:
@@ -73,79 +77,29 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
           ${{ runner.os }}-
+
     - name: Install Dependencies
       working-directory: ./covid-data-model
       run: pip install -r requirements.txt
 
-    # - name: create temp file
-    #   run: |
-    #     mkdir -p /data/api-results-${{env.SNAPSHOT_ID}}
-    #     touch /data/api-results-${{env.SNAPSHOT_ID}}/deleteme
     - name: run raw data QA
       run: ./covid-data-model/run.sh ./covid-data-public /data/api-results-${{env.SNAPSHOT_ID}} execute_raw_data_qa
+
     - name: Build Model Results (run.sh .. .. execute_model)
       run: ./covid-data-model/run.sh ./covid-data-public /data/api-results-${{env.SNAPSHOT_ID}} execute_model
+
     - name: Zip Model Results (run.sh .. .. execute_zip_folder)
       run: ./covid-data-model/run.sh ./covid-data-public /data/api-results-${{env.SNAPSHOT_ID}} execute_zip_folder
+
     - name: Upload Raw Data QA and Model Results
       uses: actions/upload-artifact@v2-preview
       with:
         name: model-results-${{env.SNAPSHOT_ID}}
         path: /data/api-results-${{env.SNAPSHOT_ID}}/api-results.zip
 
-  execute-api:
-    runs-on: self-hosted
-    needs: execute-model
-    steps:
-    - name: Checkout covid-data-model
-      uses: actions/checkout@v2
-      with:
-        repository: covid-projections/covid-data-model
-        path: covid-data-model
-        ref: '${{env.COVID_DATA_MODEL_REF}}'
-    - name: Checkout covid-data-public
-      uses: actions/checkout@v2
-      with:
-        repository: covid-projections/covid-data-public
-        path: covid-data-public
-        lfs: true
-        ref: '${{env.COVID_DATA_PUBLIC_REF}}'
-    - name: Setup Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: '3.7.6'
-        architecture: 'x64'
-    - name: Cache Pip
-      uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-          ${{ runner.os }}-
-    - name: Install Dependencies
-      working-directory: ./covid-data-model
-      run: pip install -r requirements.txt
-
-    # - uses: actions/download-artifact@v1
-    #   with:
-    #     name: model-results
-    #     path: ./api-results
     - name: Build API (run.sh .. .. execute_api)
       run: ./covid-data-model/run.sh ./covid-data-public /data/api-results-${{env.SNAPSHOT_ID}} execute_api
-    # - name: Upload API with Model Results
-    #   uses: actions/upload-artifact@v1
-    #   with:
-    #     name: model-results-with-api
-    #     path: ./api-results
 
-  push-snapshot-to-s3:
-    runs-on: self-hosted
-    needs:
-      - execute-model
-      - execute-api
-
-    steps:
     - name: make and copy to local tmp directory
       run: |
         mkdir -p ./tmp/data/
@@ -165,12 +119,6 @@ jobs:
       run: |
         rm -rf ./tmp/data/
 
-  finish:
-    runs-on: self-hosted
-    needs:
-      - push-snapshot-to-s3
-
-    steps:
     - name: Maybe trigger covid-projections repo to use new snapshot.
       env:
         GITHUB_TOKEN: ${{ secrets.CAN_ROBOT_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -16,7 +16,7 @@ on:
     types: publish-api
 
 env:
-  # !!! Change this to your BRANCH if you want to test it !!!
+  # !! Change this to your BRANCH if you want to test it !!
   COVID_DATA_MODEL_REF: 'github-runner-queue'
 
   # To pin to an old data sets, put the branch/tag/commit here:

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   # !!! Change this to your BRANCH if you want to test it
-  COVID_DATA_MODEL_REF: 'master'
+  COVID_DATA_MODEL_REF: 'github-runner-queue'
 
   # To pin to an old data sets, put the branch/tag/commit here:
   COVID_DATA_PUBLIC_REF: 'master'

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -9,14 +9,14 @@ on:
   schedule:
    - cron: '30 0,12 * * *'
 
-  # push:
+  push:
   # Hook to trigger a manual run.
   # See: https://goobar.io/2019/12/07/manually-trigger-a-github-actions-workflow/
   repository_dispatch:
     types: publish-api
 
 env:
-  # !!! Change this to your BRANCH if you want to test it
+  # !!! Change this to your BRANCH if you want to test it !!!
   COVID_DATA_MODEL_REF: 'github-runner-queue'
 
   # To pin to an old data sets, put the branch/tag/commit here:

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -9,7 +9,7 @@ on:
   schedule:
    - cron: '30 0,12 * * *'
 
-  push:
+  # push:
   # Hook to trigger a manual run.
   # See: https://goobar.io/2019/12/07/manually-trigger-a-github-actions-workflow/
   repository_dispatch:

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -16,7 +16,7 @@ on:
     types: publish-api
 
 env:
-  # !! Change this to your BRANCH if you want to test it !!
+  # !!! Change this to your BRANCH if you want to test it !!!
   COVID_DATA_MODEL_REF: 'github-runner-queue'
 
   # To pin to an old data sets, put the branch/tag/commit here:

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   # !!! Change this to your BRANCH if you want to test it !!!
-  COVID_DATA_MODEL_REF: 'github-runner-queue'
+  COVID_DATA_MODEL_REF: 'master'
 
   # To pin to an old data sets, put the branch/tag/commit here:
   COVID_DATA_PUBLIC_REF: 'master'
@@ -44,7 +44,7 @@ env:
 
 
 jobs:
-  build-entire-job:
+  build-and-publish-snapshot:
     runs-on: self-hosted
     steps:
 
@@ -119,7 +119,7 @@ jobs:
       run: |
         rm -rf ./tmp/data/
 
-    - name: Maybe trigger covid-projections repo to use new snapshot.
+    - name: Trigger website PR generation if conditions are met (master branch, morning build, etc)
       env:
         GITHUB_TOKEN: ${{ secrets.CAN_ROBOT_PERSONAL_ACCESS_TOKEN }}
       run: ./covid-data-model/tools/maybe-trigger-web-snapshot-update.sh ${{env.SNAPSHOT_ID}} ${{env.COVID_DATA_MODEL_REF}} ${{env.COVID_DATA_PUBLIC_REF}}


### PR DESCRIPTION
Enforce a queue to the GitHub self-hosted runner that treats the creation of the entire snapshot as the job.

The previous version separated the workflow into multiple "jobs" that were linearly dependent on each other. That "jobs" abstraction is built to allow parallel processes, and if we used the GitHub hosted version it would run up to 20 jobs in parallel. However, the runner built for self-hosting prioritizes the jobs across snapshots in a way that delays the time to first snapshot completion (without changing the time to last snapshot completion). Instead of completing all the jobs of the first snapshot, it will cycle through each outstanding snapshot request calling the next available job for that snapshot.

It is better to have the early snapshot complete and unblock the person waiting for it.

This is solved by switching a given snapshot to a single job with multiple steps. The "steps" abstraction is the correct mental model that enforces sequential ordering (which we want anyways in our current implementations). So this will send all the commands to the runner as one packet.

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [ ] Are tests passing?
