### PR TITLE
Fix the Florida Negative Negative_Tests Edge Case

### DIFF
--- a/pyseir/load_data.py
+++ b/pyseir/load_data.py
@@ -639,7 +639,8 @@ def load_new_test_data_by_fips(fips, t0, smoothing_tau=5, correction_threshold=5
     df = df.loc[
         (df[CommonFields.POSITIVE_TESTS].notnull())
         & (df[CommonFields.NEGATIVE_TESTS].notnull())
-        & ((df[CommonFields.POSITIVE_TESTS] + df[CommonFields.NEGATIVE_TESTS]) > 0),
+        & (df[CommonFields.NEGATIVE_TESTS] > 0)
+        & (df[CommonFields.POSITIVE_TESTS] > 0),
         :,
     ]
 

--- a/pyseir/rt/infer_rt.py
+++ b/pyseir/rt/infer_rt.py
@@ -25,6 +25,9 @@ def run_rt_for_fips(
 ):
     """Entry Point for Infer Rt"""
 
+    # TODO: This fails silently if you pass it a numeric fips instead of a string
+    # assert type(fips) == str
+
     # Generate the Data Packet to Pass to RtInferenceEngine
     input_df = _generate_input_data(
         fips=fips,
@@ -72,6 +75,7 @@ def _generate_input_data(
     include_testing_correction: bool
         If True, include a correction for testing increases and decreases.
     """
+    # TODO: Outlier Removal Before Test Correction
     times, observed_new_cases, observed_new_deaths = load_data.load_new_case_data_by_fips(
         fips, t0=InferRtConstants.REF_DATE, include_testing_correction=include_testing_correction
     )


### PR DESCRIPTION
Some counties in Florida have erroneously reported test data that was not caught by our test correction filters. This tightens up filter restrictions as a first step towards a more robust pipeline.

https://trello.com/c/88PFNVhy/325-florida-infection-rate-wild-ride

This PR addresses issue #<insert number>

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [ ] Are tests passing?
