### PR TITLE
Fix key error exception handling

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -9,7 +9,7 @@ on:
   schedule:
    - cron: '30 0,12 * * *'
 
-  # push:
+  push:
   # Hook to trigger a manual run.
   # See: https://goobar.io/2019/12/07/manually-trigger-a-github-actions-workflow/
   repository_dispatch:
@@ -17,7 +17,7 @@ on:
 
 env:
   # !!! Change this to your BRANCH if you want to test it
-  COVID_DATA_MODEL_REF: 'master'
+  COVID_DATA_MODEL_REF: 'fix-key-error-exception-handling'
 
   # To pin to an old data sets, put the branch/tag/commit here:
   COVID_DATA_PUBLIC_REF: 'master'

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -9,7 +9,7 @@ on:
   schedule:
    - cron: '30 0,12 * * *'
 
-  push:
+  # push:
   # Hook to trigger a manual run.
   # See: https://goobar.io/2019/12/07/manually-trigger-a-github-actions-workflow/
   repository_dispatch:
@@ -17,7 +17,7 @@ on:
 
 env:
   # !!! Change this to your BRANCH if you want to test it
-  COVID_DATA_MODEL_REF: 'fix-key-error-exception-handling'
+  COVID_DATA_MODEL_REF: 'master'
 
   # To pin to an old data sets, put the branch/tag/commit here:
   COVID_DATA_PUBLIC_REF: 'master'

--- a/libs/datasets/sources/nytimes_dataset.py
+++ b/libs/datasets/sources/nytimes_dataset.py
@@ -47,11 +47,31 @@ class NYTimesDataset(data_source.DataSource):
     @classmethod
     def standardize_data(cls, data: pd.DataFrame) -> pd.DataFrame:
         data[cls.Fields.COUNTRY] = "USA"
+        data[cls.Fields.AGGREGATE_LEVEL] = "county"
         data = dataset_utils.strip_whitespace(data)
         data[cls.Fields.STATE] = data[cls.Fields.STATE].apply(dataset_utils.parse_state)
         # Super hacky way of filling in new york.
         data.loc[data[cls.Fields.COUNTY] == "New York City", "county"] = "New York County"
         data.loc[data[cls.Fields.COUNTY] == "New York County", "fips"] = "36061"
         data.loc[data[cls.Fields.COUNTY] == "Unknown", "fips"] = "99999"
-        data[cls.Fields.AGGREGATE_LEVEL] = "county"
-        return data
+
+        # https://github.com/nytimes/covid-19-data/blob/master/README.md#geographic-exceptions
+        # Both Joplin and Kansas City numbers are reported separately from the surrounding counties.
+        # Until we figure out a better way to spread amongst counties they are in, combining all
+        # data missing a fips into one unknown fips.
+        is_kc = data[cls.Fields.COUNTY] == "Kansas City"
+        is_joplin = data[cls.Fields.COUNTY] == "Joplin"
+        data.loc[is_kc | is_joplin, cls.Fields.FIPS] = "99999"
+        is_missouri = data[cls.Fields.STATE] == "MO"
+        is_unknown = data[cls.Fields.FIPS] == "99999"
+        missouri_unknown = data.loc[is_missouri & is_unknown, :]
+        group_columns = [
+            cls.Fields.AGGREGATE_LEVEL,
+            cls.Fields.FIPS,
+            cls.Fields.DATE,
+            cls.Fields.COUNTRY,
+            cls.Fields.STATE,
+        ]
+        missouri_unknown = missouri_unknown.groupby(group_columns).sum().reset_index()
+        missouri_unknown[cls.Fields.COUNTY] = "Aggregated City and Unknown Data"
+        return pd.concat([data.loc[~(is_missouri & is_unknown), :], missouri_unknown])

--- a/pyseir/cli.py
+++ b/pyseir/cli.py
@@ -193,11 +193,11 @@ def _build_all_for_states(
 ):
     # prepare data
     _cache_global_datasets()
-    # do everything for just states in parallel
 
     if not skip_whitelist:
         _generate_whitelist()
 
+    # do everything for just states in parallel
     with Pool(maxtasksperchild=1) as p:
         states_only_func = partial(
             _state_only_pipeline,

--- a/pyseir/cli.py
+++ b/pyseir/cli.py
@@ -194,6 +194,10 @@ def _build_all_for_states(
     # prepare data
     _cache_global_datasets()
     # do everything for just states in parallel
+
+    if not skip_whitelist:
+        _generate_whitelist()
+
     with Pool(maxtasksperchild=1) as p:
         states_only_func = partial(
             _state_only_pipeline,
@@ -207,9 +211,6 @@ def _build_all_for_states(
     if states_only:
         root.info("Only executing for states. returning.")
         return
-
-    if not skip_whitelist:
-        _generate_whitelist()
 
     all_county_fips = build_counties_to_run_per_state(states, fips=fips)
 

--- a/pyseir/cli.py
+++ b/pyseir/cli.py
@@ -393,7 +393,14 @@ def map_outputs(state, output_interval_days, run_mode, states_only):
 @click.option(
     "--skip-whitelist", default=False, is_flag=True, type=bool, help="Skip the whitelist phase.",
 )
-@click.option("--fips", help="County level fips code to restrict runs to.")
+@click.option(
+    "--fips",
+    help=(
+        "County level fips code to restrict runs to. "
+        "This does not restrict the states that run, so also specifying states with "
+        "`--states` is recommended."
+    ),
+)
 @click.option("--states-only", is_flag=True, help="If set, only runs on states.")
 @click.option("--output-dir", default=None, type=str, help="Directory to deploy webui output.")
 def build_all(

--- a/pyseir/cli.py
+++ b/pyseir/cli.py
@@ -24,15 +24,6 @@ from pyseir.inference.whitelist_generator import WhitelistGenerator
 sys.path.insert(0, os.path.join(os.path.abspath(os.path.dirname(__file__)), ".."))
 
 root = logging.getLogger()
-root.setLevel(logging.INFO)
-
-handler = logging.StreamHandler(sys.stdout)
-handler.setLevel(logging.DEBUG)
-formatter = logging.Formatter(
-    "%(asctime)s - %(filename)s - %(lineno)d - %(levelname)s - %(message)s"
-)
-handler.setFormatter(formatter)
-root.addHandler(handler)
 
 DEFAULT_RUN_MODE = "can-inference-derived"
 ALL_STATES = [getattr(state_obj, "name") for state_obj in us.STATES]

--- a/pyseir/deployment/webui_data_adaptor_v1.py
+++ b/pyseir/deployment/webui_data_adaptor_v1.py
@@ -312,8 +312,8 @@ class WebUIDataAdaptorV1:
             output_model = output_model.fillna(0)
 
             # Fill in results for the Rt indicator.
-            try:
-                rt_results = load_Rt_result(fips)
+            rt_results = load_Rt_result(fips)
+            if rt_results is not None:
                 rt_results.index = rt_results["Rt_MAP_composite"].index.strftime("%m/%d/%y")
                 merged = output_model.merge(
                     rt_results[["Rt_MAP_composite", "Rt_ci95_composite"]],
@@ -328,8 +328,12 @@ class WebUIDataAdaptorV1:
                 output_model[schema.RT_INDICATOR_CI90] = (
                     merged["Rt_ci95_composite"] - merged["Rt_MAP_composite"]
                 )
-            except (ValueError, KeyError) as e:
-                log.warning("Clearing Rt in output for fips.", fips=fips, exc_info=e)
+            else:
+                log.warning(
+                    "No Rt Results found, clearing Rt in output.",
+                    fips=fips,
+                    suppression_policy=suppression_policy,
+                )
                 output_model[schema.RT_INDICATOR] = "NaN"
                 output_model[schema.RT_INDICATOR_CI90] = "NaN"
 

--- a/pyseir/inference/fit_results.py
+++ b/pyseir/inference/fit_results.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import os
 from pyseir.load_data import load_county_metadata
 import ujson
@@ -53,7 +54,7 @@ def load_inference_result(fips):
         return df.set_index("fips").loc[fips].to_dict()
 
 
-def load_Rt_result(fips):
+def load_Rt_result(fips) -> Optional[pd.DataFrame]:
     """
     Load the Rt inference result.
 
@@ -68,4 +69,6 @@ def load_Rt_result(fips):
         DataFrame containing the R_t inferences.
     """
     path = get_run_artifact_path(fips, RunArtifact.RT_INFERENCE_RESULT)
+    if not os.path.exists(path):
+        return None
     return pd.read_json(path)

--- a/pyseir/inference/infer_rt.py
+++ b/pyseir/inference/infer_rt.py
@@ -956,7 +956,7 @@ def replace_outliers(
     m = r.mean().shift(1)
     s = r.std(ddof=0).shift(1)
     z_score = (x - m) / (s + EPSILON)
-    possible_changes_idx = np.where(z_score > z_threshold)[0]
+    possible_changes_idx = np.flatnonzero(z_score > z_threshold)
     changed_idx = []
     changed_value = []
     changed_snippets = []
@@ -968,8 +968,8 @@ def replace_outliers(
             slicer = slice(idx - local_lookback_window, idx + local_lookback_window)
             changed_snippets.append(x[slicer].astype(int).tolist())
             try:
-                x[idx] = np.mean([x[idx - 1], x[idx + 1]])
-            except KeyError:  # Value to replace can be newest and fail on x[idx+1].
+                x[idx] = np.mean([x.iloc[idx - 1], x.iloc[idx + 1]])
+            except IndexError:  # Value to replace can be newest and fail on x[idx+1].
                 # If so, just use previous.
                 x[idx] = x[idx - 1]
 

--- a/pyseir/inference/infer_rt.py
+++ b/pyseir/inference/infer_rt.py
@@ -969,7 +969,7 @@ def replace_outliers(
             changed_snippets.append(x[slicer].astype(int).tolist())
             try:
                 x[idx] = np.mean([x[idx - 1], x[idx + 1]])
-            except IndexError:  # Value to replace can be newest and fail on x[idx+1].
+            except KeyError:  # Value to replace can be newest and fail on x[idx+1].
                 # If so, just use previous.
                 x[idx] = x[idx - 1]
 

--- a/pyseir/inference/infer_rt.py
+++ b/pyseir/inference/infer_rt.py
@@ -629,73 +629,76 @@ class RtInferenceEngine:
 
             df = pd.DataFrame()
             dates, times, posteriors = self.get_posteriors(timeseries_type)
-
             # Note that it is possible for the dates to be missing days
             # This can cause problems when:
             #   1) computing posteriors that assume continuous data (above),
             #   2) when merging data with variable keys
-            if posteriors is not None:
-                df[f"Rt_MAP__{timeseries_type.value}"] = posteriors.idxmax()
-                for ci in self.confidence_intervals:
-                    ci_low, ci_high = self.highest_density_interval(posteriors, ci=ci)
+            if posteriors is None:
+                continue
 
-                    low_val = 1 - ci
-                    high_val = ci
-                    df[f"Rt_ci{int(math.floor(100 * low_val))}__{timeseries_type.value}"] = ci_low
-                    df[f"Rt_ci{int(math.floor(100 * high_val))}__{timeseries_type.value}"] = ci_high
+            df[f"Rt_MAP__{timeseries_type.value}"] = posteriors.idxmax()
+            for ci in self.confidence_intervals:
+                ci_low, ci_high = self.highest_density_interval(posteriors, ci=ci)
 
-                df["date"] = dates
-                df = df.set_index("date")
+                low_val = 1 - ci
+                high_val = ci
+                df[f"Rt_ci{int(math.floor(100 * low_val))}__{timeseries_type.value}"] = ci_low
+                df[f"Rt_ci{int(math.floor(100 * high_val))}__{timeseries_type.value}"] = ci_high
 
-                if df_all is None:
-                    df_all = df
-                else:
-                    # To avoid any surprises merging the data, keep only the keys from the case data
-                    # which will be the first added to df_all. So merge with how ="left" rather than "outer"
-                    df_all = df_all.merge(df, left_index=True, right_index=True, how="left")
+            df["date"] = dates
+            df = df.set_index("date")
 
-                # ------------------------------------------------
-                # Compute the indicator lag using the curvature
-                # alignment method.
-                # ------------------------------------------------
-                if (
-                    timeseries_type
-                    in (TimeseriesType.NEW_DEATHS, TimeseriesType.NEW_HOSPITALIZATIONS)
-                    and f"Rt_MAP__{TimeseriesType.NEW_CASES.value}" in df_all.columns
-                ):
+            if df_all is None:
+                df_all = df
+            else:
+                # To avoid any surprises merging the data, keep only the keys from the case data
+                # which will be the first added to df_all. So merge with how ="left" rather than "outer"
+                df_all = df_all.merge(df, left_index=True, right_index=True, how="left")
 
-                    # Go back up to 30 days or the max time series length we have if shorter.
-                    last_idx = max(-21, -len(df))
-                    series_a = df_all[f"Rt_MAP__{TimeseriesType.NEW_CASES.value}"].iloc[-last_idx:]
-                    series_b = df_all[f"Rt_MAP__{timeseries_type.value}"].iloc[-last_idx:]
+            # ------------------------------------------------
+            # Compute the indicator lag using the curvature
+            # alignment method.
+            # ------------------------------------------------
+            if (
+                timeseries_type in (TimeseriesType.NEW_DEATHS, TimeseriesType.NEW_HOSPITALIZATIONS)
+                and f"Rt_MAP__{TimeseriesType.NEW_CASES.value}" in df_all.columns
+            ):
 
-                    shift_in_days = self.align_time_series(series_a=series_a, series_b=series_b,)
+                # Go back up to 30 days or the max time series length we have if shorter.
+                last_idx = max(-21, -len(df))
+                series_a = df_all[f"Rt_MAP__{TimeseriesType.NEW_CASES.value}"].iloc[-last_idx:]
+                series_b = df_all[f"Rt_MAP__{timeseries_type.value}"].iloc[-last_idx:]
 
-                    df_all[f"lag_days__{timeseries_type.value}"] = shift_in_days
-                    logging.debug(
-                        "Using timeshift of: %s for timeseries type: %s ",
-                        shift_in_days,
-                        timeseries_type,
-                    )
-                    # Shift all the columns.
-                    for col in df_all.columns:
-                        if timeseries_type.value in col:
-                            df_all[col] = df_all[col].shift(shift_in_days)
-                            # Extend death and hopitalization rt signals beyond
-                            # shift to avoid sudden jumps in composite metric.
-                            #
-                            # N.B interpolate() behaves differently depending on the location
-                            # of the missing values: For any nans appearing in between valid
-                            # elements of the series, an interpolated value is filled in.
-                            # For values at the end of the series, the last *valid* value is used.
-                            logging.debug("Filling in %s missing values", shift_in_days)
-                            df_all[col] = df_all[col].interpolate(
-                                limit_direction="forward", method="linear"
-                            )
+                shift_in_days = self.align_time_series(series_a=series_a, series_b=series_b,)
+
+                df_all[f"lag_days__{timeseries_type.value}"] = shift_in_days
+                logging.debug(
+                    "Using timeshift of: %s for timeseries type: %s ",
+                    shift_in_days,
+                    timeseries_type,
+                )
+                # Shift all the columns.
+                for col in df_all.columns:
+                    if timeseries_type.value in col:
+                        df_all[col] = df_all[col].shift(shift_in_days)
+                        # Extend death and hopitalization rt signals beyond
+                        # shift to avoid sudden jumps in composite metric.
+                        #
+                        # N.B interpolate() behaves differently depending on the location
+                        # of the missing values: For any nans appearing in between valid
+                        # elements of the series, an interpolated value is filled in.
+                        # For values at the end of the series, the last *valid* value is used.
+                        logging.debug("Filling in %s missing values", shift_in_days)
+                        df_all[col] = df_all[col].interpolate(
+                            limit_direction="forward", method="linear"
+                        )
+
+        if df_all is None:
+            logging.warning("Inference not possible for fips: %s", self.fips)
+            return None
 
         if (
-            df_all is not None
-            and not InferRtConstants.DISABLE_DEATHS
+            not InferRtConstants.DISABLE_DEATHS
             and "Rt_MAP__new_deaths" in df_all
             and "Rt_MAP__new_cases" in df_all
         ):
@@ -709,7 +712,7 @@ class RtInferenceEngine:
             # any case.
             df_all["Rt_ci95_composite"] = df_all["Rt_ci95__new_cases"]
 
-        elif df_all is not None and "Rt_MAP__new_cases" in df_all:
+        elif "Rt_MAP__new_cases" in df_all:
             df_all["Rt_MAP_composite"] = df_all["Rt_MAP__new_cases"]
             df_all["Rt_ci95_composite"] = df_all["Rt_ci95__new_cases"]
 
@@ -737,7 +740,7 @@ class RtInferenceEngine:
                 )
             ).apply(lambda v: max(v, InferRtConstants.MIN_CONF_WIDTH)) + df_all["Rt_MAP_composite"]
 
-        if plot and df_all is not None:
+        if plot:
             plt.figure(figsize=(10, 6))
 
             # plt.hlines([1.0], *plt.xlim(), alpha=1, color="g")
@@ -837,7 +840,7 @@ class RtInferenceEngine:
             output_path = get_run_artifact_path(self.fips, RunArtifact.RT_INFERENCE_REPORT)
             plt.savefig(output_path, bbox_inches="tight")
             plt.close()
-        if df_all is None or df_all.empty:
+        if df_all.empty:
             logging.warning("Inference not possible for fips: %s", self.fips)
         return df_all
 

--- a/pyseir/load_data.py
+++ b/pyseir/load_data.py
@@ -381,11 +381,7 @@ def load_new_case_data_by_state(
         - state_case_data[CommonFields.DEATHS].values[:-1]
     )
 
-    return (
-        times_new,
-        np.array(observed_new_cases).clip(min=0),
-        observed_new_deaths.clip(min=0)
-    )
+    return (times_new, np.array(observed_new_cases).clip(min=0), observed_new_deaths.clip(min=0))
 
 
 def get_hospitalization_data():

--- a/pyseir/utils.py
+++ b/pyseir/utils.py
@@ -50,7 +50,7 @@ class RunArtifact(Enum):
     BACKTEST_RESULT = "backtest_result"
 
 
-def get_run_artifact_path(fips, artifact, output_dir=None):
+def get_run_artifact_path(fips, artifact, output_dir=None) -> str:
     """
     Get an artifact path for a given locale and artifact type.
 

--- a/test/pyseir/infer_rt_test.py
+++ b/test/pyseir/infer_rt_test.py
@@ -1,0 +1,12 @@
+import pandas as pd
+import structlog
+from pyseir.inference import infer_rt
+
+
+def test_replace_outliers_on_last_day():
+    x = pd.Series([10, 10, 10, 500], [0, 1, 2, 3])
+
+    results = infer_rt.replace_outliers(x, structlog.getLogger(), local_lookback_window=3)
+
+    expected = pd.Series([10, 10, 10, 10], [0, 1, 2, 3])
+    pd.testing.assert_series_equal(results, expected)

--- a/test/test_pyseir_end_to_end_test.py
+++ b/test/test_pyseir_end_to_end_test.py
@@ -32,6 +32,7 @@ def test__pyseir_end_to_end():
 
 @pytest.mark.parametrize("fips,expected_results", [(None, True), ("16013", True), ("26013", False)])
 def test_filters_counties_properly(fips, expected_results):
+    cli._generate_whitelist()
     results = cli.build_counties_to_run_per_state(["Idaho"], fips=fips)
     if fips and expected_results:
         assert results == {fips: "Idaho"}

--- a/test/test_pyseir_end_to_end_test.py
+++ b/test/test_pyseir_end_to_end_test.py
@@ -28,3 +28,15 @@ def test__pyseir_end_to_end():
 
     assert (output[rt_col].astype(float) > 0).any()
     assert (output.loc[output[rt_col].astype(float).notnull(), rt_col].astype(float) < 6).all()
+
+
+@pytest.mark.parametrize("fips,expected_results", [(None, True), ("16013", True), ("26013", False)])
+def test_filters_counties_properly(fips, expected_results):
+    results = cli.build_counties_to_run_per_state(["Idaho"], fips=fips)
+    if fips and expected_results:
+        assert results == {fips: "Idaho"}
+    elif expected_results:
+        assert results
+
+    if not expected_results:
+        assert results == {}


### PR DESCRIPTION
This PR addresses a handful of small pyseir bugs/warnings:
 * Adds an option to `pyseir build-all` to run on a single fips. This further filters the counties that it runs on.
 * Fixes (this)[https://sentry.io/organizations/covidactnow/issues/1748441676/] sentry error where infer rt was failing if an outlier was detected on the last day
 * Fixes (this)[https://sentry.io/organizations/covidactnow/issues/1736478765/] sentry error where if there were no timeseries for a county it would error out.
 * Fixes noisy logs in webui data adapter if a county didn't have a valid rt inference - before it was trying to load a non existing file, now it checks if path exists before reading into pandas data frame.
 * Removed hampel filtering in load data (duplicating Natasha's change)

Some of the larger diffs are just from doing a couple earlier returns.
