### PR TITLE
add pytest.mark.slow to tests that take over 1s

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 # Per https://stackoverflow.com/a/42281313/341400
 python_classes=NoThanksNoClassDiscovery
 junit_family=xunit1
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')

--- a/test/cli/data_cli_test.py
+++ b/test/cli/data_cli_test.py
@@ -1,9 +1,11 @@
+import pytest
 from click.testing import CliRunner
 
 
 from cli import data
 
 
+@pytest.mark.slow
 def test_summary_save(tmp_path):
 
     runner = CliRunner()

--- a/test/combined_dataset_test.py
+++ b/test/combined_dataset_test.py
@@ -32,6 +32,7 @@ import pytest
 # is returning multiple values for a single row.
 
 
+@pytest.mark.slow
 def test_unique_index_values_us_timeseries():
     timeseries = combined_datasets.load_us_timeseries_dataset()
     timeseries_data = timeseries.data.set_index(timeseries.INDEX_FIELDS)
@@ -74,6 +75,7 @@ def test_combined_county_has_some_timeseries_data(fips):
         assert df.loc["2020-05-01", CommonFields.CURRENT_ICU] > 0
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "data_source_cls",
     [
@@ -97,6 +99,7 @@ def test_unique_timeseries(data_source_cls):
     assert not sum(duplicates), str(timeseries_data.loc[duplicates])
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "data_source_cls",
     [
@@ -241,6 +244,7 @@ def test_build_timeseries_override():
     assert combined.loc["97123", "m1"].replace({np.nan: None}).tolist() == [1, None, 3]
 
 
+@pytest.mark.slow
 def test_build_combined_dataset_from_sources_smoke_test():
     # Quickly make sure _build_combined_dataset_from_sources doesn't crash when run with a small
     # number of features.

--- a/test/infer_rt_test.py
+++ b/test/infer_rt_test.py
@@ -93,6 +93,7 @@ def check_standard_assertions(rt1, rt2, t_switch, rt):
     ), f"Test {id} Failed: Today Value Not Within Spec: Predicted={round(rt[-1],2)} Observed={rt2}."
 
 
+@pytest.mark.slow
 def test_constant_cases_high_count(tmp_path):
     """Track constant cases (R=1) at low count"""
     data_spec = load_data.DataSpec(
@@ -108,6 +109,7 @@ def test_constant_cases_high_count(tmp_path):
     check_standard_assertions(rt1, rt2, t_switch, rt)
 
 
+@pytest.mark.slow
 def test_med_scale_strong_growth_and_decay():
     """Track cases growing strongly and then decaying strongly"""
     (rt1, rt2, t_switch, rt) = run_individual(
@@ -124,6 +126,7 @@ def test_med_scale_strong_growth_and_decay():
     check_standard_assertions(rt1, rt2, t_switch, rt)
 
 
+@pytest.mark.slow
 def test_low_cases_weak_growth():
     """Track with low scale (count = 5) and slow growth"""
     (rt1, rt2, t_switch, rt) = run_individual(
@@ -141,6 +144,7 @@ def test_low_cases_weak_growth():
     # TODO is failing this test rt = .84 instead of rt1
 
 
+@pytest.mark.slow
 def test_high_scale_late_growth():
     """Track decaying from high initial count to low number then strong growth"""
     (rt1, rt2, t_switch, rt) = run_individual(
@@ -157,6 +161,7 @@ def test_high_scale_late_growth():
     check_standard_assertions(rt1, rt2, t_switch, rt)
 
 
+@pytest.mark.slow
 def test_low_scale_two_decays():
     """Track low scale decay at two different rates"""
     (rt1, rt2, t_switch, rt) = run_individual(
@@ -173,6 +178,7 @@ def test_low_scale_two_decays():
     check_standard_assertions(rt1, rt2, t_switch, rt)
 
 
+@pytest.mark.slow
 def test_smoothing_and_causality():
     run_individual(
         "56",  # Wyoming

--- a/test/libs/api_pipeline_test.py
+++ b/test/libs/api_pipeline_test.py
@@ -17,6 +17,7 @@ from pyseir import cli
 NYC_FIPS = "36061"
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "intervention",
     [

--- a/test/test_pyseir_end_to_end_test.py
+++ b/test/test_pyseir_end_to_end_test.py
@@ -12,6 +12,7 @@ import pytest
 pytestmark = pytest.mark.filterwarnings("error")
 
 
+@pytest.mark.slow
 def test_pyseir_end_to_end_idaho():
     # This covers a lot of edge cases.
     # cli._run_all(state='Idaho')
@@ -29,6 +30,7 @@ def test_pyseir_end_to_end_idaho():
     assert (with_values < 6).all()
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("fips,expected_results", [(None, True), ("16013", True), ("26013", False)])
 def test_filters_counties_properly(fips, expected_results):
     cli._generate_whitelist()


### PR DESCRIPTION
I want a way to easily run the fast tests so I don't need to wait as long to see the failures when the code is horribly broken. https://docs.pytest.org/en/stable/mark.html#registering-marks suggests adding a slow marker. `pytest --durations=50 test` got me a list of the slow tests and now `pytest -m 'not slow' test` finishes in about 6 seconds.