### PR TITLE
Less FIPS 99999

### DIFF
--- a/libs/datasets/sources/dh_beds.py
+++ b/libs/datasets/sources/dh_beds.py
@@ -8,6 +8,7 @@ from libs.datasets import dataset_utils
 from libs.datasets.dataset_utils import AggregationLevel
 from libs.datasets import data_source
 from libs.datasets.common_fields import CommonIndexFields
+from libs.us_state_abbrev import ABBREV_US_UNKNOWN_COUNTY_FIPS
 
 _logger = logging.getLogger(__name__)
 
@@ -91,7 +92,7 @@ def match_county_to_fips(data, fips_data, county_key="county", state_key="state"
                 break
 
         if not match and state == "VI":
-            matched[key] = enums.UNKNOWN_FIPS
+            matched[key] = ABBREV_US_UNKNOWN_COUNTY_FIPS[state]
         elif not match:
             _logger.warning(f"Could not match {key}")
             if not counties_by_state[state]:
@@ -151,7 +152,7 @@ class DHBeds(data_source.DataSource):
         # Backfilling FIPS data based on county names.
         fips_data = dataset_utils.build_fips_data_frame()
         fips_data = fips_data[fips_data.aggregate_level == AggregationLevel.COUNTY.value]
-        fips_data = fips_data[fips_data.fips != "99999"]
+        fips_data = fips_data[fips_data.fips != enums.UNKNOWN_FIPS]
         data = match_county_to_fips(data, fips_data)
 
         data[cls.Fields.MAX_BED_COUNT] = data[

--- a/libs/datasets/sources/fips_population.py
+++ b/libs/datasets/sources/fips_population.py
@@ -4,7 +4,7 @@ import pandas as pd
 from covidactnow.datapublic.common_fields import CommonFields
 from libs.datasets import dataset_utils
 from libs.datasets import data_source
-from libs.us_state_abbrev import US_STATE_ABBREV, ABBREV_US_FIPS
+from libs.us_state_abbrev import US_STATE_ABBREV, ABBREV_US_FIPS, ABBREV_US_UNKNOWN_COUNTY_FIPS
 from libs import enums
 from libs.datasets.dataset_utils import AggregationLevel
 from libs.datasets.common_fields import CommonIndexFields
@@ -62,8 +62,7 @@ class FIPSPopulation(data_source.DataSource):
         for state in data.state.unique():
             row = {
                 cls.Fields.STATE: state,
-                # TODO(chris): Possibly separate fips out by state prefix
-                cls.Fields.FIPS: enums.UNKNOWN_FIPS,
+                cls.Fields.FIPS: ABBREV_US_UNKNOWN_COUNTY_FIPS[state],
                 cls.Fields.POPULATION: None,
                 cls.Fields.COUNTY: "Unknown",
             }

--- a/libs/datasets/sources/jhu_dataset.py
+++ b/libs/datasets/sources/jhu_dataset.py
@@ -137,7 +137,7 @@ class JHUDataset(data_source.DataSource):
             rows_to_replace, cls.Fields.STATE
         ].map(ABBREV_US_UNKNOWN_COUNTY_FIPS)
         still_no_fips = has_county & data[cls.Fields.FIPS].isnull()
-        if still_no_fips.sum() > 0:
+        if still_no_fips.any():
             _logger.warning(
                 f"County rows without FIPS: {data.loc[still_no_fips, [cls.Fields.STATE, cls.Fields.COUNTY]]}"
             )

--- a/libs/datasets/sources/jhu_dataset.py
+++ b/libs/datasets/sources/jhu_dataset.py
@@ -9,6 +9,7 @@ from libs.datasets import data_source
 from libs.datasets.common_fields import CommonIndexFields
 from libs.datasets.dataset_utils import AggregationLevel
 from libs import enums
+from libs.us_state_abbrev import ABBREV_US_UNKNOWN_COUNTY_FIPS
 
 _logger = logging.getLogger(__name__)
 
@@ -120,8 +121,6 @@ class JHUDataset(data_source.DataSource):
         """Fills incomplete county data.
 
         Most of this data is "unassigned" (at least in more recent days.
-        We probably need to either give each state its own fake FIP, or spread this
-        out over the existing counties for the state.
         """
         overrides = {
             # Assigning nantucket county to dukes and nantucket
@@ -134,7 +133,14 @@ class JHUDataset(data_source.DataSource):
 
         has_county = data[cls.Fields.COUNTY].notnull()
         rows_to_replace = has_county & data[cls.Fields.FIPS].isnull()
-        data.loc[rows_to_replace, cls.Fields.FIPS] = enums.UNKNOWN_FIPS
+        data.loc[rows_to_replace, cls.Fields.FIPS] = data.loc[
+            rows_to_replace, cls.Fields.STATE
+        ].map(ABBREV_US_UNKNOWN_COUNTY_FIPS)
+        still_no_fips = has_county & data[cls.Fields.FIPS].isnull()
+        if still_no_fips.sum() > 0:
+            _logger.warning(
+                f"County rows without FIPS: {data.loc[still_no_fips, [cls.Fields.STATE, cls.Fields.COUNTY]]}"
+            )
         return data
 
     @classmethod

--- a/libs/datasets/sources/nytimes_dataset.py
+++ b/libs/datasets/sources/nytimes_dataset.py
@@ -57,6 +57,8 @@ class NYTimesDataset(data_source.DataSource):
         # Super hacky way of filling in new york.
         data.loc[data[cls.Fields.COUNTY] == "New York City", "county"] = "New York County"
         data.loc[data[cls.Fields.COUNTY] == "New York County", "fips"] = "36061"
+
+        # UNKNOWN_FIPS is overwritten with values from ABBREV_US_UNKNOWN_COUNTY_FIPS below.
         data.loc[data[cls.Fields.COUNTY] == "Unknown", "fips"] = enums.UNKNOWN_FIPS
 
         # https://github.com/nytimes/covid-19-data/blob/master/README.md#geographic-exceptions

--- a/libs/datasets/sources/nytimes_dataset.py
+++ b/libs/datasets/sources/nytimes_dataset.py
@@ -1,9 +1,11 @@
 import pandas as pd
 
 from covidactnow.datapublic.common_fields import CommonFields
+from libs import enums
 from libs.datasets import data_source
 from libs.datasets import dataset_utils
 from libs.datasets.common_fields import CommonIndexFields
+from libs.us_state_abbrev import ABBREV_US_UNKNOWN_COUNTY_FIPS
 
 
 class NYTimesDataset(data_source.DataSource):
@@ -55,7 +57,7 @@ class NYTimesDataset(data_source.DataSource):
         # Super hacky way of filling in new york.
         data.loc[data[cls.Fields.COUNTY] == "New York City", "county"] = "New York County"
         data.loc[data[cls.Fields.COUNTY] == "New York County", "fips"] = "36061"
-        data.loc[data[cls.Fields.COUNTY] == "Unknown", "fips"] = "99999"
+        data.loc[data[cls.Fields.COUNTY] == "Unknown", "fips"] = enums.UNKNOWN_FIPS
 
         # https://github.com/nytimes/covid-19-data/blob/master/README.md#geographic-exceptions
         # Both Joplin and Kansas City numbers are reported separately from the surrounding counties.
@@ -63,9 +65,9 @@ class NYTimesDataset(data_source.DataSource):
         # data missing a fips into one unknown fips.
         is_kc = data[cls.Fields.COUNTY] == "Kansas City"
         is_joplin = data[cls.Fields.COUNTY] == "Joplin"
-        data.loc[is_kc | is_joplin, cls.Fields.FIPS] = "99999"
+        data.loc[is_kc | is_joplin, cls.Fields.FIPS] = enums.UNKNOWN_FIPS
         is_missouri = data[cls.Fields.STATE] == "MO"
-        is_unknown = data[cls.Fields.FIPS] == "99999"
+        is_unknown = data[cls.Fields.FIPS] == enums.UNKNOWN_FIPS
         missouri_unknown = data.loc[is_missouri & is_unknown, :]
         group_columns = [
             cls.Fields.AGGREGATE_LEVEL,
@@ -76,4 +78,12 @@ class NYTimesDataset(data_source.DataSource):
         ]
         missouri_unknown = missouri_unknown.groupby(group_columns).sum().reset_index()
         missouri_unknown[cls.Fields.COUNTY] = "Aggregated City and Unknown Data"
-        return pd.concat([data.loc[~(is_missouri & is_unknown), :], missouri_unknown])
+        data = pd.concat([data.loc[~(is_missouri & is_unknown), :], missouri_unknown])
+
+        # Change all the 99999 FIPS to per-state unknown
+        unknown_fips = data[cls.Fields.FIPS] == enums.UNKNOWN_FIPS
+        data.loc[unknown_fips, cls.Fields.FIPS] = data.loc[unknown_fips, cls.Fields.STATE].map(
+            ABBREV_US_UNKNOWN_COUNTY_FIPS
+        )
+
+        return data

--- a/libs/us_state_abbrev.py
+++ b/libs/us_state_abbrev.py
@@ -184,6 +184,10 @@ us_fips = {
 
 ABBREV_US_FIPS = {US_STATE_ABBREV[state]: fips for state, fips in us_fips.items()}
 
+# Map from 2 letter state abbreviation to 5 digit FIPS code of the unknown county of that state.
+# This is not an official FIPS code but lets us aggregate values within a state using FIPS codes.
+ABBREV_US_UNKNOWN_COUNTY_FIPS = {abbrev: f"{fips}999" for abbrev, fips in ABBREV_US_FIPS.items()}
+
 # thank you to @kinghelix and @trevormarburger for this idea
 abbrev_us_state = dict(map(reversed, US_STATE_ABBREV.items()))
 

--- a/test/us_state_abbrev_test.py
+++ b/test/us_state_abbrev_test.py
@@ -1,0 +1,17 @@
+from libs.us_state_abbrev import (
+    US_STATE_ABBREV,
+    abbrev_us_state,
+    ABBREV_US_FIPS,
+    ABBREV_US_UNKNOWN_COUNTY_FIPS,
+)
+
+
+def test():
+    assert US_STATE_ABBREV["Wisconsin"] == "WI"
+    assert abbrev_us_state["WI"] == "Wisconsin"
+    assert ABBREV_US_FIPS["TX"] == "48"
+
+    # Number of entries (50 states, DC, 5 Territories) == 56?
+    assert 56 == len(US_STATE_ABBREV)
+
+    assert ABBREV_US_UNKNOWN_COUNTY_FIPS["CA"] == "06999"

--- a/test/us_state_abbrev_test.py
+++ b/test/us_state_abbrev_test.py
@@ -6,7 +6,7 @@ from libs.us_state_abbrev import (
 )
 
 
-def test():
+def test_state_name_fips_abbrev_maps():
     assert US_STATE_ABBREV["Wisconsin"] == "WI"
     assert abbrev_us_state["WI"] == "Wisconsin"
     assert ABBREV_US_FIPS["TX"] == "48"


### PR DESCRIPTION
This PR reduces the use of FIPS 99999 by datasources, which is a step towards a world where we use only the FIPS as the region identifier.

## Test

Tested by comparing the combined latest data from master and this branch. I saw that the state aggregation values didn't change, ( 'cases', '99999') and ('deaths', '99999') were removed and bunch of new timeseries were added with FIPS such as 02999, 04999 etc.

```
git reset --hard origin/master
python ./run.py utils save-combined-csv --output-dir output/
python ./run.py utils save-combined-latest-csv --output-dir output/

git checkout tgb-fips-99999-no-more
python ./run.py utils save-combined-csv --output-dir output/
python ./run.py utils save-combined-latest-csv --output-dir output/

python ./run.py utils csv-diff output/combined-master-cc45347-20200630T141544.csv output/combined-tgb-fips-99999-no-more-0840909-20200630T143510.csv
```

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [ ] Are tests passing?
