### PR TITLE
Infer Rt Flag and Logging Cleanup

### DIFF
--- a/pyseir/rt/infer_rt.py
+++ b/pyseir/rt/infer_rt.py
@@ -16,27 +16,38 @@ from pyseir.rt import plotting, utils
 rt_log = structlog.get_logger(__name__)
 
 
-def run_rt_for_fips(fips, figure_collector=None):
+def run_rt_for_fips(
+    fips, include_deaths=False, include_testing_correction=True, figure_collector=None
+):
     """Entry Point for Infer Rt"""
 
     # Generate the Data Packet to Pass to RtInferenceEngine
     input_df = _generate_input_data(
-        fips, include_testing_correction=True, figure_collector=figure_collector
+        fips=fips,
+        include_testing_correction=include_testing_correction,
+        include_deaths=include_deaths,
+        figure_collector=figure_collector,
     )
+    if input_df.dropna().empty:
+        rt_log.warning(event="Infer Rt Skipped. No Data Passed Filter Requirements:", fips=fips)
+    else:
+        # Save a reference to instantiated engine (eventually I want to pull out the figure
+        # generation and saving so that I don't have to pass a display_name and fips into the class
+        engine = RtInferenceEngine(
+            data=input_df,
+            display_name=_get_display_name(fips),
+            fips=fips,
+            include_deaths=include_deaths,
+        )
 
-    # Save a reference to instantiated engine (eventually I want to pull out the figure generation
-    # and saving so that I don't have to pass a display_name and fips into the class
-    engine = RtInferenceEngine(
-        data=input_df, display_name=_get_display_name(fips), fips=fips, include_deaths=False
-    )
+        # Generate the output DataFrame (consider renaming the function infer_all to be clearer)
+        output_df = engine.infer_all()
 
-    # Generate the output DataFrame (consider renaming the function infer_all to make it clearer)
-    output_df = engine.infer_all()
-
-    # Save the output to json for downstream repacking and incorporation.
-    county_output_file = get_run_artifact_path(fips, RunArtifact.RT_INFERENCE_RESULT)
-    if output_df is not None and not output_df.empty:
-        output_df.to_json(county_output_file)
+        # Save the output to json for downstream repacking and incorporation.
+        county_output_file = get_run_artifact_path(fips, RunArtifact.RT_INFERENCE_RESULT)
+        if output_df is not None and not output_df.empty:
+            output_df.to_json(county_output_file)
+    return
 
 
 def _get_display_name(fips) -> str:
@@ -44,9 +55,7 @@ def _get_display_name(fips) -> str:
     return str(fips)
 
 
-def _generate_input_data(
-    fips, include_testing_correction=True, include_deaths=True, figure_collector=None
-):
+def _generate_input_data(fips, include_testing_correction, include_deaths, figure_collector):
     """
     Allow the RtInferenceEngine to be agnostic to aggregation level by handling the loading first
 
@@ -64,14 +73,15 @@ def _generate_input_data(
         include_deaths=include_deaths,
         figure_collector=figure_collector,
         display_name=fips,
+        log=rt_log.new(fips=fips),
     )
     return df
 
 
 def filter_and_smooth_input_data(
-    df: [pd.DataFrame], display_name, include_deaths=False, figure_collector=None
+    df: [pd.DataFrame], display_name, include_deaths, figure_collector, log
 ) -> pd.DataFrame:
-    """Do Everything Strange Here Before it Gets to the Inference Engine"""
+    """Do Filtering Here Before it Gets to the Inference Engine"""
     MIN_CUMULATIVE_COUNTS = dict(cases=20, deaths=10)
     MIN_INCIDENT_COUNTS = dict(cases=5, deaths=5)
 
@@ -133,7 +143,7 @@ def filter_and_smooth_input_data(
             df[column] = smoothed
         else:
             df = df.drop(columns=column, inplace=False)
-            rt_log.info("Dropping:", columns=column, requirements=requirements)
+            log.info("Dropping:", columns=column, requirements=requirements)
 
     return df
 

--- a/test/infer_rt_test.py
+++ b/test/infer_rt_test.py
@@ -51,7 +51,11 @@ def run_individual(
     # Now apply smoothing and filtering
     collector = {}
     smoothed_df = infer_rt.filter_and_smooth_input_data(
-        df=input_df, display_name=fips, include_deaths=False, figure_collector=collector
+        df=input_df,
+        display_name=fips,
+        include_deaths=False,
+        figure_collector=collector,
+        log=structlog.getLogger(),
     )
 
     engine = infer_rt.RtInferenceEngine(


### PR DESCRIPTION
This PR combines multiple points where we use the include_deaths flag into one flag. The data loading setup steps will also exit if neither case nor death data meet any of the filtering requirements. This makes it clearer where infer_rt "failed to generate output" by separating cases where we gave it no input from cases vs where it failed to find a solution given the non-empty input.

This should have a small speedup in the infer_rt code because (1) the engine won't be initialized on empty input data and (2) the include_deaths flag will short-circuit the engine from calculating the deaths based rt (which is dropped at the end by default).

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [x] Are tests passing?
