### PR TITLE
change indexing of summarize_timeseries_fields and add test

### DIFF
--- a/libs/qa/dataset_summary.py
+++ b/libs/qa/dataset_summary.py
@@ -43,9 +43,9 @@ def summarize_timeseries_fields(data: pd.DataFrame) -> pd.DataFrame:
     data = data[[column for column in data.columns if column not in IGNORE_COLUMNS]]
 
     melted = pd.melt(data, id_vars=[CommonFields.FIPS, CommonFields.DATE]).set_index(
-        [CommonFields.FIPS, CommonFields.DATE, VARIABLE_FIELD]
+        CommonFields.DATE
     )
-    fips_variable_grouped = melted.groupby([CommonFields.FIPS, VARIABLE_FIELD])
+    fips_variable_grouped = melted.groupby([CommonFields.FIPS, VARIABLE_FIELD], sort=False)
     return fips_variable_grouped["value"].apply(generate_field_summary).unstack()
 
 

--- a/libs/qa/dataset_summary_gen.py
+++ b/libs/qa/dataset_summary_gen.py
@@ -20,8 +20,8 @@ def generate_field_summary(series: pd.Series) -> pd.Series:
     largest_delta_date = None
 
     if has_value:
-        min_date = series.first_valid_index()[1]
-        max_date = series.last_valid_index()[1]
+        min_date = series.first_valid_index()
+        max_date = series.last_valid_index()
         latest_value = series[series.notnull()].iloc[-1]
         max_value = series.max()
         min_value = series.min()
@@ -29,7 +29,7 @@ def generate_field_summary(series: pd.Series) -> pd.Series:
         largest_delta = series.diff().abs().max()
         # If a
         if len(series.diff().abs().dropna()):
-            largest_delta_date = series.diff().abs().idxmax()[1]
+            largest_delta_date = series.diff().abs().idxmax()
 
     results = {
         "has_value": has_value,


### PR DESCRIPTION
`dataset_summary_gen.py` depended on the order of the indexes set in `summarize_timeseries_fields` but it wasn't tested. This PR adds a test and changes the indexing to add only dates. My next PR adds another caller to dataset_summary_gen which can't as easily set the same index.