### PR TITLE
Fixing padded nans stripping off one too many days

### DIFF
--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -152,7 +152,7 @@ def _remove_padded_nans(df, columns):
 
     first_valid_index = min(df[column].first_valid_index() for column in columns)
     last_valid_index = max(df[column].last_valid_index() for column in columns)
-    df = df.iloc[first_valid_index:last_valid_index]
+    df = df.iloc[first_valid_index : last_valid_index + 1]
     return df.reset_index(drop=True)
 
 

--- a/test/combined_dataset_test.py
+++ b/test/combined_dataset_test.py
@@ -2,7 +2,7 @@ import logging
 import re
 
 import pytest
-
+import pandas as pd
 from covidactnow.datapublic.common_fields import CommonFields
 from libs.datasets import combined_datasets
 from libs.datasets.dataset_utils import AggregationLevel
@@ -115,3 +115,24 @@ def test_expected_field_in_sources(data_source_cls):
             else:
                 logging.info(f"Ignoring {state} in {data_source.SOURCE_NAME}")
         assert len(good_state) >= 48
+
+
+@pytest.mark.parametrize("include_na_at_end", [False, True])
+def test_remove_padded_nans(include_na_at_end):
+    rows = [
+        {"date": "2020-02-01", "cases": pd.NA},
+        {"date": "2020-02-02", "cases": pd.NA},
+        {"date": "2020-02-03", "cases": 1},
+        {"date": "2020-02-04", "cases": pd.NA},
+        {"date": "2020-02-05", "cases": 2},
+        {"date": "2020-02-06", "cases": 3},
+    ]
+    if include_na_at_end:
+        rows += [{"date": "2020-02-07", "cases": pd.NA}]
+
+    df = pd.DataFrame(rows)
+
+    results = combined_datasets._remove_padded_nans(df, ["cases"])
+    expected_series = pd.Series([1, pd.NA, 2, 3], name="cases")
+
+    pd.testing.assert_series_equal(results.cases, expected_series)


### PR DESCRIPTION
Fixes https://trello.com/c/ROauACzW/270-pyseir-load-data-not-returning-latest-day

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [ ] Are tests passing?
