### PR TITLE
Add data availability sheet

### DIFF
--- a/.github/workflows/update_repo_datasets.yml
+++ b/.github/workflows/update_repo_datasets.yml
@@ -20,6 +20,10 @@ env:
   # use a webhook to write to slack channel dev-alerts for QA
   SLACK_DEV_ALERTS_WEBHOOK: ${{ secrets.SLACK_DEV_ALERTS_WEBHOOK }}
 
+  DATA_AVAILABILITY_SHEET_NAME: "Data Availability"
+
+  GOOGLE_SHEETS_SERVICE_ACCOUNT_DATA: ${{ secrets.GOOGLE_SHEETS_SERVICE_ACCOUNT_DATA }}
+
 jobs:
   update-and-promote-datasets:
     runs-on: ubuntu-latest
@@ -67,6 +71,10 @@ jobs:
     - name: Create Update Commit
       working-directory: ./covid-data-model
       run: ./tools/push-data-update.sh
+    - name: Update Data Availability Sheet
+      working-directory: ./covid-data-model
+      run: |
+        ./run.py data update-availability-report
     - name: Slack notification
       if: failure()
       env:

--- a/cli/data.py
+++ b/cli/data.py
@@ -1,15 +1,19 @@
 from typing import Optional
 import logging
 import pathlib
+
 import click
+import gspread
+
+from libs import google_sheet_helpers
 from libs.qa import dataset_summary
+from libs.qa import data_availability
 from libs.datasets.timeseries import TimeseriesDataset
 from libs.datasets import dataset_utils
 from libs.datasets import combined_dataset_utils
 from libs.datasets import combined_datasets
 from libs.datasets.combined_dataset_utils import DatasetType
 from libs.datasets.dataset_utils import AggregationLevel
-
 
 PROD_BUCKET = "data.covidactnow.org"
 
@@ -52,3 +56,21 @@ def save_summary(output_dir: pathlib.Path, filename: str, level: Optional[Aggreg
         us_timeseries = us_timeseries.get_subset(aggregation_level=level)
 
     _save_field_summary(us_timeseries, output_dir / filename)
+
+
+@main.command()
+@click.option("--name", envvar="DATA_AVAILIBILITY_SHEET_NAME", default="Data Availability - Dev")
+@click.option("--share-email")
+def update_availability_report(name: str, share_email: Optional[str]):
+    sheet = google_sheet_helpers.open_or_create_spreadsheet(name, share_email=share_email)
+    google_sheet_helpers.update_info_sheet(sheet)
+    data_sources_by_source_name = data_availability.load_all_latest_sources()
+
+    for name, dataset in data_sources_by_source_name.items():
+        _logger.info(f"Updating {name}")
+        report = data_availability.build_data_availability_report(dataset)
+        data_availability.update_multi_field_availability_report(
+            sheet, report, name, columns_to_drop=["source", "fips", "generated"]
+        )
+
+    _logger.info("Finished updating data availability report")

--- a/libs/google_sheet_helpers.py
+++ b/libs/google_sheet_helpers.py
@@ -1,0 +1,113 @@
+from typing import Optional
+import datetime
+import base64
+import os
+import tempfile
+import structlog
+import gspread
+import pathlib
+from libs.datasets import dataset_utils
+from libs.datasets import dataset_pointer
+from libs.datasets.dataset_utils import DatasetType
+from libs.datasets.dataset_pointer import DatasetPointer
+
+
+_logger = structlog.getLogger(__name__)
+
+# base 64 encoded service account json file.
+SERVICE_ACCOUNT_DATA_ENV_NAME = "GOOGLE_SHEETS_SERVICE_ACCOUNT_DATA"
+
+
+def init_client() -> gspread.Client:
+    service_account_data = os.environ[SERVICE_ACCOUNT_DATA_ENV_NAME]
+    if service_account_data:
+        _logger.info("Loading service account from env variable data.")
+        service_account_data = base64.b64decode(service_account_data)
+
+        with tempfile.NamedTemporaryFile() as tmp_file:
+            tmp_file.write(service_account_data)
+            tmp_file.flush()
+            return gspread.service_account(filename=tmp_file.name)
+
+    return gspread.service_account()
+
+
+def create_or_replace_worksheet(
+    sheet: gspread.Spreadsheet, worksheet_name: str
+) -> gspread.Worksheet:
+    """Creates or replaces a worksheet with name `worksheet_name`.
+
+    Note(chris): Taking the approach of deleting worksheet to make sure that
+    state of worksheet is totally clean.  Other methods of clearing worksheet using gspread
+    did not clear conditional formatting rules.
+
+    Args:
+        sheet: Spreadsheet
+        worksheet_name: Name of worksheet.
+
+    Returns: Newly created Worksheet.
+    """
+    try:
+        worksheet = sheet.worksheet(worksheet_name)
+        try:
+            sheet.del_worksheet(worksheet)
+        except Exception:
+            # If worksheet name exists but is the only worksheet, need to add a new tmp sheet
+            # first then delete the old one
+            new_worksheet = sheet.add_worksheet("tmp", 100, 100)
+            sheet.del_worksheet(worksheet)
+            new_worksheet.update_title(worksheet_name)
+            return new_worksheet
+    except gspread.WorksheetNotFound:
+        pass
+
+    return sheet.add_worksheet(worksheet_name, 100, 100)
+
+
+def open_or_create_spreadsheet(
+    sheet_name: str,
+    share_email: Optional[str] = None,
+    gspread_client: Optional[gspread.Client] = None,
+) -> gspread.Spreadsheet:
+    """Opens or creates a spreadsheet, optionally sharing with `share_email`.
+
+    Args:
+        sheet_name: Name of sheet to open or create.
+        share_email: Email to share sheet with.
+
+    Returns: Spreadsheet.
+    """
+
+    gspread_client = gspread_client or init_client()
+
+    try:
+        sheet = gspread_client.open(sheet_name)
+    except gspread.SpreadsheetNotFound:
+        _logger.info("Sheet not found, creating.", sheet_name=sheet_name)
+        sheet = gspread_client.create(sheet_name)
+
+    if share_email:
+        _logger.info("Sharing sheet", email=share_email)
+        sheet.share(share_email, perm_type="user", role="writer")
+
+    return sheet
+
+
+def update_info_sheet(
+    sheet: gspread.Spreadsheet,
+    sheet_name: str = "Update Info",
+    pointer_directory: pathlib.Path = dataset_utils.DATA_DIRECTORY,
+):
+    filename = dataset_pointer.form_filename(DatasetType.TIMESERIES)
+    pointer_path = pointer_directory / filename
+    pointer = DatasetPointer.parse_raw(pointer_path.read_text())
+    data = [
+        ("Field", "Value"),
+        ("Updated at", datetime.datetime.utcnow().isoformat()),
+        ("Covid Data Model SHA", pointer.model_git_info.sha),
+        ("Covid Data Public SHA", pointer.data_git_info.sha),
+    ]
+    worksheet = create_or_replace_worksheet(sheet, sheet_name)
+    worksheet.update(data)
+
+    _logger.info("Successfully updated Info worksheet")

--- a/libs/google_sheet_helpers.py
+++ b/libs/google_sheet_helpers.py
@@ -19,7 +19,7 @@ SERVICE_ACCOUNT_DATA_ENV_NAME = "GOOGLE_SHEETS_SERVICE_ACCOUNT_DATA"
 
 
 def init_client() -> gspread.Client:
-    service_account_data = os.environ[SERVICE_ACCOUNT_DATA_ENV_NAME]
+    service_account_data = os.environ.get(SERVICE_ACCOUNT_DATA_ENV_NAME)
     if service_account_data:
         _logger.info("Loading service account from env variable data.")
         service_account_data = base64.b64decode(service_account_data)
@@ -111,3 +111,4 @@ def update_info_sheet(
     worksheet.update(data)
 
     _logger.info("Successfully updated Info worksheet")
+    return worksheet

--- a/libs/qa/data_availability.py
+++ b/libs/qa/data_availability.py
@@ -1,0 +1,179 @@
+from typing import List, Optional
+import pandas as pd
+
+from covidactnow.datapublic.common_fields import CommonFields
+from libs import google_sheet_helpers
+from libs.datasets.sources import fips_population
+from libs import notebook_helpers
+from libs.datasets import combined_datasets
+from libs.datasets.latest_values_dataset import LatestValuesDataset
+import gspread
+import gspread_formatting
+
+LOCATION_GROUP_KEY = "location_group"
+
+
+def load_all_latest_sources():
+    latest = combined_datasets.load_us_latest_dataset()
+    sources = notebook_helpers.load_data_sources_by_name()
+    sources_latest = {name: source.latest_values() for name, source in sources.items()}
+    combined_latest_data = latest.data.copy()
+    combined_latest_data["source"] = "Combined"
+    sources_latest["Combined Data"] = combined_latest_data
+
+    for source_name in sources_latest:
+        data = sources_latest[source_name]
+
+        # Drop unknown sources
+        invalid_locations = (data[CommonFields.FIPS].str.endswith("999")) | (
+            data[CommonFields.FIPS].str.startswith("90")
+        )
+        data = data.loc[~invalid_locations]
+        sources_latest[source_name] = LatestValuesDataset(data)
+
+    return sources_latest
+
+
+def build_data_availability_report(latest: LatestValuesDataset) -> pd.DataFrame:
+    """Builds report containing counts of locations with values.
+
+    Args:
+        latest: Dataset to summarize.
+
+    Returns:
+    """
+
+    data = latest.data.copy()
+
+    if "population" not in data.columns:
+        pop = fips_population.FIPSPopulation.local()
+        pop_map = pop.data.set_index("fips")["population"]
+        data["population"] = data["fips"].map(pop_map)
+
+    def classify_row(row):
+
+        if row.aggregate_level == "state":
+            return "state data"
+        return row.state
+
+    def count_with_values(x):
+        return x.apply(lambda y: sum(~y.isna()))
+
+    data[LOCATION_GROUP_KEY] = data.apply(classify_row, axis=1)
+
+    counts_per_location = data.groupby(LOCATION_GROUP_KEY).apply(count_with_values)
+
+    columns_to_drop = [
+        CommonFields.STATE,
+        CommonFields.COUNTY,
+        CommonFields.AGGREGATE_LEVEL,
+    ]
+    columns_to_drop = [
+        column for column in columns_to_drop if column in counts_per_location.columns
+    ]
+
+    counts_per_location = counts_per_location.drop(columns_to_drop, axis="columns")
+    counts_per_location["total_population"] = data.groupby(LOCATION_GROUP_KEY).population.sum()
+    counts_per_location = counts_per_location.sort_values("total_population", ascending=False).drop(
+        ["total_population"], axis="columns"
+    )
+
+    return counts_per_location.rename({LOCATION_GROUP_KEY: "num_locations"}, axis="columns")
+
+
+def build_data_availability_for_field(
+    latest_dataset: LatestValuesDataset, field: str
+) -> pd.DataFrame:
+    """Builds data availability report for a specific field.
+
+    Args:
+        latest_dataset: Dataset with multiple data sources
+        field: Name of field to select.
+
+    """
+    data = latest_dataset.data
+    data = data.set_index(
+        [CommonFields.FIPS, CommonFields.AGGREGATE_LEVEL, CommonFields.STATE, "source"]
+    )
+    series = data[field]
+    field_by_source = series.unstack(level=-1)
+    field_by_source.columns = field_by_source.columns.get_level_values(0).values
+    field_by_source = field_by_source.reset_index()
+    field_by_source = LatestValuesDataset(field_by_source)
+    return build_data_availability_report(field_by_source)
+
+
+def update_google_sheet_with_data(sheet, data: pd.DataFrame, worksheet_name):
+
+    sheet_data = [data.columns.values.tolist()] + data.where(~data.isna(), None).values.tolist()
+
+    worksheet = google_sheet_helpers.create_or_replace_worksheet(sheet, worksheet_name)
+    update_results = worksheet.update(sheet_data)
+
+    # Rotate first column and resize to make more readable
+    # TODO: Make this range dynamic
+    worksheet.format("A1:X1", {"textRotation": {"angle": 75}})
+    sheet.batch_update(
+        {
+            "requests": [
+                {
+                    "autoResizeDimensions": {
+                        "dimensions": {
+                            "sheetId": worksheet.id,
+                            "dimension": "COLUMNS",
+                            "startIndex": 0,
+                            "endIndex": len(data.columns),
+                        }
+                    }
+                }
+            ]
+        }
+    )
+    return worksheet
+
+
+def _build_color_scale_row_rule(worksheet, cell_range):
+    rule = gspread_formatting.ConditionalFormatRule(
+        ranges=[gspread_formatting.GridRange.from_a1_range(cell_range, worksheet)],
+        gradientRule=gspread_formatting.GradientRule(
+            minpoint=gspread_formatting.InterpolationPoint(
+                type="NUMBER", value="0", color=gspread_formatting.Color(0.9, 0.48, 0.46)
+            ),
+            midpoint=gspread_formatting.InterpolationPoint(
+                type="PERCENT", value="50", color=gspread_formatting.Color(0.98, 0.73, 0.01)
+            ),
+            maxpoint=gspread_formatting.InterpolationPoint(
+                type="MAX", color=gspread_formatting.Color(0.34, 0.73, 0.54)
+            ),
+        ),
+    )
+    return rule
+
+
+def update_multi_field_availability_report(
+    sheet: gspread.Spreadsheet,
+    dataset: pd.DataFrame,
+    name: str,
+    columns_to_drop: Optional[List[str]] = None,
+):
+    columns_to_drop = columns_to_drop or []
+    # Reorder dataset indices to put location group and num_locations first
+    # + sort columns for consistency.
+    dataset = dataset.reset_index()
+    columns = [column for column in dataset.columns.values if column not in columns_to_drop]
+    columns.pop(columns.index(LOCATION_GROUP_KEY))
+    columns.pop(columns.index("num_locations"))
+    columns = [LOCATION_GROUP_KEY, "num_locations"] + sorted(columns)
+    dataset = dataset[columns]
+
+    worksheet = update_google_sheet_with_data(sheet, dataset, name)
+
+    # Add conditional formatting
+    rules = gspread_formatting.get_conditional_format_rules(worksheet)
+    for i in range(len(dataset) + 1):
+        row = i + 1
+        # TODO: make this range dynamic
+        rule = _build_color_scale_row_rule(worksheet, f"B{row}:X{row}")
+
+        rules.append(rule)
+    rules.save()

--- a/notebooks/data_availability.ipynb
+++ b/notebooks/data_availability.ipynb
@@ -21,11 +21,12 @@
     "import ipywidgets as widgets\n",
     "import pandas as pd\n",
     "from covidactnow.datapublic.common_fields import CommonFields\n",
-    "from libs.datasets.sources import fips_population\n",
-    "from libs.datasets import combined_datasets\n",
+    "from libs.qa import data_availability\n",
     "from libs.datasets.latest_values_dataset import LatestValuesDataset\n",
     "from libs.datasets.timeseries import TimeseriesDataset\n",
     "\n",
+    "pd.options.display.max_rows = 3000\n",
+    "pd.options.display.max_columns = 3000\n",
     "pandarallel.pandarallel.initialize(progress_bar=True)"
    ]
   },
@@ -35,71 +36,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset = combined_datasets.load_us_timeseries_dataset()\n",
-    "latest = dataset.to_latest_values_dataset()\n",
-    "\n",
-    "sources = notebook_helpers.load_data_sources_by_name()\n",
-    "sources_latest = {name: source.latest_values() for name, source in sources.items()}\n",
-    "combined_latest_data = latest.data.copy()\n",
-    "combined_latest_data['source'] = 'Combined'\n",
-    "sources_latest[\"Combined Data\"] = combined_latest_data\n",
-    "\n",
-    "all_sources_latest = LatestValuesDataset(pd.concat(sources_latest.values()))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def build_prevalence_report(latest: LatestValuesDataset):\n",
-    "\n",
-    "    data = latest.data.copy()\n",
-    "    if 'population' not in data.columns:\n",
-    "        pop = fips_population.FIPSPopulation.local()\n",
-    "        pop_map = pop.data.set_index('fips')[\"population\"]\n",
-    "        data['population'] = data['fips'].map(pop_map)\n",
-    "\n",
-    "    def classify_row(row):\n",
-    "\n",
-    "        if row.aggregate_level == \"state\":\n",
-    "            return \"state data\"\n",
-    "        return row.state\n",
-    "\n",
-    "    def count_with_values(x):\n",
-    "        return x.apply(lambda y: sum(~y.isna()))\n",
-    "\n",
-    "    data[\"location_group\"] = data.apply(classify_row, axis=1)\n",
-    "\n",
-    "\n",
-    "    counts_per_location = data.groupby(\"location_group\").apply(count_with_values)\n",
-    "    columns_to_drop = ['state', 'country', 'aggregate_level', 'cumulative_hospitalized', 'cumulative_icu']\n",
-    "    columns_to_drop = [column for column in columns_to_drop if column in counts_per_location.columns]\n",
-    "\n",
-    "    counts_per_location = counts_per_location.drop(columns_to_drop, axis='columns')\n",
-    "    counts_per_location[\"total_population\"] = data.groupby(\"location_group\").population.sum()\n",
-    "    counts_per_location = counts_per_location.sort_values(\"total_population\", ascending=False).drop([\"total_population\"], axis='columns')\n",
-    "\n",
-    "    return (\n",
-    "        counts_per_location\n",
-    "        .style\n",
-    "        .background_gradient(axis=1, cmap='RdYlGn')\n",
-    "    )\n",
-    "\n",
-    "\n",
-    "def data_availability_by_field(latest_dataset, field):\n",
-    "    data = all_sources_latest.data\n",
-    "    columns = [CommonFields.FIPS, CommonFields.AGGREGATE_LEVEL, CommonFields.STATE] + [field, \"source\"]\n",
-    "    data[columns]\n",
-    "    data = data.set_index([\"fips\", \"aggregate_level\", \"state\", \"source\"])\n",
-    "    series = data[field]\n",
-    "    field_by_source = series.unstack(level=-1)\n",
-    "    field_by_source.columns = field_by_source.columns.get_level_values(0).values\n",
-    "    field_by_source = field_by_source.reset_index()\n",
-    "    field_by_source = LatestValuesDataset(field_by_source)\n",
-    "    return build_prevalence_report(field_by_source)\n",
-    "\n"
+    "sources_latest = data_availability.load_all_latest_sources()\n",
+    "all_data = [source.data for source in sources_latest.values()]\n",
+    "all_sources_latest = LatestValuesDataset(pd.concat(all_data))"
    ]
   },
   {
@@ -121,7 +60,7 @@
     "\n",
     "@interact\n",
     "def show_field_data_sources(field=widgets.Select(options=sorted(columns))):\n",
-    "    display(data_availability_by_field(all_sources_latest, field))\n"
+    "    display(data_availability.build_data_availability_for_field(all_sources_latest, field))\n"
    ]
   },
   {
@@ -137,25 +76,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "select_widget = widgets.Select(options=list({k: LatestValuesDataset(v) for k, v in sources_latest.items()}.items()))\n",
+    "select_widget = widgets.Select(options=list({k: v for k, v in sources_latest.items()}.items()))\n",
     "\n",
     "\n",
     "@interact\n",
     "def show_provenance_by_source_sources(dataset=select_widget):\n",
-    "    return build_prevalence_report(dataset)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Sample code to save provenance image\n",
-    "# import imgkit\n",
-    "\n",
-    "# html = build_prevalence_report(LatestValuesDataset(sources_latest[\"CmdcDataSource\"])).render()\n",
-    "# imgkit.from_string(html, 'styled_table.png')"
+    "    return data_availability.build_data_availability_report(dataset)"
    ]
   }
  ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,8 @@ idna==2.9
 isort==4.3.21
 kiwisolver==1.1.0
 lazy-object-proxy==1.4.1
+gspread==3.6.0
+gspread-formatting==0.2.5
 GitPython==3.1.0
 numpy==1.18.2
 matplotlib==3.2.1

--- a/test/libs/data_availability_report_test.py
+++ b/test/libs/data_availability_report_test.py
@@ -16,7 +16,7 @@ def test_build_availability_report():
     ]
     input_csv = "\n".join(input_csv)
 
-    dataset = LatestValuesDataset.load_csv(io.StringIO())
+    dataset = LatestValuesDataset.load_csv(io.StringIO(input_csv))
 
     report = data_availability.build_data_availability_report(dataset)
 

--- a/test/libs/data_availability_report_test.py
+++ b/test/libs/data_availability_report_test.py
@@ -1,0 +1,28 @@
+import io
+import pandas as pd
+from libs.datasets.latest_values_dataset import LatestValuesDataset
+from libs.qa import data_availability
+
+
+def test_build_availability_report():
+
+    input_csv = [
+        "fips,state,aggregate_level,population,field1,field2",
+        "36061,NY,county,500,1,",
+        "36062,NY,county,501,0,10",
+        "36063,NY,county,501,0,15",
+        "36,NY,state,10000,,10",
+        "09,CT,state,10000,10,10",
+    ]
+
+    dataset = LatestValuesDataset.load_csv(io.StringIO("\n".join(input_csv)))
+
+    report = data_availability.build_data_availability_report(dataset)
+
+    expected_csv = [
+        "location_group,fips,population,field1,field2,num_locations",
+        "state data,2,2,1,2,2",
+        "NY,3,3,3,2,3",
+    ]
+    expected_df = pd.read_csv(io.StringIO("\n".join(expected_csv)))
+    pd.testing.assert_frame_equal(expected_df, report.reset_index())

--- a/test/libs/data_availability_report_test.py
+++ b/test/libs/data_availability_report_test.py
@@ -14,8 +14,9 @@ def test_build_availability_report():
         "36,NY,state,10000,,10",
         "09,CT,state,10000,10,10",
     ]
+    input_csv = "\n".join(input_csv)
 
-    dataset = LatestValuesDataset.load_csv(io.StringIO("\n".join(input_csv)))
+    dataset = LatestValuesDataset.load_csv(io.StringIO())
 
     report = data_availability.build_data_availability_report(dataset)
 
@@ -24,5 +25,6 @@ def test_build_availability_report():
         "state data,2,2,1,2,2",
         "NY,3,3,3,2,3",
     ]
-    expected_df = pd.read_csv(io.StringIO("\n".join(expected_csv)))
+    expected_csv = "\n".join(expected_csv)
+    expected_df = pd.read_csv(io.StringIO(expected_csv))
     pd.testing.assert_frame_equal(expected_df, report.reset_index())


### PR DESCRIPTION
This computes and builds the [data availability sheet](https://docs.google.com/spreadsheets/d/1Z2wy8X9Xp1aWfXNYetPrr1FWNKN5Fraw3MVGMsHBFfc/edit?usp=sharing) from a command line: `./run.py data update-availability-sheet`.

It currently requires login via a service account token. When I add this onto the build token, we can base 64 encode the json file and store it in a github actions secret `GOOGLE_SHEETS_SERVICE_ACCOUNT_DATA`.  

I would like to do a bit more work to make it more dynamic, there are a couple hard coded ranges that are based on the specifics of the sheet. But other than that this PR should be good for a review