### PR TITLE
Dont raise error on model fit failure

### DIFF
--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -667,8 +667,7 @@ class ModelFitter:
             return model_fitter
         except Exception:
             logging.exception(f"Failed to run {fips}")
-            raise
-            # return None
+            return None
 
 
 def _execute_model_for_fips(fips):


### PR DESCRIPTION
Looks like we were accidentally raising an error on a single model fitter failure rather than carrying on.  This should allow the build to not fail if one region fails