### PR TITLE
Disable outputting if model file is missing

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -9,7 +9,7 @@ on:
   schedule:
    - cron: '30 1,16 * * *'
 
-  # push:
+  push:
   # Hook to trigger a manual run.
   # See: https://goobar.io/2019/12/07/manually-trigger-a-github-actions-workflow/
   repository_dispatch:
@@ -17,7 +17,7 @@ on:
 
 env:
   # !!! Change this to your BRANCH if you want to test it
-  COVID_DATA_MODEL_REF: 'master'
+  COVID_DATA_MODEL_REF: 'disable-output-for-all-counties'
 
   # To pin to an old data sets, put the branch/tag/commit here:
   COVID_DATA_PUBLIC_REF: 'master'

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -9,7 +9,7 @@ on:
   schedule:
    - cron: '30 1,16 * * *'
 
-  push:
+  # push:
   # Hook to trigger a manual run.
   # See: https://goobar.io/2019/12/07/manually-trigger-a-github-actions-workflow/
   repository_dispatch:
@@ -17,7 +17,7 @@ on:
 
 env:
   # !!! Change this to your BRANCH if you want to test it
-  COVID_DATA_MODEL_REF: 'disable-output-for-all-counties'
+  COVID_DATA_MODEL_REF: 'master'
 
   # To pin to an old data sets, put the branch/tag/commit here:
   COVID_DATA_PUBLIC_REF: 'master'

--- a/libs/pipelines/api_pipeline.py
+++ b/libs/pipelines/api_pipeline.py
@@ -76,11 +76,16 @@ def build_timeseries_for_fips(
     model_output = CANPyseirLocationOutput.load_from_model_output_if_exists(
         fips, intervention, model_output_dir
     )
-    if not model_output and intervention is not Intervention.OBSERVED_INTERVENTION:
-        # All model output is currently tied to a specific intervention. However,
-        # we want to generate results for areas that don't have a fit result, but we're not
-        # duplicating non-model outputs.
+    # TODO(chris): Skipping returning all counties right now as the frontend expects projections
+    # and in many places errors out if there are no projections. Once the frontend can handle outputs
+    # without projections, this should be removed and the code below should be uncommented.
+    if not model_output:
         return None
+    # if not model_output and intervention is not Intervention.OBSERVED_INTERVENTION:
+    #     # All model output is currently tied to a specific intervention. However,
+    #     # we want to generate results for areas that don't have a fit result, but we're not
+    #     # duplicating non-model outputs.
+    #     return None
 
     try:
         area_summary = api.generate_area_summary(fips_latest, model_output)

--- a/test/libs/api_pipeline_test.py
+++ b/test/libs/api_pipeline_test.py
@@ -34,7 +34,9 @@ def test_build_timeseries_and_summary_outputs(nyc_model_output_path, nyc_fips, i
         intervention, us_latest, us_timeseries, nyc_model_output_path.parent, nyc_fips
     )
 
-    if intervention is Intervention.NO_INTERVENTION:
+    # TODO(chris): Uncomment and replace when API is outputting for all counties.
+    # if intervention is Intervention.NO_INTERVENTION:
+    if intervention is not Intervention.STRONG_INTERVENTION:
         # Test data does not contain no intervention model, should not output any results.
         assert not timeseries
         return
@@ -44,9 +46,10 @@ def test_build_timeseries_and_summary_outputs(nyc_model_output_path, nyc_fips, i
     if intervention is Intervention.STRONG_INTERVENTION:
         assert timeseries.projections
         assert timeseries.timeseries
-    elif intervention is Intervention.OBSERVED_INTERVENTION:
-        assert not timeseries.projections
-        assert not timeseries.timeseries
+    # TODO(chris): Uncomment when API is outputting for all counties
+    # elif intervention is Intervention.OBSERVED_INTERVENTION:
+    #     assert not timeseries.projections
+    #     assert not timeseries.timeseries
 
 
 def test_build_api_output_for_intervention(nyc_fips, nyc_model_output_path, tmp_path):


### PR DESCRIPTION
As of right now, the frontend breaks on counties where there aren't any projections.  this is a temporary band-aid to skip regions where we don't have models for them so the api outputs will not break the current page. 