### PR TITLE
Removing recovered cases from JHU data

### DIFF
--- a/libs/datasets/sources/jhu_dataset.py
+++ b/libs/datasets/sources/jhu_dataset.py
@@ -118,7 +118,7 @@ class JHUDataset(data_source.DataSource):
         # Not including cases grouped in recovered state.
         # on 8/11 recovered cases were assigned to a specific fips which caused duplicates.
         is_recovered_state = data[cls.Fields.STATE] == "Recovered"
-        data = data.loc[~is_recovered_state]
+        data.loc[is_recovered_state, cls.Fields.FIPS] = None
 
         return data
 

--- a/libs/datasets/sources/jhu_dataset.py
+++ b/libs/datasets/sources/jhu_dataset.py
@@ -115,6 +115,11 @@ class JHUDataset(data_source.DataSource):
             data, county_key=cls.Fields.COUNTY, fips_key=cls.Fields.FIPS
         )
 
+        # Not including cases grouped in recovered state.
+        # on 8/11 recovered cases were assigned to a specific fips which caused duplicates.
+        is_recovered_state = data[cls.Fields.STATE] == "Recovered"
+        data = data.loc[~is_recovered_state]
+
         return data
 
     @classmethod


### PR DESCRIPTION
This was a bit annoying - looks like the recovered cases were added to a single fips in the 8/11 data, which was causing the source data to fail.  The fips has historically been none, so i just removed the fips for that record:
![image](https://user-images.githubusercontent.com/1422280/90027723-d7a71080-dc86-11ea-950e-e4d626afad46.png)