### PR TITLE
Explore/limit test fraction to 0.1

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -20,9 +20,7 @@ env:
   COVID_DATA_MODEL_REF: 'explore/limit-test-fraction'
 
   # To pin to an old data sets, put the branch/tag/commit here:
-  COVID_DATA_PUBLIC_REF: 'master'
-
-
+  COVID_DATA_PUBLIC_REF: '5185374eafbc83c2bb4d0cd81054ad9ad00f8bd7'
 
   # S3 Bucket (used by s3-sync-action tasks) to store final API snapshot.
   AWS_S3_BUCKET: 'data.covidactnow.org'

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   # !!! Change this to your BRANCH if you want to test it
-  COVID_DATA_MODEL_REF: 'limit-test-fraction'
+  COVID_DATA_MODEL_REF: 'explore/limit-test-fraction'
 
   # To pin to an old data sets, put the branch/tag/commit here:
   COVID_DATA_PUBLIC_REF: 'master'

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -9,7 +9,7 @@ on:
   schedule:
    - cron: '30 1,16 * * *'
 
-  # push:
+  push:
   # Hook to trigger a manual run.
   # See: https://goobar.io/2019/12/07/manually-trigger-a-github-actions-workflow/
   repository_dispatch:
@@ -17,7 +17,7 @@ on:
 
 env:
   # !!! Change this to your BRANCH if you want to test it
-  COVID_DATA_MODEL_REF: 'master'
+  COVID_DATA_MODEL_REF: 'limit-test-fraction'
 
   # To pin to an old data sets, put the branch/tag/commit here:
   COVID_DATA_PUBLIC_REF: 'master'

--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -93,8 +93,8 @@ class ModelFitter:
         limit_t_delta_phases=[14, 100],  # good as of June 3, 2020 may need to update in the future
         error_t_delta_phases=1,
         test_fraction=0.1,
-        limit_test_fraction=[0.02, 1],
-        # fix_test_fraction=True,
+        # limit_test_fraction=[0.02, 1],
+        fix_test_fraction=True,
         error_test_fraction=0.02,
         hosp_fraction=1,
         # fix_hosp_fraction=True,
@@ -231,7 +231,7 @@ class ModelFitter:
             "eps2",
             "t_delta_phases",
             # "test_fraction",
-            # "hosp_fraction",
+            "hosp_fraction",
             "log10_I_initial",
         ]
         if self.fips in overwrite_params_df["fips"].values:

--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -93,8 +93,8 @@ class ModelFitter:
         limit_t_delta_phases=[14, 100],  # good as of June 3, 2020 may need to update in the future
         error_t_delta_phases=1,
         test_fraction=0.1,
-        # limit_test_fraction=[0.02, 1],
-        fix_test_fraction=True,
+        limit_test_fraction=[0.02, 1],
+        # fix_test_fraction=True,
         error_test_fraction=0.02,
         hosp_fraction=1,
         # fix_hosp_fraction=True,
@@ -230,7 +230,7 @@ class ModelFitter:
             "t_break",
             "eps2",
             "t_delta_phases",
-            # "test_fraction",
+            "test_fraction",
             "hosp_fraction",
             "log10_I_initial",
         ]

--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -93,6 +93,7 @@ class ModelFitter:
         # limit_test_fraction=[0.02, 1],
         fix_test_fraction=True,
         error_test_fraction=0.02,
+        hosp_fraction=1,
         fix_hosp_fraction=True,
         limit_hosp_fraction=[0.25, 1],
         error_hosp_fraction=0.05,

--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -90,7 +90,8 @@ class ModelFitter:
         limit_t_delta_phases=[14, 100],  # good as of June 3, 2020 may need to update in the future
         error_t_delta_phases=1,
         test_fraction=0.1,
-        limit_test_fraction=[0.02, 1],
+        # limit_test_fraction=[0.02, 1],
+        fix_test_fraction=True,
         error_test_fraction=0.02,
         hosp_fraction=0.7,
         limit_hosp_fraction=[0.25, 1],

--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -93,7 +93,7 @@ class ModelFitter:
         # limit_test_fraction=[0.02, 1],
         fix_test_fraction=True,
         error_test_fraction=0.02,
-        hosp_fraction=0.7,
+        fix_hosp_fraction=True,
         limit_hosp_fraction=[0.25, 1],
         error_hosp_fraction=0.05,
         # Let's not fit this to start...
@@ -226,8 +226,8 @@ class ModelFitter:
             "t_break",
             "eps2",
             "t_delta_phases",
-            "test_fraction",
-            "hosp_fraction",
+            # "test_fraction",
+            # "hosp_fraction",
             "log10_I_initial",
         ]
         if self.fips in overwrite_params_df["fips"].values:
@@ -235,9 +235,9 @@ class ModelFitter:
             for param in INITIAL_PARAM_SETS:
                 self.fit_params[param] = this_fips_df[param]
 
-        self.fit_params["fix_hosp_fraction"] = self.hospitalizations is None
-        if self.fit_params["fix_hosp_fraction"]:
-            self.fit_params["hosp_fraction"] = 1
+        # self.fit_params["fix_hosp_fraction"] = self.hospitalizations is None
+        # if self.fit_params["fix_hosp_fraction"]:
+        #     self.fit_params["hosp_fraction"] = 1
 
         if len(self.fips) == 5:
             OBSERVED_NEW_CASES_GUESS_THRESHOLD = 2

--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -94,7 +94,7 @@ class ModelFitter:
         error_t_delta_phases=1,
         test_fraction=0.1,
         limit_test_fraction=[0.02, 1],
-        fix_test_fraction=True,
+        # fix_test_fraction=True,
         error_test_fraction=0.02,
         hosp_fraction=1,
         # fix_hosp_fraction=True,

--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -1,6 +1,9 @@
 import os
 import us
-import logging
+import json
+
+# import logging
+import structlog
 from pprint import pformat
 import datetime as dt
 from datetime import datetime, timedelta
@@ -23,7 +26,7 @@ from pyseir.load_data import HospitalizationDataType, HospitalizationCategory
 from pyseir.utils import get_run_artifact_path, RunArtifact
 from pyseir.inference.fit_results import load_inference_result
 
-log = logging.getLogger()
+log = structlog.getLogger()
 
 
 def calc_chi_sq(obs, predicted, stddev):
@@ -588,7 +591,7 @@ class ModelFitter:
             )
 
         if np.isnan(self.fit_results["t0"]):
-            logging.error(f"Could not compute MLE values for {self.display_name}")
+            log.error(f"Could not compute MLE values for {self.display_name}")
             self.fit_results["t0_date"] = (
                 self.ref_date + timedelta(days=self.t0_guess)
             ).isoformat()
@@ -614,12 +617,15 @@ class ModelFitter:
 
         try:
             param_state = minuit.get_param_states()
-            logging.info(f"Fit Results for {self.display_name} \n {param_state}")
+            log.info(f"Fit Results for {self.display_name} \n {param_state}")
         except:
             param_state = dict(minuit.values)
-            logging.info(f"Fit Results for {self.display_name} \n {param_state}")
+            log.info(f"Fit Results for {self.display_name} \n {param_state}")
 
-        logging.info(f"Complete fit results for {self.display_name} \n {pformat(self.fit_results)}")
+        log.info(
+            event=f"Fit results for {self.display_name}:",
+            results=f"###{json.dumps(self.fit_results)})###",
+        )
         self.mle_model = self.run_model(**{k: self.fit_results[k] for k in self.model_fit_keys})
 
     @classmethod
@@ -660,7 +666,7 @@ class ModelFitter:
                     if model_fitter.mle_model and os.environ.get("PYSEIR_PLOT_RESULTS") == "True":
                         model_plotting.plot_fitting_results(model_fitter)
                 except RuntimeError as e:
-                    logging.warning("No convergence.. Retrying " + str(e))
+                    log.warning("No convergence.. Retrying " + str(e))
                 retries_left = retries_left - 1
                 if model_fitter.mle_model:
                     model_is_empty = False
@@ -668,7 +674,7 @@ class ModelFitter:
                 raise RuntimeError(f"Could not converge after {n_retries} for fips {fips}")
             return model_fitter
         except Exception:
-            logging.exception(f"Failed to run {fips}")
+            log.exception(f"Failed to run {fips}")
             return None
 
 
@@ -676,7 +682,7 @@ def execute_model_for_fips(fips):
     if fips:
         model_fitter = ModelFitter.run_for_fips(fips)
         return model_fitter
-    logging.warning(f"Not running model run for ${fips}")
+    log.warning(f"Not running model run for ${fips}")
     return None
 
 
@@ -695,7 +701,7 @@ def build_county_list(state):
     Build the and return the fips list
     """
     state_obj = us.states.lookup(state)
-    logging.info(f"Get fips list for state {state_obj.name}")
+    log.info(f"Get fips list for state {state_obj.name}")
 
     df_whitelist = load_data.load_whitelist()
     df_whitelist = df_whitelist[df_whitelist["inference_ok"] == True]
@@ -720,7 +726,7 @@ def run_state(state, states_only=False, with_age_structure=False):
         If True run model with age structure.
     """
     state_obj = us.states.lookup(state)
-    logging.info(f"Running MLE fitter for state {state_obj.name}")
+    log.info(f"Running MLE fitter for state {state_obj.name}")
 
     model_fitter = ModelFitter.run_for_fips(
         fips=state_obj.fips, with_age_structure=with_age_structure

--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -93,11 +93,11 @@ class ModelFitter:
         limit_t_delta_phases=[14, 100],  # good as of June 3, 2020 may need to update in the future
         error_t_delta_phases=1,
         test_fraction=0.1,
-        # limit_test_fraction=[0.02, 1],
+        limit_test_fraction=[0.02, 1],
         fix_test_fraction=True,
         error_test_fraction=0.02,
         hosp_fraction=1,
-        fix_hosp_fraction=True,
+        # fix_hosp_fraction=True,
         limit_hosp_fraction=[0.25, 1],
         error_hosp_fraction=0.05,
         # Let's not fit this to start...
@@ -239,9 +239,9 @@ class ModelFitter:
             for param in INITIAL_PARAM_SETS:
                 self.fit_params[param] = this_fips_df[param]
 
-        # self.fit_params["fix_hosp_fraction"] = self.hospitalizations is None
-        # if self.fit_params["fix_hosp_fraction"]:
-        #     self.fit_params["hosp_fraction"] = 1
+        self.fit_params["fix_hosp_fraction"] = self.hospitalizations is None
+        if self.fit_params["fix_hosp_fraction"]:
+            self.fit_params["hosp_fraction"] = 1
 
         if len(self.fips) == 5:
             OBSERVED_NEW_CASES_GUESS_THRESHOLD = 2


### PR DESCRIPTION
Check out snapshot 654. I've fixed hosp_fraction to 1 and test_fraction to 0.1 . It does as expected on my local machine for the state and counties of California. We were getting %infected numbers that were unreasonably high when we let test_fraction float, especially in places like Marin County. This seems to fix those parts of the model that aren't captured in the chi2 scoring.

I would like to merge this before tomorrow morning's 9:30am build.

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [ ] Are tests passing?
