### PR TITLE
Adding in logic to remove CT case backfill

### DIFF
--- a/libs/datasets/sources/nytimes_dataset.py
+++ b/libs/datasets/sources/nytimes_dataset.py
@@ -7,6 +7,21 @@ from libs.datasets import dataset_utils
 from libs.datasets.common_fields import CommonIndexFields
 from libs.us_state_abbrev import ABBREV_US_UNKNOWN_COUNTY_FIPS
 
+# On 2020-07-24, CT reported a backfill of 440 additional positive cases.
+# https://portal.ct.gov/Office-of-the-Governor/News/Press-Releases/2020/07-2020/Governor-Lamont-Coronavirus-Update-July-24
+# See https://trello.com/c/rPiM6UF4/333-adjust-ct-case-data-based-on-reported-backfill-vs-current-cases
+# for more information on backfill.
+ESTIMATED_REMOVED_CT_CASES_COUNTY = {
+    "09001": 188,
+    "09003": 154,
+    "09005": 24,
+    "09007": 4,
+    "09009": 39,
+    "09011": 8,
+    "09013": 22,
+    "09015": 2,
+}
+
 
 class NYTimesDataset(data_source.DataSource):
     SOURCE_NAME = "NYTimes"
@@ -49,6 +64,22 @@ class NYTimesDataset(data_source.DataSource):
         return cls(data_root / cls.DATA_FOLDER / cls.COUNTIES_DATA_FILE)
 
     @classmethod
+    def _remove_ct_cases(cls, data: pd.DataFrame) -> pd.DataFrame:
+        is_county = data[cls.Fields.AGGREGATE_LEVEL] == "county"
+        is_ct = data[cls.Fields.STATE] == "CT"
+        # July 24th was the day there was a backfill of cases
+        is_on_or_after_july_24 = data[cls.Fields.DATE] >= "2020-07-24"
+        is_ct_county_data_after_jul_24 = is_county & is_ct & is_on_or_after_july_24
+
+        # Remove backfilled tests from cumulatives on and after July 24th.
+        for fips, count in ESTIMATED_REMOVED_CT_CASES_COUNTY.items():
+            is_ct_fips_data_after_jul_24 = is_ct_county_data_after_jul_24 & (
+                data[CommonFields.FIPS] == fips
+            )
+            data.loc[is_ct_fips_data_after_jul_24, CommonFields.CASES] -= count
+        return data
+
+    @classmethod
     def standardize_data(cls, data: pd.DataFrame) -> pd.DataFrame:
         data[cls.Fields.COUNTRY] = "USA"
         data[cls.Fields.AGGREGATE_LEVEL] = "county"
@@ -87,5 +118,7 @@ class NYTimesDataset(data_source.DataSource):
         data.loc[unknown_fips, cls.Fields.FIPS] = data.loc[unknown_fips, cls.Fields.STATE].map(
             ABBREV_US_UNKNOWN_COUNTY_FIPS
         )
+
+        data = cls._remove_ct_cases(data)
 
         return data

--- a/test/libs/datasets/sources/nytimes_dataset_test.py
+++ b/test/libs/datasets/sources/nytimes_dataset_test.py
@@ -1,0 +1,34 @@
+import io
+
+import pytest
+import pandas as pd
+
+from libs.datasets.sources import nytimes_dataset
+from covidactnow.datapublic import common_df
+
+
+@pytest.mark.parametrize("is_ct_county", [True, False])
+def test_remove_ct_cases(is_ct_county):
+    if is_ct_county:
+        fips = "09001"
+    else:
+        fips = "36061"
+
+    data_buf = io.StringIO(
+        "fips,state,date,aggregate_level,cases\n"
+        f"{fips},CT,2020-07-23,county,1000\n"
+        f"{fips},CT,2020-07-24,county,1288\n"
+        f"{fips},CT,2020-07-25,county,1388\n"
+    )
+
+    data = common_df.read_csv(data_buf)
+    data = data.reset_index()
+
+    results = nytimes_dataset.NYTimesDataset._remove_ct_cases(data)
+
+    if is_ct_county:
+        expected_cases = pd.Series([1000, 1100, 1200], name="cases")
+    else:
+        expected_cases = pd.Series([1000, 1288, 1388], name="cases")
+
+    pd.testing.assert_series_equal(expected_cases, results.cases)

--- a/test/libs/datasets/sources/nytimes_dataset_test.py
+++ b/test/libs/datasets/sources/nytimes_dataset_test.py
@@ -24,7 +24,7 @@ def test_remove_ct_cases(is_ct_county):
     data = common_df.read_csv(data_buf)
     data = data.reset_index()
 
-    results = nytimes_dataset.NYTimesDataset._remove_ct_cases(data)
+    results = nytimes_dataset._remove_ct_backfill_cases(data)
 
     if is_ct_county:
         expected_cases = pd.Series([1000, 1100, 1200], name="cases")


### PR DESCRIPTION
Removes CT case backfill from the NYTimes dataset.  

Cases are removed weighted on number of cases that day, see: https://trello.com/c/rPiM6UF4/333-adjust-ct-case-data-based-on-reported-backfill-vs-current-cases