### PR TITLE
Update Counties to Include in Greater New Orleans Infer Rt Aggregate

### DIFF
--- a/pyseir/rt/utils.py
+++ b/pyseir/rt/utils.py
@@ -15,7 +15,7 @@ import pyseir.rt.patches
 utils_log = logging.getLogger(__name__)
 
 
-# PR597 Request by Greater New Orlean Public Health to have a consistent Rt across the following:
+# PR598 Request by Greater New Orlean Public Health to have a consistent Rt across the following:
 NEW_ORLEANS_FIPS = (
     "22051",  # Jefferson
     "22071",  # Orleans

--- a/pyseir/rt/utils.py
+++ b/pyseir/rt/utils.py
@@ -14,7 +14,15 @@ import pyseir.rt.patches
 
 utils_log = logging.getLogger(__name__)
 
-NEW_ORLEANS_FIPS = ("22051", "22071", "22075", "22087", "22089", "22093", "22095", "22103")
+
+# PR597 Request by Greater New Orlean Public Health to have a consistent Rt across the following:
+NEW_ORLEANS_FIPS = (
+    "22051",  # Jefferson
+    "22071",  # Orleans
+    "22075",  # Plaquemines
+    "22087",  # St Bernard
+    "22103",  # St Tammany
+)
 
 
 class LagMonitor:


### PR DESCRIPTION
We got a request to limit the aggregated counties to a specific 5, instead of the 8 that are part of the greater CBSA.

Here are the individual timeseries:
![Individual Infer Rt Graphs](https://user-images.githubusercontent.com/20585842/89367194-4683d880-d68d-11ea-8fea-90a499900912.png)

Here is the difference between aggregating the raw data versus a population-weight average. The current solution is a population-weighted average and shows very little difference in recent rt predictions.
![Aggregate Metric](https://user-images.githubusercontent.com/20585842/89367211-4f74aa00-d68d-11ea-9bd9-23448e893882.png)

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [x] Are tests passing?
