### PR TITLE
add DatasetBase.yield_records

### DIFF
--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -163,14 +163,8 @@ def load_us_latest_dataset(
     return pointer.load_dataset()
 
 
-def get_us_latest_for_state(state) -> dict:
-    """Gets latest values for a given state."""
-    us_latest = load_us_latest_dataset()
-    return us_latest.get_record_for_state(state)
-
-
 def get_us_latest_for_fips(fips) -> dict:
-    """Gets latest values for a given fips code."""
+    """Gets latest values for a given state or county fips code."""
     us_latest = load_us_latest_dataset()
     return us_latest.get_record_for_fips(fips)
 

--- a/libs/datasets/dataset_base.py
+++ b/libs/datasets/dataset_base.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Mapping, Iterable
 import pathlib
 from covidactnow.datapublic import common_df
 import pandas as pd
@@ -15,6 +15,12 @@ class DatasetBase(object):
     def get_subset(self, aggregation_level: AggregationLevel, **filters) -> "DatasetBase":
         """Returns a subset of the existing dataset."""
         raise NotImplementedError("Subsclass must implement")
+
+    def yield_records(self) -> Iterable[dict]:
+        # It'd be faster to use self.data.itertuples or find a way to avoid yield_records, but that
+        # needs larger changes in code calling this.
+        for idx, row in self.data.iterrows():
+            yield row.where(pd.notnull(row), None).to_dict()
 
     @classmethod
     def build_from_data_source(cls, source) -> "DatasetBase":

--- a/libs/datasets/latest_values_dataset.py
+++ b/libs/datasets/latest_values_dataset.py
@@ -1,5 +1,8 @@
 from typing import Type, List, Optional
 import pathlib
+
+from more_itertools import first
+
 from libs import us_state_abbrev
 import pandas as pd
 import numpy as np
@@ -188,12 +191,7 @@ class LatestValuesDataset(dataset_base.DatasetBase):
 
         Returns: Dictionary with all data for a given fips code.
         """
-        # we map NaNs to none here so that they can be generated via the API easier
-        row = self.data[self.data[CommonFields.FIPS] == fips].where(pd.notnull(self.data), None)
-        if not len(row):
-            return {}
-
-        return row.iloc[0].to_dict()
+        return first(self.get_subset(aggregation_level=AggregationLevel.COUNTY, fips=fips).yield_records(), default={})
 
     def to_csv(self, path: pathlib.Path):
         """Save data to CSV.

--- a/libs/datasets/latest_values_dataset.py
+++ b/libs/datasets/latest_values_dataset.py
@@ -145,7 +145,7 @@ class LatestValuesDataset(dataset_base.DatasetBase):
 
     def get_subset(
         self,
-        aggregation_level,
+        aggregation_level=None,
         country=None,
         fips: Optional[str] = None,
         state: Optional[str] = None,
@@ -167,31 +167,15 @@ class LatestValuesDataset(dataset_base.DatasetBase):
         )
         return self.__class__(self.data.loc[rows_binary_array, :])
 
-    def get_record_for_state(self, state) -> dict:
-        """Gets all data for a given state.
-
-        Args:
-            state: State abbreviation.
-
-        Returns: Dictionary with all data for a given state.
-        """
-        # we map NaNs to none here so that they can be generated via the API easier
-        data = self.state_data.where(pd.notnull(self.state_data), None)
-        row = data[data[CommonFields.STATE] == state]
-        if not len(row):
-            return {}
-
-        return row.iloc[0].to_dict()
-
     def get_record_for_fips(self, fips) -> dict:
         """Gets all data for a given fips code.
 
         Args:
-            fips: fips code.
+            fips: 2 digits for a state or 5 digits for a county
 
         Returns: Dictionary with all data for a given fips code.
         """
-        return first(self.get_subset(aggregation_level=AggregationLevel.COUNTY, fips=fips).yield_records(), default={})
+        return first(self.get_subset(fips=fips).yield_records(), default={})
 
     def to_csv(self, path: pathlib.Path):
         """Save data to CSV.

--- a/libs/datasets/sources/cds_dataset.py
+++ b/libs/datasets/sources/cds_dataset.py
@@ -91,7 +91,7 @@ class CDSDataset(data_source.DataSource):
             dtype={self.Fields.FIPS: str},
             low_memory=False,
         )
-        data = self.standardize_data(data)
+        data = self._standardize_data(data)
         super().__init__(data)
 
     @classmethod
@@ -100,10 +100,10 @@ class CDSDataset(data_source.DataSource):
         return cls(data_root / cls.DATA_PATH)
 
     @classmethod
-    def standardize_data(cls, data: pd.DataFrame) -> pd.DataFrame:
+    def _standardize_data(cls, data: pd.DataFrame) -> pd.DataFrame:
         data = dataset_utils.strip_whitespace(data)
 
-        data = cls.remove_duplicate_city_data(data)
+        data = cls._remove_duplicate_city_data(data)
 
         # CDS state level aggregates are identifiable by not having a city or county.
         only_county = data[cls.Fields.COUNTY].notnull() & data[cls.Fields.STATE].notnull()
@@ -156,7 +156,7 @@ class CDSDataset(data_source.DataSource):
         return data
 
     @classmethod
-    def remove_duplicate_city_data(cls, data):
+    def _remove_duplicate_city_data(cls, data):
         # City data before 3-23 was not duplicated, copy the city name to the county field.
         select_pre_march_23 = data.date < "2020-03-23"
         data.loc[select_pre_march_23, cls.Fields.COUNTY] = data.loc[select_pre_march_23].apply(

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -81,9 +81,10 @@ class TimeseriesDataset(dataset_base.DatasetBase):
 
         if aggregation_level == AggregationLevel.COUNTY:
             group = [CommonFields.COUNTRY, CommonFields.STATE, CommonFields.FIPS]
-        if aggregation_level == AggregationLevel.STATE:
+        elif aggregation_level == AggregationLevel.STATE:
             group = [CommonFields.COUNTRY, CommonFields.STATE]
-        if aggregation_level == AggregationLevel.COUNTRY:
+        else:
+            assert aggregation_level == AggregationLevel.COUNTRY
             group = [CommonFields.COUNTRY]
 
         data = self.data[
@@ -128,8 +129,7 @@ class TimeseriesDataset(dataset_base.DatasetBase):
 
         Returns: List of dictionary records with NA values replaced to be None
         """
-        subset = self.get_subset(AggregationLevel.COUNTY, fips=fips)
-        return subset.records
+        return list(self.get_subset(aggregation_level=AggregationLevel.COUNTY, fips=fips).yield_records())
 
     def get_records_for_state(self, state) -> List[dict]:
         """Get data for state.
@@ -139,14 +139,7 @@ class TimeseriesDataset(dataset_base.DatasetBase):
 
         Returns: List of dictionary records with NA values replaced to be None.
         """
-        subset = self.get_subset(AggregationLevel.STATE, state=state)
-        return subset.records
-
-    @property
-    def records(self) -> List[dict]:
-        """Returns rows in current data."""
-        data = self.data
-        return data.where(pd.notnull(data), None).to_dict(orient="records")
+        return list(self.get_subset(aggregation_level=AggregationLevel.COUNTY, state=state).yield_records())
 
     def get_data(
         self,

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -74,12 +74,11 @@ class TimeseriesDataset(dataset_base.DatasetBase):
 
         Return: DataFrame
         """
-        if not aggregation_level:
+        if aggregation_level is None:
             county = self.latest_values(aggregation_level=AggregationLevel.COUNTY)
             state = self.latest_values(aggregation_level=AggregationLevel.STATE)
             return pd.concat([county, state])
-
-        if aggregation_level == AggregationLevel.COUNTY:
+        elif aggregation_level == AggregationLevel.COUNTY:
             group = [CommonFields.COUNTRY, CommonFields.STATE, CommonFields.FIPS]
         elif aggregation_level == AggregationLevel.STATE:
             group = [CommonFields.COUNTRY, CommonFields.STATE]

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -78,12 +78,12 @@ class TimeseriesDataset(dataset_base.DatasetBase):
             county = self.latest_values(aggregation_level=AggregationLevel.COUNTY)
             state = self.latest_values(aggregation_level=AggregationLevel.STATE)
             return pd.concat([county, state])
-        elif aggregation_level == AggregationLevel.COUNTY:
+        elif aggregation_level is AggregationLevel.COUNTY:
             group = [CommonFields.COUNTRY, CommonFields.STATE, CommonFields.FIPS]
-        elif aggregation_level == AggregationLevel.STATE:
+        elif aggregation_level is AggregationLevel.STATE:
             group = [CommonFields.COUNTRY, CommonFields.STATE]
         else:
-            assert aggregation_level == AggregationLevel.COUNTRY
+            assert aggregation_level is AggregationLevel.COUNTRY
             group = [CommonFields.COUNTRY]
 
         data = self.data[

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -96,7 +96,7 @@ class TimeseriesDataset(dataset_base.DatasetBase):
 
     def get_subset(
         self,
-        aggregation_level,
+        aggregation_level=None,
         country=None,
         fips: Optional[str] = None,
         state: Optional[str] = None,
@@ -125,25 +125,15 @@ class TimeseriesDataset(dataset_base.DatasetBase):
         """Get data for FIPS code.
 
         Args:
-            fips: FIPS code.
+            fips: 2 digits for a state or 5 digits for a county
 
         Returns: List of dictionary records with NA values replaced to be None
         """
-        return list(self.get_subset(aggregation_level=AggregationLevel.COUNTY, fips=fips).yield_records())
-
-    def get_records_for_state(self, state) -> List[dict]:
-        """Get data for state.
-
-        Args:
-            state: 2 letter state abbrev.
-
-        Returns: List of dictionary records with NA values replaced to be None.
-        """
-        return list(self.get_subset(aggregation_level=AggregationLevel.COUNTY, state=state).yield_records())
+        return list(self.get_subset(fips=fips).yield_records())
 
     def get_data(
         self,
-        aggregation_level,
+        aggregation_level=None,
         country=None,
         fips: Optional[str] = None,
         state: Optional[str] = None,

--- a/libs/functions/generate_api.py
+++ b/libs/functions/generate_api.py
@@ -142,7 +142,7 @@ def generate_region_timeseries(
 
     actuals_timeseries = []
 
-    for row in timeseries.records:
+    for row in timeseries.yield_records():
         # Timeseries records don't have population
         row[CommonFields.POPULATION] = region_summary.population
         actual = _generate_actuals(row, region_summary.intervention)

--- a/pyseir/deployment/webui_data_adaptor_v1.py
+++ b/pyseir/deployment/webui_data_adaptor_v1.py
@@ -74,11 +74,15 @@ class WebUIDataAdaptorV1:
         return metric is not None and metric > 0
 
     def _get_population(self, fips: str) -> int:
-        if len(fips) == 5:
-            return self.population_data.get_record_for_fips(fips)[CommonFields.POPULATION]
-        return self.population_data.get_record_for_state(self.state_abbreviation)[
-            CommonFields.POPULATION
-        ]
+        """
+        Get the population for a region.
+
+        Parameters
+        ----------
+        fips: str
+            2 digits for a state or 5 digits for a county.
+        """
+        return self.population_data.get_record_for_fips(fips)[CommonFields.POPULATION]
 
     def map_fips(self, fips: str) -> None:
         """

--- a/pyseir/ensembles/ensemble_runner.py
+++ b/pyseir/ensembles/ensemble_runner.py
@@ -83,14 +83,12 @@ class EnsembleRunner:
 
         if self.agg_level is AggregationLevel.COUNTY:
             self.county_metadata = load_data.load_county_metadata_by_fips(fips)
-            self.state_abbr = us.states.lookup(self.county_metadata["state"]).abbr
             self.state_name = us.states.lookup(self.county_metadata["state"]).name
 
             self.output_file_report = get_run_artifact_path(self.fips, RunArtifact.ENSEMBLE_REPORT)
             self.output_file_data = get_run_artifact_path(self.fips, RunArtifact.ENSEMBLE_RESULT)
 
         else:
-            self.state_abbr = us.states.lookup(self.fips).abbr
             self.state_name = us.states.lookup(self.fips).name
 
             self.output_file_report = None

--- a/pyseir/parameters/parameter_ensemble_generator.py
+++ b/pyseir/parameters/parameter_ensemble_generator.py
@@ -28,19 +28,10 @@ class ParameterEnsembleGenerator:
 
     def __init__(self, fips, N_samples, t_list, I_initial=1, suppression_policy=None):
         self.fips = fips
-        self.agg_level = AggregationLevel.COUNTY if len(self.fips) == 5 else AggregationLevel.STATE
         self.N_samples = N_samples
         self.I_initial = I_initial
         self.suppression_policy = suppression_policy
         self.t_list = t_list
-
-        if self.agg_level is AggregationLevel.COUNTY:
-            self.county_metadata = (
-                load_data.load_county_metadata().set_index("fips").loc[fips].to_dict()
-            )
-            self.state_abbr = us.states.lookup(self.county_metadata["state"]).abbr
-        else:
-            self.state_abbr = us.states.lookup(fips).abbr
         self._latest = combined_datasets.get_us_latest_for_fips(self.fips)
 
     @property

--- a/pyseir/parameters/parameter_ensemble_generator.py
+++ b/pyseir/parameters/parameter_ensemble_generator.py
@@ -39,10 +39,9 @@ class ParameterEnsembleGenerator:
                 load_data.load_county_metadata().set_index("fips").loc[fips].to_dict()
             )
             self.state_abbr = us.states.lookup(self.county_metadata["state"]).abbr
-            self._latest = combined_datasets.get_us_latest_for_fips(self.fips)
         else:
             self.state_abbr = us.states.lookup(fips).abbr
-            self._latest = combined_datasets.get_us_latest_for_state(self.state_abbr)
+        self._latest = combined_datasets.get_us_latest_for_fips(self.fips)
 
     @property
     def population(self) -> int:

--- a/test/beds_dataset_test.py
+++ b/test/beds_dataset_test.py
@@ -106,10 +106,13 @@ def test_dh_beds_loading():
 
 def test_get_data():
     beds_data = CovidCareMapBeds.local().beds()
-    data = beds_data.get_record_for_state("MA")
+    data = beds_data.get_record_for_fips("25")
     assert data
 
-    data = beds_data.get_record_for_state("NOTSTATE")
+    data = beds_data.get_record_for_fips("NOTSTATE")
+    assert not data
+
+    data = beds_data.get_record_for_fips("99")
     assert not data
 
 

--- a/test/cds_dataset_test.py
+++ b/test/cds_dataset_test.py
@@ -21,7 +21,7 @@ def test_remove_duplicate_city_data():
         )
     )
 
-    output_df = cds_dataset.CDSDataset.remove_duplicate_city_data(input_df)
+    output_df = cds_dataset.CDSDataset._remove_duplicate_city_data(input_df)
     expected_df = pd.read_csv(
         StringIO(
             "city,county,state,fips,date,metric_a\n"

--- a/test/combined_dataset_test.py
+++ b/test/combined_dataset_test.py
@@ -42,6 +42,7 @@ def test_combined_county_has_some_data(fips):
     )
     assert latest.data[CommonFields.POSITIVE_TESTS].all()
     assert latest.data[CommonFields.NEGATIVE_TESTS].all()
+    assert latest.get_record_for_fips(fips=fips)[CommonFields.DEATHS] > 1
 
 
 # Check some counties picked arbitrarily: San Francisco/06075 and Houston (Harris County, TX)/48201

--- a/test/dataset_utils_test.py
+++ b/test/dataset_utils_test.py
@@ -145,6 +145,33 @@ def test_fill_fields_with_data_source():
     assert logs == []
 
 
+def test_fill_fields_with_data_source_nan_overwrite():
+    existing_df = pd.read_csv(
+        StringIO(
+            "fips,state,aggregate_level,county,current_icu,preserved\n"
+            "55,ZZ,state,Grand State,46,ef\n"
+        )
+    )
+    new_df = pd.read_csv(
+        StringIO("fips,state,aggregate_level,county,current_icu\n" "55,ZZ,state,Grand State,\n")
+    )
+
+    with testing.capture_logs() as logs:
+        log = get_logger()
+        result = fill_fields_with_data_source(
+            log, existing_df, new_df, "fips state aggregate_level county".split(), ["current_icu"],
+        )
+    expected = pd.read_csv(
+        StringIO(
+            "fips,state,aggregate_level,county,current_icu,preserved\n"
+            "55,ZZ,state,Grand State,,ef\n"
+        )
+    )
+
+    assert to_dict(["fips"], result) == to_dict(["fips"], expected)
+    assert logs == []
+
+
 def test_fill_fields_with_data_source_timeseries():
     # Timeseries in existing_df and new_df are merged together.
     existing_df = pd.read_csv(

--- a/test/test_pyseir_end_to_end_test.py
+++ b/test/test_pyseir_end_to_end_test.py
@@ -12,7 +12,7 @@ import pytest
 pytestmark = pytest.mark.filterwarnings("error")
 
 
-def test_pyseir_end_to_end():
+def test_pyseir_end_to_end_idaho():
     # This covers a lot of edge cases.
     # cli._run_all(state='Idaho')
     cli._build_all_for_states(states=["Idaho"], generate_reports=False, fips="16001")


### PR DESCRIPTION
## This PR

* adds DatasetBase.yield_records, replacing `records` property that breaks in a future PR
* replaces use of `get_us_latest_for_state` with 2 digit code passed to `get_records_for_fips` 
* adds `test_fill_fields_with_data_source_nan_overwrite` that exercises the unexpected current behavior when combining datasets
* make get_subset aggregation_level parameter optional, it was required
* add `_` prefix to some functions that are internal to a class


### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [ ] Are tests passing?
