### PR TITLE
Make it easy to kick off a snapshot from an arbitrary branch / commit.

### DIFF
--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -1,0 +1,27 @@
+# Workflow to trigger our daily snapshot builds.
+#
+# See https://github.com/covid-projections/covid-data-model/blob/master/.github/workflows/deploy_api.yml
+# for the actual meat of the snapshot build.
+
+name: Trigger daily Snapshot Build
+
+on:
+  # covid-data-public fetches data at 01:00 and 12:00 UTC.
+  # So we rebuild / publish the API at 01:30 and 12:30 UTC.
+  schedule:
+   - cron: '30 1,12 * * *'
+
+jobs:
+  trigger-daily-build:
+    steps:
+
+    - name: Checkout covid-data-model
+      uses: actions/checkout@v2
+      with:
+        repository: covid-projections/covid-data-model
+
+    - name: Trigger snapshot build.
+      env:
+        GITHUB_TOKEN: ${{ secrets.CAN_ROBOT_PERSONAL_ACCESS_TOKEN }}
+      run: |
+        ./tools/build-snapshot.sh master

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -1,27 +1,22 @@
-# To debug, it's recommended you modify / use the version in the test-actions repo:
-# https://github.com/covid-projections/test-actions/blob/master/.github/workflows/deploy_api.yml
+name: Build & Publish API snapshot to data.covidactnow.org
 
-name: Build & Publish API artifacts to data.covidactnow.org
+#######################################################################################
+###
+### YOU DON'T NEED TO MODIFY THIS FILE TO KICK OFF A SNAPSHOT FROM YOUR BRANCH ANYMORE.
+###
+### See: https://github.com/covid-projections/covid-data-model/#api-snapshots
+###
+#######################################################################################
 
 on:
-  # covid-data-public fetches data at 01:00 and 12:00 UTC.
-  # So we rebuild / publish the API at 01:30 and 12:30 UTC.
-  schedule:
-   - cron: '30 1,12 * * *'
-
-  # Hook to trigger a manual run.
-  # See: https://goobar.io/2019/12/07/manually-trigger-a-github-actions-workflow/
   repository_dispatch:
     types: publish-api
 
 env:
-  # !!! Change this to your BRANCH if you want to test it
-  COVID_DATA_MODEL_REF: 'master'
+  COVID_DATA_MODEL_REF: ${{ github.event.client_payload.branch }}
 
-  # To pin to an old data sets, put the branch/tag/commit here:
+  # TODO: This may no longer be used for anything anymore. Remove?
   COVID_DATA_PUBLIC_REF: 'master'
-
-
 
   # S3 Bucket (used by s3-sync-action tasks) to store final API snapshot.
   AWS_S3_BUCKET: 'data.covidactnow.org'
@@ -42,7 +37,6 @@ env:
 
   # use a webhook to write to slack channel dev-alerts for QA
   SLACK_DEV_ALERTS_WEBHOOK: ${{ secrets.SLACK_DEV_ALERTS_WEBHOOK }}
-
 
 jobs:
   build-and-publish-snapshot:

--- a/.github/workflows/update_repo_datasets.yml
+++ b/.github/workflows/update_repo_datasets.yml
@@ -1,6 +1,9 @@
 name: Update combined datasets
 
 on:
+  # This hook is automatically triggered by
+  # https://github.com/covid-projections/covid-data-public/blob/master/.github/workflows/update_data.yml
+  # after covid-data-public datasets have been updated.
   repository_dispatch:
     types: update-dataset-snapshot
 

--- a/README.md
+++ b/README.md
@@ -38,22 +38,27 @@ Some code in the `covid-data-model` repo depends on there being a copy of the `c
 Detailed setup instructions can be found [here](./SETUP.md)
 
 # API Snapshots
+We automatically build & publish an API snapshot (e.g.
+https://data.covidactnow.org/snapshot/123/) twice a day via a [github
+action](./.github/workflows/daily_build.yml).
 
-We automatically build & publish an API snapshot (e.g. https://data.covidactnow.org/snapshot/123/)
-twice a day via a [github action](./.github/workflows/deploy_api.yml).  To manually kick off a new
-snapshot, get a
-[personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line),
+To manually kick off a new snapshot (e.g. from a feature branch), get a
+[github personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line),
 and run:
 
 ```bash
-export GITHUB_TOKEN=<YOUR PERSONAL GITHUB TOKEN>
-./tools/push-api.sh
+GITHUB_TOKEN=<YOUR PERSONAL GITHUB TOKEN> ./tools/build-snapshot.sh <branch (or commit sha, etc.)>
 ```
 
-Once a snapshot has been vetted, you can "label" it with a friendly name, e.g. pointing https://data.covidactnow.org/v0/ at https://data.covidactnow.org/snapshot/123/ with:
+## Labelling Snapshots
+Once a snapshot has been vetted and shipped to the production website, it should also be labeled
+as our "latest" snapshot, which will allow our API consumers to pick it up.
+
+The command to label snapshot 123 as latest (i.e. pointing https://data.covidactnow.org/latest/
+at https://data.covidactnow.org/snapshot/123/) is:
+
 ```bash
-export GITHUB_TOKEN=<YOUR PERSONAL GITHUB TOKEN>
-./tools/label-api.sh v0 123
+GITHUB_TOKEN=<YOUR PERSONAL GITHUB TOKEN> ./tools/label-api.sh latest 123
 ```
 
 # Development

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ and run:
 GITHUB_TOKEN=<YOUR PERSONAL GITHUB TOKEN> ./tools/build-snapshot.sh <branch (or commit sha, etc.)>
 ```
 
-## Labelling Snapshots
+## Labeling Snapshots
 Once a snapshot has been vetted and shipped to the production website, it should also be labeled
 as our "latest" snapshot, which will allow our API consumers to pick it up.
 

--- a/tools/build-snapshot.sh
+++ b/tools/build-snapshot.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# push-api.sh - Builds and publishes a new API snapshot (e.g.
+# build-snapshot.sh - Builds and publishes a new API snapshot (e.g.
 # https://data.covidactnow.org/snapshot/123/).
 
 set -o nounset
@@ -10,9 +10,11 @@ CMD=$0
 # Checks command-line arguments, sets variables, etc.
 prepare () {
   # Parse args if specified.
-  if [ $# -ne 0 ]; then
+  if [ $# -ne 1 ]; then
     exit_with_usage
   fi
+
+  BRANCH=$1
 
   if [[ -z ${GITHUB_TOKEN:-} ]]; then
     echo "Error: GITHUB_TOKEN must be set to a personal access token. See:"
@@ -22,14 +24,14 @@ prepare () {
 }
 
 exit_with_usage () {
-  echo "Usage: $CMD"
+  echo "Usage: $CMD <branch (or commit sha, etc.)>"
   exit 1
 }
 
 execute () {
   curl -H "Authorization: token $GITHUB_TOKEN" \
       --request POST \
-      --data "{\"event_type\": \"publish-api\" }" \
+      --data "{\"event_type\": \"publish-api\", \"client_payload\": { \"branch\": \"${BRANCH}\" } }" \
       https://api.github.com/repos/covid-projections/covid-data-model/dispatches
 
   echo "Publish requested. Go to https://github.com/covid-projections/covid-data-model/actions to monitor progress."


### PR DESCRIPTION
This splits deploy_api.yml into 2 workflows.  
* deploy_api.yml is now only triggered via repository_dispatch and can be provided a branch to run on in the client payload.
* daily_build.yml is triggered on the preexisting schedule and just triggers the deploy_api.yml repository_dispatch.

NOTE:
1. I left the COVID_DATA_PUBLIC plumbing as-is even though it probably should be cleaned up.  But I got nervous because a) I don't know the state of the raw data QA, and b) I don't know if Natasha's early warning ML stuff is going to need it still.
2. I decided to defer adding the the ability to load older datasets (timeseries.csv / latest.csv), since you can always just create a temp branch with the older timeseries data.

