### PR TITLE
fix latest combined column order

### DIFF
--- a/data/latest.csv
+++ b/data/latest.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fc1befb1b0dc4a0b01b96e9e31743a28210ece70dbb820446c0622388a2c07c2
-size 276117
+oid sha256:3ff0fb77db9f193ed04754cb316741ecdbe8dd304f346658ac993cdb4b814db2
+size 272714

--- a/data/latest.csv
+++ b/data/latest.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4fbe17f023f157671eea9d8fa7c140efa6725ac9e8527d39469418da0d62c240
+oid sha256:fc1befb1b0dc4a0b01b96e9e31743a28210ece70dbb820446c0622388a2c07c2
 size 276117

--- a/data/latest.json
+++ b/data/latest.json
@@ -7,9 +7,9 @@
     "is_dirty": false
   },
   "model_git_info": {
-    "sha": "f00d64ac607c6fe072c744339380bea02affd423",
+    "sha": "84e4aff9936dfdffbf0ce2c80d8eda6907cebdc5",
     "branch": "tgb-combined-column-order",
-    "is_dirty": false
+    "is_dirty": true
   },
-  "updated_at": "2020-07-17T17:06:01.938991"
+  "updated_at": "2020-07-17T17:41:25.900384"
 }

--- a/data/latest.json
+++ b/data/latest.json
@@ -7,9 +7,9 @@
     "is_dirty": false
   },
   "model_git_info": {
-    "sha": "e5bbc160bba898e37d5af56f6f021dbe764ee1b2",
-    "branch": "detached",
-    "is_dirty": true
+    "sha": "f00d64ac607c6fe072c744339380bea02affd423",
+    "branch": "tgb-combined-column-order",
+    "is_dirty": false
   },
-  "updated_at": "2020-07-17T16:51:40.587234"
+  "updated_at": "2020-07-17T17:06:01.938991"
 }

--- a/data/latest.json
+++ b/data/latest.json
@@ -7,9 +7,9 @@
     "is_dirty": false
   },
   "model_git_info": {
-    "sha": "e95e69c377be83c5bf1cffc9508186912da04118",
-    "branch": "master",
-    "is_dirty": false
+    "sha": "e5bbc160bba898e37d5af56f6f021dbe764ee1b2",
+    "branch": "detached",
+    "is_dirty": true
   },
-  "updated_at": "2020-07-17T16:30:13.535419"
+  "updated_at": "2020-07-17T16:51:40.587234"
 }

--- a/data/timeseries.json
+++ b/data/timeseries.json
@@ -7,9 +7,9 @@
     "is_dirty": false
   },
   "model_git_info": {
-    "sha": "e5bbc160bba898e37d5af56f6f021dbe764ee1b2",
-    "branch": "detached",
+    "sha": "84e4aff9936dfdffbf0ce2c80d8eda6907cebdc5",
+    "branch": "tgb-combined-column-order",
     "is_dirty": true
   },
-  "updated_at": "2020-07-17T17:02:37.310801"
+  "updated_at": "2020-07-17T17:52:02.147809"
 }

--- a/data/timeseries.json
+++ b/data/timeseries.json
@@ -7,9 +7,9 @@
     "is_dirty": false
   },
   "model_git_info": {
-    "sha": "e95e69c377be83c5bf1cffc9508186912da04118",
-    "branch": "master",
+    "sha": "e5bbc160bba898e37d5af56f6f021dbe764ee1b2",
+    "branch": "detached",
     "is_dirty": true
   },
-  "updated_at": "2020-07-17T16:40:51.368398"
+  "updated_at": "2020-07-17T17:02:37.310801"
 }

--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -124,21 +124,16 @@ US_STATES_FILTER = dataset_filter.DatasetFilter(
 
 
 @dataset_cache.cache_dataset_on_disk(TimeseriesDataset)
-def build_timeseries_with_all_fields(skip_cache=False) -> TimeseriesDataset:
-    return build_combined_dataset_from_sources(TimeseriesDataset, ALL_TIMESERIES_FEATURE_DEFINITION)
-
-
-@dataset_cache.cache_dataset_on_disk(TimeseriesDataset)
 def build_us_timeseries_with_all_fields(skip_cache=False) -> TimeseriesDataset:
-    return build_combined_dataset_from_sources(
-        TimeseriesDataset, ALL_TIMESERIES_FEATURE_DEFINITION, filters=[US_STATES_FILTER]
+    return _build_combined_dataset_from_sources(
+        TimeseriesDataset, ALL_TIMESERIES_FEATURE_DEFINITION, filter=US_STATES_FILTER,
     )
 
 
 @dataset_cache.cache_dataset_on_disk(LatestValuesDataset)
 def build_us_latest_with_all_fields(skip_cache=False) -> LatestValuesDataset:
-    return build_combined_dataset_from_sources(
-        LatestValuesDataset, ALL_FIELDS_FEATURE_DEFINITION, filters=[US_STATES_FILTER]
+    return _build_combined_dataset_from_sources(
+        LatestValuesDataset, ALL_FIELDS_FEATURE_DEFINITION, filter=US_STATES_FILTER,
     )
 
 
@@ -253,10 +248,10 @@ def load_data_sources(
     return loaded_data_sources
 
 
-def build_combined_dataset_from_sources(
+def _build_combined_dataset_from_sources(
     target_dataset_cls: Type[dataset_base.DatasetBase],
     feature_definition_config: FeatureDataSourceMap,
-    filters: List[dataset_filter.DatasetFilter] = None,
+    filter: dataset_filter.DatasetFilter,
 ):
     """Builds a combined dataset from a feature definition.
 
@@ -269,18 +264,11 @@ def build_combined_dataset_from_sources(
     """
     loaded_data_sources = load_data_sources(feature_definition_config)
 
-    # Convert data sources to instances of `target_data_cls`.
+    # Convert data sources to instances of `target_data_cls` and apply filter
     intermediate_datasets = {
-        data_source_cls: target_dataset_cls.build_from_data_source(source)
+        data_source_cls: filter.apply(target_dataset_cls.build_from_data_source(source))
         for data_source_cls, source in loaded_data_sources.items()
     }
-
-    # Apply filters to datasets.
-    for key in intermediate_datasets:
-        dataset = intermediate_datasets[key]
-        for data_filter in filters or []:
-            dataset = data_filter.apply(dataset)
-        intermediate_datasets[key] = dataset
 
     # Build feature columns from feature_definition_config.
     data = pd.DataFrame({})

--- a/libs/datasets/dataset_filter.py
+++ b/libs/datasets/dataset_filter.py
@@ -2,6 +2,7 @@ from typing import Union, List
 
 from pydantic.dataclasses import dataclass
 
+from libs.datasets.dataset_base import DatasetBase
 from libs.datasets.dataset_utils import AggregationLevel
 from libs.datasets.timeseries import TimeseriesDataset
 from libs.datasets.latest_values_dataset import LatestValuesDataset
@@ -14,7 +15,7 @@ class DatasetFilter(object):
     country: str
     states: List[str]
 
-    def apply(self, dataset: Union[TimeseriesDataset, LatestValuesDataset]):
+    def apply(self, dataset: DatasetBase) -> DatasetBase:
         """Applies filter to dataset by returning subset that matches filter arguments."""
         aggregation_level = None
         return dataset.get_subset(

--- a/libs/datasets/latest_values_dataset.py
+++ b/libs/datasets/latest_values_dataset.py
@@ -1,6 +1,7 @@
 from typing import Type, List, Optional
 import pathlib
 
+import structlog
 from more_itertools import first
 
 from covidactnow.datapublic import common_df
@@ -186,7 +187,8 @@ class LatestValuesDataset(dataset_base.DatasetBase):
         """
         # Cannot use common_df.write_csv as it doesn't support data without a date index field.
         data = self.data.set_index(CommonFields.FIPS).replace({pd.NA: np.nan}).convert_dtypes()
-        data = common_df.sort_common_field_columns(data)
+        data = common_df.only_common_columns(data, structlog.get_logger())  # Drops `index`
+        data = common_df.sort_common_field_columns(data).sort_index()
         data.to_csv(path, date_format="%Y-%m-%d", index=True, float_format="%.12g")
 
     @classmethod

--- a/libs/datasets/latest_values_dataset.py
+++ b/libs/datasets/latest_values_dataset.py
@@ -3,6 +3,7 @@ import pathlib
 
 from more_itertools import first
 
+from covidactnow.datapublic import common_df
 from libs import us_state_abbrev
 import pandas as pd
 import numpy as np
@@ -185,6 +186,7 @@ class LatestValuesDataset(dataset_base.DatasetBase):
         """
         # Cannot use common_df.write_csv as it doesn't support data without a date index field.
         data = self.data.set_index(CommonFields.FIPS).replace({pd.NA: np.nan}).convert_dtypes()
+        data = common_df.sort_common_field_columns(data)
         data.to_csv(path, date_format="%Y-%m-%d", index=True, float_format="%.12g")
 
     @classmethod

--- a/libs/datasets/sources/jhu_dataset.py
+++ b/libs/datasets/sources/jhu_dataset.py
@@ -73,12 +73,14 @@ class JHUDataset(data_source.DataSource):
             loaded_data.append(data)
 
         data = pd.concat(loaded_data)
-        data = self.standardize_data(data)
+        data = self._standardize_data(data)
         super().__init__(data)
 
     @classmethod
-    def standardize_data(cls, data: pd.DataFrame) -> pd.DataFrame:
+    def _standardize_data(cls, data: pd.DataFrame) -> pd.DataFrame:
         data = dataset_utils.strip_whitespace(data)
+        # Drop all data outside the USA to speed up debugging
+        data = data.loc[data[cls.Fields.COUNTRY].isin(["US", "USA"])]
         # TODO Figure out how to rename to some ISO standard.
         country_remap = {
             "Mainland China": "China",

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 import pandas as pd
 import structlog
 from covidactnow.datapublic import common_df
+from covidactnow.datapublic.common_fields import COMMON_FIELDS_TIMESERIES_KEYS
 from libs import us_state_abbrev
 from libs.datasets import dataset_utils
 from libs.datasets import dataset_base
@@ -201,6 +202,17 @@ class TimeseriesDataset(dataset_base.DatasetBase):
         is_state = data[CommonFields.AGGREGATE_LEVEL] == AggregationLevel.STATE.value
         state_fips = data.loc[is_state, CommonFields.STATE].map(us_state_abbrev.ABBREV_US_FIPS)
         data.loc[is_state, CommonFields.FIPS] = state_fips
+
+        no_fips = data[CommonFields.FIPS].isnull()
+        if no_fips.any():
+            print(f"Dropping rows without FIPS in {source}:\n{data.loc[no_fips]}")
+            data = data.loc[~no_fips]
+
+        if data.duplicated(COMMON_FIELDS_TIMESERIES_KEYS, keep=False).any():
+            raise ValueError(
+                f"Duplicates in {source}:\n"
+                f"{data.loc[data.duplicated(COMMON_FIELDS_TIMESERIES_KEYS)]}"
+            )
 
         # Choosing to sort by date
         data = data.sort_values(CommonFields.DATE)

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -14,6 +14,16 @@ from libs.datasets.common_fields import CommonFields
 from libs.datasets.dataset_utils import AggregationLevel
 
 
+class DuplicateDataException(Exception):
+    def __init__(self, message, duplicates):
+        self.message = message
+        self.duplicates = duplicates
+        super().__init__()
+
+    def __str__(self):
+        return f"DuplicateDataException({self.message})"
+
+
 class TimeseriesDataset(dataset_base.DatasetBase):
     """Represents timeseries dataset.
 
@@ -205,14 +215,14 @@ class TimeseriesDataset(dataset_base.DatasetBase):
 
         no_fips = data[CommonFields.FIPS].isnull()
         if no_fips.any():
-            print(f"Dropping rows without FIPS in {source}:\n{data.loc[no_fips]}")
+            structlog.get_logger().warning(
+                "Dropping rows without FIPS", source=str(source), rows=repr(data.loc[no_fips])
+            )
             data = data.loc[~no_fips]
 
-        if data.duplicated(COMMON_FIELDS_TIMESERIES_KEYS, keep=False).any():
-            raise ValueError(
-                f"Duplicates in {source}:\n"
-                f"{data.loc[data.duplicated(COMMON_FIELDS_TIMESERIES_KEYS)]}"
-            )
+        dups = data.duplicated(COMMON_FIELDS_TIMESERIES_KEYS, keep=False)
+        if dups.any():
+            raise DuplicateDataException(f"Duplicates in {source}", data.loc[dups])
 
         # Choosing to sort by date
         data = data.sort_values(CommonFields.DATE)

--- a/test/combined_dataset_test.py
+++ b/test/combined_dataset_test.py
@@ -97,6 +97,7 @@ def test_unique_timeseries(data_source_cls):
 )
 def test_expected_field_in_sources(data_source_cls):
     data_source = data_source_cls.local()
+    ts = TimeseriesDataset.from_source(data_source)
     # Extract the USA data from the raw DF. Replace this with cleaner access when the DataSource makes it easy.
     rename_columns = {source: common for common, source in data_source.all_fields_map().items()}
     renamed_data = data_source.data.rename(columns=rename_columns)


### PR DESCRIPTION
## This PR

* sort columns and rows in LatestValuesDataset before writing
* drop `index` column in LatestValuesDataset
* Dropping rows without FIPS in Timeseries, as produced by JHU but hard to filter in data source class because of the cleanup done in the timeseries class

## Tested

`data/timeseries.csv` is identical.

`git show master:data/latest.csv | git lfs smudge > data/latest-master.csv` and then in jupyter: 
```
import pandas as pd
from covidactnow.datapublic import common_df
from libs.datasets.common_fields import CommonFields

path = 'data/latest-master.csv'
df = common_df.sort_common_field_columns(pd.read_csv(path, dtype={CommonFields.FIPS: str}).set_index(CommonFields.FIPS).sort_index())
df.to_csv(path, date_format="%Y-%m-%d", index=True, float_format="%.12g")
```
and the only difference is the empty index column dropped.