### PR TITLE
Pyseir location cleanup + start of removing county_metadata

### DIFF
--- a/libs/datasets/__init__.py
+++ b/libs/datasets/__init__.py
@@ -11,3 +11,4 @@ from libs.datasets.sources.fips_population import FIPSPopulation
 from libs.datasets.sources.nha_hospitalization import NevadaHospitalAssociationData
 
 from libs.datasets.common_fields import CommonFields
+from libs.datasets.dataset_utils import AggregationLevel

--- a/libs/datasets/latest_values_dataset.py
+++ b/libs/datasets/latest_values_dataset.py
@@ -123,6 +123,10 @@ class LatestValuesDataset(dataset_base.DatasetBase):
         return data
 
     @property
+    def county(self):
+        return self.get_subset(aggregation_level=AggregationLevel.COUNTY)
+
+    @property
     def state_data(self) -> pd.DataFrame:
         """Returns a new BedsDataset containing only state data."""
 

--- a/pyseir/backtest/backtester.py
+++ b/pyseir/backtest/backtester.py
@@ -166,32 +166,17 @@ class Backtester:
         """
 
         observations = {}
-        if len(fips) == 5:
-            (
-                times,
-                observations["new_cases"],
-                observations["new_deaths"],
-            ) = load_data.load_new_case_data_by_fips(fips, ref_date)
-            (
-                hospital_times,
-                hospitalizations,
-                hospitalization_data_type,
-            ) = load_data.load_hospitalization_data(fips, t0=ref_date)
-            observations["times"] = times.values
-        elif len(fips) == 2:
-            state_obj = us.states.lookup(fips)
-            (
-                observations["times"],
-                observations["new_cases"],
-                observations["new_deaths"],
-            ) = load_data.load_new_case_data_by_state(state_obj.name, ref_date)
-            (
-                hospital_times,
-                hospitalizations,
-                hospitalization_data_type,
-            ) = load_data.load_hospitalization_data_by_state(state_obj.abbr, t0=ref_date)
-            observations["times"] = np.array(observations["times"])
-
+        (
+            times,
+            observations["new_cases"],
+            observations["new_deaths"],
+        ) = load_data.load_new_case_data_by_fips(fips, ref_date)
+        (
+            hospital_times,
+            hospitalizations,
+            hospitalization_data_type,
+        ) = load_data.load_hospitalization_data(fips, t0=ref_date)
+        observations["times"] = times.values
         observations["hospitalizations"] = np.full(observations["times"].shape[0], np.nan)
         if hospitalization_data_type is HospitalizationDataType.CUMULATIVE_HOSPITALIZATIONS:
             observations["hospitalizations"][

--- a/pyseir/cli.py
+++ b/pyseir/cli.py
@@ -144,7 +144,7 @@ def build_counties_to_run_per_state(states: List[str], fips: str = None) -> Dict
             all_county_fips.update(county_fips_per_state)
             continue
 
-        if fips in county_fips_per_state:
+        if fips in county_fips_per_state and len(county_fips_per_state[fips]) > 0:
             root.info(f"Found {fips}, restricting run to found fips")
             all_county_fips.update({fips: state})
 
@@ -164,8 +164,10 @@ def _build_all_for_states(
     # prepare data
     _cache_global_datasets()
 
-    if not skip_whitelist:
-        _generate_whitelist()
+    # if not skip_whitelist:
+    #     _generate_whitelist()
+
+    all_county_fips = build_counties_to_run_per_state(states, fips=fips)
 
     # do everything for just states in parallel
     with Pool(maxtasksperchild=1) as p:

--- a/pyseir/cli.py
+++ b/pyseir/cli.py
@@ -164,10 +164,8 @@ def _build_all_for_states(
     # prepare data
     _cache_global_datasets()
 
-    # if not skip_whitelist:
-    #     _generate_whitelist()
-
-    all_county_fips = build_counties_to_run_per_state(states, fips=fips)
+    if not skip_whitelist:
+        _generate_whitelist()
 
     # do everything for just states in parallel
     with Pool(maxtasksperchild=1) as p:

--- a/pyseir/ensembles/ensemble_runner.py
+++ b/pyseir/ensembles/ensemble_runner.py
@@ -16,7 +16,8 @@ from pyseir import load_data
 from pyseir.reports.county_report import CountyReport
 from pyseir.utils import get_run_artifact_path, RunArtifact, RunMode
 from pyseir.inference import fit_results
-from libs.datasets.dataset_utils import AggregationLevel
+from libs.datasets import AggregationLevel
+from libs.datasets import combined_datasets
 
 
 _logger = logging.getLogger(__name__)
@@ -458,7 +459,7 @@ def run_state(state, ensemble_kwargs, states_only=False):
 
     if not states_only:
         # Run county level
-        all_fips = load_data.get_all_fips_codes_for_a_state(state)
+        all_fips = combined_datasets.load_us_latest_dataset().county.all_fips
         with Pool(maxtasksperchild=1) as p:
             f = partial(_run_county, ensemble_kwargs=ensemble_kwargs)
             p.map(f, all_fips)

--- a/pyseir/ensembles/ensemble_runner.py
+++ b/pyseir/ensembles/ensemble_runner.py
@@ -440,7 +440,7 @@ def _run_county(fips, ensemble_kwargs):
     runner.run_ensemble()
 
 
-def run_state(state, ensemble_kwargs, states_only=False):
+def run_state(state_full_name, ensemble_kwargs, states_only=False):
     """
     Run the EnsembleRunner for each county in a state.
 
@@ -454,12 +454,16 @@ def run_state(state, ensemble_kwargs, states_only=False):
         If True only run the state level.
     """
     # Run the state level
-    runner = EnsembleRunner(fips=us.states.lookup(state).fips, **ensemble_kwargs)
+    state_obj = us.states.lookup(state_full_name)
+    fips = state_obj.fips
+    runner = EnsembleRunner(fips=fips, **ensemble_kwargs)
     runner.run_ensemble()
 
     if not states_only:
         # Run county level
-        all_fips = combined_datasets.load_us_latest_dataset().county.all_fips
+        state = state_obj.abbr
+        county_latest = combined_datasets.load_us_latest_dataset().county
+        all_fips = county_latest.get_subset(state=state).all_fips
         with Pool(maxtasksperchild=1) as p:
             f = partial(_run_county, ensemble_kwargs=ensemble_kwargs)
             p.map(f, all_fips)

--- a/pyseir/inference/fit_results.py
+++ b/pyseir/inference/fit_results.py
@@ -1,4 +1,6 @@
 import os
+from libs import us_state_abbrev
+from covidactnow.datapublic.common_fields import CommonFields
 from libs.datasets import combined_datasets
 from pyseir import OUTPUT_DIR
 import pandas as pd
@@ -21,9 +23,11 @@ def load_t0(fips):
         t0(C=1) cases.
     """
     fips_data = combined_datasets.get_us_latest_for_fips(fips)
-    state = fips_data[CommonFields.STATE_FULL_NAME]
+    state = fips_data[CommonFields.STATE]
+    state_full_name = us_state_abbrev.ABBREV_US_STATE[state]
+
     fit_results = os.path.join(
-        OUTPUT_DIR, "pyseir", state, "data", f"summary__{state}_imputed_start_times.pkl"
+        OUTPUT_DIR, "pyseir", state, "data", f"summary__{state_full_name}_imputed_start_times.pkl"
     )
     return datetime.fromtimestamp(
         pd.read_pickle(fit_results).set_index("fips").loc[fips]["t0_date"].timestamp()

--- a/pyseir/inference/fit_results.py
+++ b/pyseir/inference/fit_results.py
@@ -1,5 +1,5 @@
 import os
-from pyseir.load_data import load_county_metadata
+from libs.datasets import combined_datasets
 from pyseir import OUTPUT_DIR
 import pandas as pd
 from datetime import datetime
@@ -8,7 +8,7 @@ from pyseir.utils import get_run_artifact_path, RunArtifact
 
 def load_t0(fips):
     """
-    Load the simulation start time by county.
+    Load the simulation start time by county from fit_results
 
     Parameters
     ----------
@@ -20,8 +20,8 @@ def load_t0(fips):
     : datetime
         t0(C=1) cases.
     """
-    county_metadata = load_county_metadata().set_index("fips")
-    state = county_metadata.loc[fips]["state"]
+    fips_data = combined_datasets.get_us_latest_for_fips(fips)
+    state = fips_data[CommonFields.STATE_FULL_NAME]
     fit_results = os.path.join(
         OUTPUT_DIR, "pyseir", state, "data", f"summary__{state}_imputed_start_times.pkl"
     )

--- a/pyseir/inference/initial_conditions_fitter.py
+++ b/pyseir/inference/initial_conditions_fitter.py
@@ -229,6 +229,7 @@ def _fit_fips(fips, generate_report=False):
         return {"model_params": None, "t0_date": None, "reduced_chi2": None}
 
 
+# Chris: Can we delete??? Not used anywhere and I don't think start dates matter...
 def generate_start_times_for_state(state, generate_report=False):
     """
     Generate imputed start dates for each county.

--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -177,6 +177,10 @@ class ModelFitter:
         self.dof_hosp = None
 
     @property
+    def state_fips(self):
+        return self.fips[:2]
+
+    @property
     def display_name(self):
         record = combined_datasets.get_us_latest_for_fips(self.fips)
         county = record[CommonFields.COUNTY]
@@ -218,7 +222,7 @@ class ModelFitter:
             self.fit_params["hosp_fraction"] = 1
 
         if len(self.fips) == 5:
-            state_fit_result = load_inference_result(fips=self.fips)
+            state_fit_result = load_inference_result(fips=self.state_fips)
             T0_LEFT_PAD = 5
             T0_RIGHT_PAD = 30
 

--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -691,7 +691,8 @@ def build_county_list(state_full_name):
 
     df_whitelist = load_data.load_whitelist()
     df_whitelist = df_whitelist[df_whitelist["inference_ok"] == True]
-    all_fips = df_whitelist.loc[df_whitelist["state"] == state, CommonFields.FIPS].tolist()
+    is_state = df_whitelist[CommonFields.STATE] == state
+    all_fips = df_whitelist.loc[is_state, CommonFields.FIPS].tolist()
 
     return all_fips
 

--- a/pyseir/models/suppression_policies.py
+++ b/pyseir/models/suppression_policies.py
@@ -378,8 +378,8 @@ def generate_empirical_distancing_policy_by_state(
     suppression_model: callable
         suppression_model(t) returns the current suppression model at time t
     """
-    latest_values = combined_datasets.load_us_latest_dataset()
-    state_values = latest_values.get_subset(aggregation_level=AggregationLevel.COUNTY, state=state)
+    latest_values = combined_datasets.load_us_latest_dataset().county
+    state_values = latest_values.get_subset(state=state)
     counties_fips = state_values.all_fips
 
     if reference_start_date is None:

--- a/pyseir/reports/state_report.py
+++ b/pyseir/reports/state_report.py
@@ -31,10 +31,7 @@ class StateReport:
         self.primary_suppression_policy = primary_suppression_policy
 
         # Load the county metadata and extract names for the state.
-        county_latest = combined_datasets.load_us_latest_dataset().get_subset(
-            aggregation_level=AggregationLevel.COUNTY
-        )
-
+        county_latest = combined_datasets.load_us_latest_dataset().county
         self.county_fips = county_latest.get_subset(
             state=us_state_abbrev.US_STATE_ABBREV[state]
         ).all_fips

--- a/pyseir/utils.py
+++ b/pyseir/utils.py
@@ -3,9 +3,12 @@ import us
 from datetime import datetime
 from enum import Enum
 from scipy import signal
+from covidactnow.datapublic.common_fields import CommonFields
+
 from pyseir import OUTPUT_DIR
 from pyseir import load_data
 from libs.datasets.dataset_utils import AggregationLevel
+from libs.datasets import combined_datasets
 
 REPORTS_FOLDER = lambda output_dir, state_name: os.path.join(
     output_dir, "pyseir", state_name, "reports"
@@ -74,7 +77,7 @@ def get_run_artifact_path(fips, artifact, output_dir=None) -> str:
     state_obj = us.states.lookup(fips[:2])
     if len(fips) == 5:
         agg_level = AggregationLevel.COUNTY
-        county = load_data.load_county_metadata_by_fips(fips)["county"]
+        county = combined_datasets.get_us_latest_for_fips(fips)[CommonFields.COUNTY]
     elif len(fips) == 2:
         agg_level = AggregationLevel.STATE
     else:

--- a/test/mocks/inference/load_data.py
+++ b/test/mocks/inference/load_data.py
@@ -80,18 +80,6 @@ def create_synthetic_df(data_generator) -> pd.DataFrame:
     return df
 
 
-# def load_hospitalization_data_by_state(state, t0=None):
-#     data_generator = DataGenerator(specs[state])
-#     times = list(range(0, 100))
-#     observed_new_cases = _get_cases_for_times(data_generator, times)
-#
-#     if data_generator.disable_deaths:
-#         hospitalizations = np.zeros(len(times))
-#     else:
-#         hospitalizations = 0.12 * observed_new_cases
-#     return (times, hospitalizations, HospitalizationDataType.CURRENT_HOSPITALIZATIONS)
-
-
 # _________________Other methods to mock__________________
 # (
 #                 self.times,


### PR DESCRIPTION
A couple things this PR accomplishes:
 * removes all state level data access functions in load_data - everything is accessed through fips.
 * Start removing most of the county_metadata references.  County metadata is another source that goes outside of our traditional data pipeline.  Removing the references helps streamline some of the pyseir code.  That source has always been very opaque to me.
 * One of the confusing things is that we use the full state name in a lot of locations when we should be using fips or the ISO 2 abbreviated name.  I start to try to make it more explicit where we do that in this PR.  I'd like to take another pass through in a separate PR to finish that cleanup.
 * It seems we only really use county metadata in the ensemble_runner for age distribution.  Do we actually use that? it would be great if we could find another way to save that data. 