### PR TITLE
do not allow county level fit to start more than 5 days before there …

### DIFF
--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -253,7 +253,7 @@ class ModelFitter:
             self.fit_params["log10_I_initial"] = np.log10(
                 initial_cases_guess / self.fit_params["test_fraction"]
             )
-            self.fit_params["limit_t0"] = state_fit_result["t0"] - 20, state_fit_result["t0"] + 30
+            self.fit_params["limit_t0"] = t0_guess - 5, state_fit_result["t0"] + 30
             self.fit_params["t_break"] = state_fit_result["t_break"] - (
                 t0_guess - state_fit_result["t0"]
             )


### PR DESCRIPTION
This PR constrains pyseir to not start county level fits more than 5 days before there is data. Previously, this created unhealthy fits in some counties.

The snapshot comparison is here (650 master, 649 this branch)
https://covidactnow.org/internal/compare?left=650&locations=0&metric=0&right=649&sort=2

Some select results:
![Santa Cruz, CA](https://user-images.githubusercontent.com/6775757/87189178-d06e9a80-c2b5-11ea-9dca-fadb6a476cde.png)
![Cobb County, GA](https://user-images.githubusercontent.com/6775757/87189181-d2d0f480-c2b5-11ea-9f76-b5afd760c9c6.png)
![Clark County, NV](https://user-images.githubusercontent.com/6775757/87189185-d3698b00-c2b5-11ea-9e1a-3c8503666267.png)




### Please Check

- [Yes] Are tests passing?
