### PR TITLE
Dont return rt result if Rt composite doesnt exist

### DIFF
--- a/pyseir/inference/infer_rt.py
+++ b/pyseir/inference/infer_rt.py
@@ -716,6 +716,13 @@ class RtInferenceEngine:
             df_all["Rt_MAP_composite"] = df_all["Rt_MAP__new_cases"]
             df_all["Rt_ci95_composite"] = df_all["Rt_ci95__new_cases"]
 
+        if "Rt_MAP_composite" not in df_all.columns:
+            # Lacking a composite Rt indicates that there was not case or death data for fips,
+            # but there may be other timeseries (such as hospitalizations).
+            # Returning early here assumes we don't want to just report only hospitalization Rt.
+            log.warning("Rt composite not found, skipping", fips=self.fips)
+            return None
+
         # Optionally Smooth just Rt_MAP_composite.
         # Note this doesn't lag in time and preserves integral of Rteff over time
         for i in range(0, InferRtConstants.SMOOTH_RT_MAP_COMPOSITE):


### PR DESCRIPTION
This fixes [this](https://sentry.io/organizations/covidactnow/issues/1697483066/?project=5203044&query=is%3Aunresolved) sentry error.  

I believe it was a result of the latest Rt smoothing - the smoothing expects Rt composite to be there but that only exists when there is some case/death data.  

This fix isn't the best fix, but was what I felt most comfortable with.  I'm pretty sure this happens in low case count counties, so shouldn't be too impactful on a global level

I tested out fips 31081 in nebraska, and case/death data was filtered out, but the smoothed hospitalization data wasn't.  

One fix I would be in favor of doing is changing how we include hosps as an "available timeseries" [here](https://github.com/covid-projections/covid-data-model/blob/master/pyseir/inference/infer_rt.py#L614-L626).  we have a condition `if len(hosps > 3)` but it might be better to define a minimum hospitalization threshold.  

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [ ] Are tests passing?
