### PR TITLE
requirements update to rm moto and add identify

### DIFF
--- a/libs/datasets/combined_dataset_utils.py
+++ b/libs/datasets/combined_dataset_utils.py
@@ -7,7 +7,6 @@ import datetime
 import enum
 from urllib.parse import urlparse
 
-import boto3
 import structlog
 import numpy as np
 import pandas as pd

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ jupyter==1.0.0
 jupyterlab==2.1.4
 simplejson==3.17.0
 ujson==2.0.3
-boto3==1.12.28
 seaborn==0.10.0
 click==7.1.1
 sentry-sdk==0.14.3

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -9,3 +9,4 @@ black==19.10b0
 nbstripout==0.3.7
 pylint==2.5.2
 pre-commit==2.6.0
+identify==1.4.23

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -8,5 +8,4 @@ pytest-mock >= 1.10.4
 black==19.10b0
 nbstripout==0.3.7
 pylint==2.5.2
-pre-commit==2.3.0
-moto==1.3.14
+pre-commit==2.6.0

--- a/test/libs/datasets/combined_dataset_utils_test.py
+++ b/test/libs/datasets/combined_dataset_utils_test.py
@@ -1,11 +1,6 @@
 import pathlib
 
-import moto
-import boto3
-import pytest
-
 from libs.datasets import combined_dataset_utils
-from libs.datasets.combined_dataset_utils import DatasetType
 from libs.datasets import combined_datasets
 from libs.qa.common_df_diff import DatasetDiff
 


### PR DESCRIPTION
# This PR

* rm unused moto and boto3 imports and in `requirements_test.txt` and `requirements.txt`
* add `identify` to requirements_test.txt fixing `'Type tag 'jupyter' is not recognized.'`. See https://covidactnow.slack.com/archives/C0110QQAPJA/p1594827445123500
* upgrades pre-commit to latest release