### PR TITLE
Feature/rt unit tests and tail suppression

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -9,7 +9,7 @@ on:
   schedule:
    - cron: '30 0,12 * * *'
 
-  # push:
+push:
   # Hook to trigger a manual run.
   # See: https://goobar.io/2019/12/07/manually-trigger-a-github-actions-workflow/
   repository_dispatch:
@@ -17,7 +17,7 @@ on:
 
 env:
   # !!! Change this to your BRANCH if you want to test it
-  COVID_DATA_MODEL_REF: 'master'
+  COVID_DATA_MODEL_REF: 'feature/rt_unit_tests_and_tail_suppression'
 
   # To pin to an old data sets, put the branch/tag/commit here:
   COVID_DATA_PUBLIC_REF: 'master'

--- a/pyseir/inference/infer_rt.py
+++ b/pyseir/inference/infer_rt.py
@@ -46,7 +46,7 @@ class InferRtConstants:
 
     # Infer Rt only using cases if True
     # Recommend True as deaths just confuse intepretability of Rt_eff and will muddy using its extrapolation
-    DISABLE_DEATHS = False
+    DISABLE_DEATHS = True
 
     # Sets the default value for sigma before adustments
     # Recommend .03 (was .05 before when not adjusted) as adjustment moves up
@@ -58,7 +58,7 @@ class InferRtConstants:
 
     # Maximum increase (from DEFAULT_PROCESS_SIGMA) permitted for low counts
     # Recommend range 20. - 50. 30. appears to be best
-    MAX_SCALING_OF_SIGMA = 1.0
+    MAX_SCALING_OF_SIGMA = 30.0
 
     # Override min_cases and min_deaths with this value.
     # Recommend 1. - 5. range. 1. is allowing some counties to run that shouldn't (unphysical results)
@@ -175,9 +175,11 @@ class RtInferenceEngine:
                 self.ref_date,
                 include_testing_correction=self.include_testing_correction,
             )
-            self.times_raw_new_cases, self.raw_new_cases, _ = load_data.load_new_case_data_by_state(
-                self.state, self.ref_date, False
-            )
+            (
+                self.times_raw_new_cases,
+                self.raw_new_cases,
+                _,
+            ) = self.load_data.load_new_case_data_by_state(self.state, self.ref_date, False)
 
             (
                 self.hospital_times,
@@ -207,14 +209,16 @@ class RtInferenceEngine:
                 t0=self.ref_date,
                 include_testing_correction=self.include_testing_correction,
             )
-            self.times_raw_new_cases, self.raw_new_cases, _ = load_data.load_new_case_data_by_state(
-                self.state, self.ref_date, False
-            )
+            (
+                self.times_raw_new_cases,
+                self.raw_new_cases,
+                _,
+            ) = self.load_data.load_new_case_data_by_state(self.state, self.ref_date, False)
             (
                 self.hospital_times,
                 self.hospitalizations,
                 self.hospitalization_data_type,
-            ) = load_data.load_hospitalization_data(self.fips, t0=self.ref_date)
+            ) = self.load_data.load_hospitalization_data(self.fips, t0=self.ref_date)
 
         self.case_dates = [ref_date + timedelta(days=int(t)) for t in self.times]
         self.raw_new_case_dates = [

--- a/pyseir/inference/infer_rt.py
+++ b/pyseir/inference/infer_rt.py
@@ -42,7 +42,8 @@ class InferRtConstants:
 
     # Window size used during smoothing of cases and deaths
     # Originally 14 but odd is better and larger avoids edges that drive R unrealistically
-    COUNT_SMOOTHING_WINDOW_SIZE = 19
+    COUNT_SMOOTHING_WINDOW_SIZE = 23
+    COUNT_SMOOTHING_KERNEL_STD = 7
 
     # Infer Rt only using cases if True
     # Recommend True as deaths just confuse intepretability of Rt_eff and will muddy using its extrapolation
@@ -72,7 +73,7 @@ class InferRtConstants:
     # Smooth RTeff (Rt_MAP_composite) to make less reactive in the short term while retaining long
     # term shape correctly.
     SMOOTH_RT_MAP_COMPOSITE = 1  # number of times to apply soothing
-    RT_SMOOTHING_WINDOW_SIZE = 25  # also controls kernel_std
+    RT_SMOOTHING_WINDOW_SIZE = 14  # also controls kernel_std
 
     # Minimum (half) width of confidence interval in composite Rt
     # Avoids too narrow values when averaging over timeseries that already have high confidence
@@ -124,7 +125,7 @@ class RtInferenceEngine:
         self,
         fips,
         window_size=InferRtConstants.COUNT_SMOOTHING_WINDOW_SIZE,
-        kernel_std=5,
+        kernel_std=InferRtConstants.COUNT_SMOOTHING_KERNEL_STD,
         r_list=np.linspace(0, 10, 501),
         process_sigma=0.05,
         ref_date=datetime(year=2020, month=1, day=1),

--- a/pyseir/inference/infer_rt.py
+++ b/pyseir/inference/infer_rt.py
@@ -42,8 +42,8 @@ class InferRtConstants:
 
     # Window size used during smoothing of cases and deaths
     # Originally 14 but odd is better and larger avoids edges that drive R unrealistically
-    COUNT_SMOOTHING_WINDOW_SIZE = 23
-    COUNT_SMOOTHING_KERNEL_STD = 7
+    COUNT_SMOOTHING_WINDOW_SIZE = 19
+    COUNT_SMOOTHING_KERNEL_STD = 5
 
     # Infer Rt only using cases if True
     # Recommend True as deaths just confuse intepretability of Rt_eff and will muddy using its extrapolation
@@ -66,14 +66,14 @@ class InferRtConstants:
     MIN_COUNTS_TO_INFER = 5.0
     # TODO really understand whether the min_cases and/or min_deaths compares to max, avg, or day to day counts
 
-    # Correct for tail suppression due to case smoothing window converting from centered to lagging
-    # as approach curren time
+    # Correct for tail suppression (if > 0.) due to case smoothing window converting from centered to lagging
+    # as approach curren time. Disabled for now until more review possible
     CORRECT_TAIL_SUPRESSION = 0.75
 
     # Smooth RTeff (Rt_MAP_composite) to make less reactive in the short term while retaining long
     # term shape correctly.
     SMOOTH_RT_MAP_COMPOSITE = 1  # number of times to apply soothing
-    RT_SMOOTHING_WINDOW_SIZE = 14  # also controls kernel_std
+    RT_SMOOTHING_WINDOW_SIZE = 25  # also controls kernel_std
 
     # Minimum (half) width of confidence interval in composite Rt
     # Avoids too narrow values when averaging over timeseries that already have high confidence

--- a/pyseir/load_data.py
+++ b/pyseir/load_data.py
@@ -602,7 +602,9 @@ def _get_current_hospitalized(
 
 
 @lru_cache(maxsize=32)
-def load_new_test_data_by_fips(fips, t0, smoothing_tau=5, correction_threshold=5):
+def load_new_test_data_by_fips(
+    fips, t0, smoothing_tau=5, correction_threshold=5, use_recent_positivity=False
+):
     """
     Return a timeseries of new tests for a geography. Note that due to reporting
     discrepancies county to county, and state-to-state, these often do not go
@@ -636,6 +638,7 @@ def load_new_test_data_by_fips(fips, t0, smoothing_tau=5, correction_threshold=5
         Do not apply a correction if the incident cases per day is lower than
         this value. There can be instability if case counts are very low.
     """
+    EPSILON = 0.1
     fips_timeseries = combined_datasets.get_timeseries_for_fips(fips)
     df = fips_timeseries.data.copy()
 
@@ -647,16 +650,26 @@ def load_new_test_data_by_fips(fips, t0, smoothing_tau=5, correction_threshold=5
         :,
     ]
 
-    df["positivity_rate"] = df[CommonFields.POSITIVE_TESTS] / (
-        df[CommonFields.POSITIVE_TESTS] + df[CommonFields.NEGATIVE_TESTS]
-    )
-    df["new_positive"] = np.append([0], np.diff(df[CommonFields.POSITIVE_TESTS]))
-
     # The first derivative gets us new instead of cumulative tests while the second derivative gives us the change in new test rate.
+    df["new_positive"] = np.append([0], np.diff(df[CommonFields.POSITIVE_TESTS]))
     df["new_tests"] = np.append(
         [0], np.diff(df[CommonFields.POSITIVE_TESTS] + df[CommonFields.NEGATIVE_TESTS])
     )
     df["increase_in_new_tests"] = np.append([0], np.diff(df["new_tests"]))
+
+    # Filter out days with nonsensical new daily values
+    df = df.loc[(df["new_positive"] >= 0) & (df["new_tests"] >= 0)]
+
+    # Is test positive rate local in time or averaged over all time?
+    if use_recent_positivity:  # Change to use positivity from 7 day moving average
+        df["raw_positivity_rate"] = df["new_positive"] / (
+            df["new_tests"].apply(lambda v: max(EPSILON, v))
+        )
+        df["positivity_rate"] = df["raw_positivity_rate"].rolling(10, min_periods=1).mean()
+    else:  # Eric's original code
+        df["positivity_rate"] = df[CommonFields.POSITIVE_TESTS] / (
+            df[CommonFields.POSITIVE_TESTS] + df[CommonFields.NEGATIVE_TESTS]
+        )
 
     # dPositive / dTotal = 0.65 * positivity_rate was empirically determined by looking at
     # the increase in positives day-over-day relative to the increase in total tests across all 50 states.
@@ -677,6 +690,7 @@ def load_new_test_data_by_fips(fips, t0, smoothing_tau=5, correction_threshold=5
     df["expected_positives_from_test_increase"] = ewma_smoothing(
         df["expected_positives_from_test_increase"], smoothing_tau
     )
+    # don't bother making adjustment if its not significant
     df.loc[df["new_positive"] < 5, "expected_positives_from_test_increase"] = 0
 
     df["times"] = [

--- a/pyseir/utils.py
+++ b/pyseir/utils.py
@@ -32,7 +32,6 @@ class RunMode(Enum):
 
 
 class RunArtifact(Enum):
-    RT_SMOOTHING_REPORT = "rt_smoothing_report"
     RT_INFERENCE_RESULT = "rt_inference_result"
     RT_INFERENCE_REPORT = "rt_inference_report"
     RT_SMOOTHING_REPORT = "rt_smoothing_report"

--- a/pyseir/utils.py
+++ b/pyseir/utils.py
@@ -35,6 +35,7 @@ class RunArtifact(Enum):
     RT_SMOOTHING_REPORT = "rt_smoothing_report"
     RT_INFERENCE_RESULT = "rt_inference_result"
     RT_INFERENCE_REPORT = "rt_inference_report"
+    RT_SMOOTHING_REPORT = "rt_smoothing_report"
 
     MLE_FIT_RESULT = "mle_fit_result"
     MLE_FIT_MODEL = "mle_fit_model"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 # Per https://stackoverflow.com/a/42281313/341400
 python_classes=NoThanksNoClassDiscovery
+junit_family=xunit1

--- a/test/infer_rt_test.py
+++ b/test/infer_rt_test.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from pyseir.inference.infer_rt import RtInferenceEngine
 from test.mocks.inference.pyseir_default_parameters import pyseir_default_parameters
@@ -8,8 +9,6 @@ from test.mocks.inference.load_data import (
     DataSpec,
     RateChange,
 )
-
-import pytest
 
 """
 Tests of Rt inference code using synthetically generated data for 100 days where the following are specified

--- a/test/infer_rt_test.py
+++ b/test/infer_rt_test.py
@@ -20,7 +20,7 @@ Tests of Rt inference code using synthetically generated data for 100 days where
 Note that smoothing of values smears out the transitions +/- window_size/2 days
 """
 
-FAILURE_ERROR_FRACTION = 0.15
+FAILURE_ERROR_FRACTION = 0.2
 
 
 def test__cases_only_large_count_rising_falling_exponential():
@@ -122,7 +122,6 @@ def test__cases_only_small_count_late_rising_exponential():
 
     rt = df_all["Rt_MAP_composite"]
 
-    # Check expected values are within 10%
     # TODO remove adjustment here when incorporated in rt calculation
     assert (
         pytest.approx(rt[99] - 1.0, FAILURE_ERROR_FRACTION) == rt2 - 1.0

--- a/test/infer_rt_test.py
+++ b/test/infer_rt_test.py
@@ -1,0 +1,125 @@
+import numpy as np
+
+from pyseir.inference.infer_rt import RtInferenceEngine
+from test.mocks.inference.pyseir_default_parameters import pyseir_default_parameters
+from test.mocks.inference.load_data import (
+    initializeStateDataGenerator,
+    DataGeneratorType,
+    DataSpec,
+    RateChange,
+)
+
+import pytest
+
+"""
+Tests of Rt inference code using synthetically generated data for 100 days where the following are specified
+1) The starting count of cases (scale)
+2) One or two Rate changes - each with
+    2a) time at which the change occurs (first should have t0=0)
+    2b) The Rt value with which to generate growing (Rt>1) or decaying (Rt<1) values starting from t0
+
+Note that smoothing of values smears out the transitions +/- window_size/2 days
+"""
+
+
+def test__cases_only_large_count_rising_falling_exponential():
+    rt1 = 1.5
+    rt2 = 0.7
+    t_switch = 50
+
+    # This configures test data generator for state NY
+    initializeStateDataGenerator(
+        "NY",
+        DataSpec(
+            generator_type=DataGeneratorType.EXP,
+            disable_deaths=True,
+            scale=100.0,
+            ratechange1=RateChange(0, rt1),
+            ratechange2=RateChange(t_switch, rt2),
+        ),
+    )
+    engine = RtInferenceEngine(
+        "36",  # fips for NY
+        load_data_parent="test.mocks.inference",
+        default_parameters=pyseir_default_parameters,
+    )
+    df_all = engine.infer_all()
+
+    rt = df_all["Rt_MAP_composite"]
+
+    # Check expected values are within 10%
+    assert pytest.approx(rt[t_switch - 10], 0.1) == rt1  # settle into first rate change
+    assert pytest.approx(rt[t_switch + 20], 0.1) == rt2  # settle into 2nd rate change
+
+
+def test__cases_only_small_count_falling_exponential():
+
+    rt1 = 0.9
+    rt2 = 0.7
+    t0 = 50
+
+    # This configures test data generator for state NY
+    initializeStateDataGenerator(
+        "HI",
+        DataSpec(
+            generator_type=DataGeneratorType.EXP,
+            disable_deaths=True,
+            scale=50.0,
+            ratechange1=RateChange(0, rt1),
+            ratechange2=RateChange(t0, rt2),
+        ),
+    )
+    engine = RtInferenceEngine(
+        "15",  # fips for HI
+        load_data_parent="test.mocks.inference",
+        default_parameters=pyseir_default_parameters,
+    )
+    df_all = engine.infer_all()
+
+    rt = df_all["Rt_MAP_composite"]
+
+    # Check expected values are within 10%
+    assert pytest.approx(rt[t0 - 10], 0.1) == rt1  # agree first rate
+    # TODO when fixed - assert (pytest.approx(rt[t0 + 10], 0.1) == rt2) # agree 2nd rate
+
+
+def test__cases_only_small_count_late_rising_exponential():
+
+    rt1 = 0.95
+    rt2 = 1.5
+    t0 = 70
+
+    # This configures test data generator for state NY
+    initializeStateDataGenerator(
+        "AK",
+        DataSpec(
+            generator_type=DataGeneratorType.EXP,
+            disable_deaths=True,
+            scale=2000.0,
+            ratechange1=RateChange(0, rt1),
+            ratechange2=RateChange(t0, rt2),
+        ),
+    )
+    engine = RtInferenceEngine(
+        "02",  # fips for AK
+        load_data_parent="test.mocks.inference",
+        default_parameters=pyseir_default_parameters,
+    )
+    df_all = engine.infer_all()
+
+    rt = df_all["Rt_MAP_composite"]
+
+    # Calculate rt suppression by smoothing delay at tail of sequence
+    tail_suppression = np.concatenate(
+        [1.0 * np.ones(len(rt) - 7), np.array([1.0, 0.72, 0.67, 0.62, 0.56, 0.52, 0.48])]
+    )
+    # Adjust rt by undoing the supppression
+    rt_adj = (rt - 1.0) / tail_suppression + 1.0
+
+    print("last 20 adjusted", rt_adj.tail(20).apply(lambda v: f"%.2f" % v).values)
+
+    # Check expected values are within 10%
+    # TODO remove adjustment here when incorporated in rt calculation
+    assert (
+        pytest.approx(rt_adj[99], 0.05) == rt2
+    )  # settle into 2nd specified rate at low case count

--- a/test/mocks/inference/load_data.py
+++ b/test/mocks/inference/load_data.py
@@ -1,0 +1,121 @@
+import numpy as np
+from math import exp
+from collections import namedtuple
+from enum import Enum
+
+from pyseir.load_data import HospitalizationDataType
+from test.mocks.inference.pyseir_default_parameters import pyseir_default_parameters
+
+"""
+This module stubs out pyseir.load_data for testing purposes. It returns special data examples
+for specific tests. Different state names will be used to control this.
+"""
+
+SERIAL_PERIOD = (
+    1 / pyseir_default_parameters["sigma"] + 0.5 * 1 / pyseir_default_parameters["delta"]
+)
+
+
+class DataGeneratorType(Enum):
+    EXP = "exponential"
+    LIN = "linear"
+
+
+RateChange = namedtuple("RateChange", "t0 reff")
+DataSpec = namedtuple("DataSpec", "generator_type disable_deaths scale ratechange1 ratechange2")
+
+# Need this because API for cases and hospitalizations use different state identifiers
+# Each of these state generators is defined in a specific unit test
+state_to_code = {"New York": "NY", "Hawaii": "HI", "Alaska": "AK", "Alabama": "AL"}
+
+specs = {}
+# Initialize a data generator and associate it with a state so can be picked up with regular processing
+def initializeStateDataGenerator(state, dataspec):
+    specs[state] = dataspec
+
+
+class DataGenerator:
+    """
+    Generates data according to a sequence of growth rates that kick in at
+    various times (assumed to be integers starting from 0 and supplied in order).
+    Growth rate of 0. implies a constant value
+    """
+
+    def __init__(self, spec):
+        self.generator_type = spec.generator_type
+        self.disable_deaths = spec.disable_deaths
+        self.scale = spec.scale
+        self.growth_rate = None
+        self.t0 = None
+        self.last_value = spec.scale
+
+        self.rate_at = {}
+        for change in [spec.ratechange1, spec.ratechange2]:
+            if change is None:
+                continue
+            if self.generator_type == DataGeneratorType.EXP:
+                self.rate_at[change.t0] = (change.reff - 1.0) / SERIAL_PERIOD
+            else:
+                self.rate_at[change.t0] = change.reff
+
+    def generate_data(self, time):
+        if time in self.rate_at:
+            self.t0 = time
+            self.growth_rate = self.rate_at[time]
+            self.scale = self.last_value
+
+        if self.generator_type == DataGeneratorType.EXP:  # exponential growth
+            self.last_value = 1.0 * self.scale * exp(self.growth_rate * (time - self.t0))
+        else:  # linear growth
+            self.last_value = self.scale + self.growth_rate * (time - self.t0)
+        return self.last_value
+
+
+def _get_cases_for_times(generator, times):
+    return np.array(list(map(generator.generate_data, times)))
+
+
+def load_new_case_data_by_state(state, ref_date, include_testing_correction):
+    """
+    Generates case and death data.
+    Note stupidly called with full name of state
+    """
+    data_generator = DataGenerator(specs[state_to_code[state]])
+    times = list(range(0, 100))
+    observed_new_cases = _get_cases_for_times(data_generator, times)
+
+    if data_generator.disable_deaths:
+        observed_new_deaths = np.zeros(len(times))
+    else:
+        observed_new_deaths = 0.03 * observed_new_cases
+    return (times, observed_new_cases, observed_new_deaths)
+
+
+def load_hospitalization_data_by_state(state, t0=None):
+    data_generator = DataGenerator(specs[state])
+    times = list(range(0, 100))
+    observed_new_cases = _get_cases_for_times(data_generator, times)
+
+    if data_generator.disable_deaths:
+        hospitalizations = np.zeros(len(times))
+    else:
+        hospitalizations = 0.12 * observed_new_cases
+    return (times, hospitalizations, HospitalizationDataType.CURRENT_HOSPITALIZATIONS)
+
+
+# _________________Other methods to mock__________________
+# (
+#                 self.times,
+#                 self.observed_new_cases,
+#                 self.observed_new_deaths,
+#             ) = self.load_data.load_new_case_data_by_fips(
+#                 self.fips,
+#                 t0=self.ref_date,
+#                 include_testing_correction=self.include_testing_correction,
+#             )
+
+# (
+#                 self.hospital_times,
+#                 self.hospitalizations,
+#                 self.hospitalization_data_type,
+#             ) = load_hospitalization_data(self.fips, t0=self.ref_date)

--- a/test/mocks/inference/pyseir_default_parameters.py
+++ b/test/mocks/inference/pyseir_default_parameters.py
@@ -1,0 +1,11 @@
+pyseir_default_parameters = {
+    # Produces serial_time = 5
+    "sigma": 0.333,
+    "delta": 0.25,
+    "test_fraction": 0.1,
+    # Used when inferring new inferring new hospital admissions
+    "hospitalization_length_of_stay_general": 7.04,
+    "hospitalization_length_of_stay_icu": 8.00,
+    "hospitalization_rate_general": 0.0201,
+    "hospitalization_rate_icu": 0.00606,
+}


### PR DESCRIPTION
Want to get early feedback on how to mock inputs (loaded data and pyseir default parameters) to Rt inference process that allow test data and known serial_period to be injected to enable robust unit testing. Change also includes some basic unit tests on synthetic data and a fix for tail suppression (forcing Rt -> 1) at start and end of a timeseries due to smoothing changing from centered in time to one sided (e.g. lagging at end).

This PR addresses issue #<insert number>

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [ ] Are tests passing?
