### PR TITLE
Share loaded data sources between latest and timeseries combined data

### DIFF
--- a/cli/data.py
+++ b/cli/data.py
@@ -40,8 +40,7 @@ def update(summary_filename, wide_dates_filename):
     """Updates latest and timeseries datasets to the current checked out covid data public commit"""
     path_prefix = dataset_utils.DATA_DIRECTORY.relative_to(dataset_utils.REPO_ROOT)
 
-    latest_dataset = combined_datasets.build_us_latest_with_all_fields()
-    timeseries_dataset = combined_datasets.build_us_timeseries_with_all_fields()
+    timeseries_dataset, latest_dataset = combined_datasets.build_us_timeseries_with_all_fields()
     _, timeseries_pointer = combined_dataset_utils.update_data_public_head(
         path_prefix, latest_dataset, timeseries_dataset
     )

--- a/cli/data.py
+++ b/cli/data.py
@@ -40,7 +40,7 @@ def update(summary_filename, wide_dates_filename):
     """Updates latest and timeseries datasets to the current checked out covid data public commit"""
     path_prefix = dataset_utils.DATA_DIRECTORY.relative_to(dataset_utils.REPO_ROOT)
 
-    timeseries_dataset, latest_dataset = combined_datasets.build_us_timeseries_with_all_fields()
+    timeseries_dataset, latest_dataset = combined_datasets.build_us_with_all_fields()
     _, timeseries_pointer = combined_dataset_utils.update_data_public_head(
         path_prefix, latest_dataset, timeseries_dataset
     )

--- a/data/latest.json
+++ b/data/latest.json
@@ -7,9 +7,9 @@
     "is_dirty": false
   },
   "model_git_info": {
-    "sha": "b530e06d0e2af1d7dcecbf70057895178a15ffce",
+    "sha": "54121af1f0f686af83d6e3ef48e4fe54ff76fca3",
     "branch": "master",
     "is_dirty": true
   },
-  "updated_at": "2020-08-12T18:49:39.697650"
+  "updated_at": "2020-08-12T19:09:41.235432"
 }

--- a/data/latest.json
+++ b/data/latest.json
@@ -3,13 +3,13 @@
   "path": "data/latest.csv",
   "data_git_info": {
     "sha": "dad635d89dc7c0780a8b306ef632f46b45e9a888",
-    "branch": "master",
+    "branch": "detached",
     "is_dirty": false
   },
   "model_git_info": {
-    "sha": "3f1beb2e6ce9b5ffbb9b3bf4124787d0cf5e05b1",
+    "sha": "b530e06d0e2af1d7dcecbf70057895178a15ffce",
     "branch": "master",
-    "is_dirty": false
+    "is_dirty": true
   },
-  "updated_at": "2020-08-12T16:21:11.777553"
+  "updated_at": "2020-08-12T18:49:39.697650"
 }

--- a/data/latest.json
+++ b/data/latest.json
@@ -7,9 +7,9 @@
     "is_dirty": false
   },
   "model_git_info": {
-    "sha": "54121af1f0f686af83d6e3ef48e4fe54ff76fca3",
+    "sha": "d14e13065d561b5adc565a81c92f59114f0838a6",
     "branch": "master",
     "is_dirty": true
   },
-  "updated_at": "2020-08-12T19:09:41.235432"
+  "updated_at": "2020-08-12T19:48:46.839324"
 }

--- a/data/timeseries.json
+++ b/data/timeseries.json
@@ -7,9 +7,9 @@
     "is_dirty": false
   },
   "model_git_info": {
-    "sha": "b530e06d0e2af1d7dcecbf70057895178a15ffce",
+    "sha": "54121af1f0f686af83d6e3ef48e4fe54ff76fca3",
     "branch": "master",
     "is_dirty": true
   },
-  "updated_at": "2020-08-12T18:49:40.215030"
+  "updated_at": "2020-08-12T19:09:41.787824"
 }

--- a/data/timeseries.json
+++ b/data/timeseries.json
@@ -3,13 +3,13 @@
   "path": "data/timeseries.csv",
   "data_git_info": {
     "sha": "dad635d89dc7c0780a8b306ef632f46b45e9a888",
-    "branch": "master",
+    "branch": "detached",
     "is_dirty": false
   },
   "model_git_info": {
-    "sha": "3f1beb2e6ce9b5ffbb9b3bf4124787d0cf5e05b1",
+    "sha": "b530e06d0e2af1d7dcecbf70057895178a15ffce",
     "branch": "master",
     "is_dirty": true
   },
-  "updated_at": "2020-08-12T16:21:13.489824"
+  "updated_at": "2020-08-12T18:49:40.215030"
 }

--- a/data/timeseries.json
+++ b/data/timeseries.json
@@ -7,9 +7,9 @@
     "is_dirty": false
   },
   "model_git_info": {
-    "sha": "54121af1f0f686af83d6e3ef48e4fe54ff76fca3",
+    "sha": "d14e13065d561b5adc565a81c92f59114f0838a6",
     "branch": "master",
     "is_dirty": true
   },
-  "updated_at": "2020-08-12T19:09:41.787824"
+  "updated_at": "2020-08-12T19:48:47.209252"
 }

--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -112,7 +112,7 @@ US_STATES_FILTER = dataset_filter.DatasetFilter(
 )
 
 
-def build_us_timeseries_with_all_fields() -> Tuple[TimeseriesDataset, LatestValuesDataset]:
+def build_us_with_all_fields() -> Tuple[TimeseriesDataset, LatestValuesDataset]:
     data_source_classes = set(
         chain(
             chain.from_iterable(ALL_FIELDS_FEATURE_DEFINITION.values()),

--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -248,9 +248,11 @@ def _build_combined_dataset_from_sources(
     """Builds a combined dataset from a feature definition.
 
     Args:
+        target_dataset_cls: Type of the returned combined dataset.
+        loaded_data_sources: Dictionary mapping source name to a DataSource object
         feature_definition_config: Dictionary mapping an output field to the
-            data sources that will be used to pull values from.
-        filters: A list of dataset filters applied to the datasets before
+            data source classes that will be used to pull values from.
+        filter: A dataset filters applied to the datasets before
             assembling features.
     """
 

--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -266,10 +266,10 @@ def _build_combined_dataset_from_sources(
     for source_name in chain.from_iterable(feature_definition.values()):
         source = loaded_data_sources[source_name]
         if target_dataset_cls == TimeseriesDataset:
-            datasets[source_name] = filter.apply(source.timeseries()).indexed_df()
+            datasets[source_name] = filter.apply(source.timeseries()).indexed_data()
         else:
             assert target_dataset_cls == LatestValuesDataset
-            datasets[source_name] = filter.apply(source.latest_values()).indexed_df()
+            datasets[source_name] = filter.apply(source.latest_values()).indexed_data()
 
     data, provenance = _build_data_and_provenance(feature_definition, datasets)
     return target_dataset_cls(data.reset_index(), provenance=_to_timeseries_rows(provenance, _log))

--- a/libs/datasets/data_source.py
+++ b/libs/datasets/data_source.py
@@ -69,8 +69,22 @@ class DataSource(object):
 
     @lru_cache(None)
     def timeseries(self) -> TimeseriesDataset:
-        return TimeseriesDataset.build_from_data_source(self)
+        """Build TimeseriesDataset from this data source."""
+        if set(self.INDEX_FIELD_MAP.keys()) != set(TimeseriesDataset.INDEX_FIELDS):
+            raise ValueError("Index fields must match")
+
+        return TimeseriesDataset.from_source(
+            self, fill_missing_state=self.FILL_MISSING_STATE_LEVEL_DATA
+        )
 
     @lru_cache(None)
     def latest_values(self) -> LatestValuesDataset:
-        return LatestValuesDataset.build_from_data_source(self)
+        if set(self.INDEX_FIELD_MAP.keys()) == set(TimeseriesDataset.INDEX_FIELDS):
+            return LatestValuesDataset(self.timeseries().latest_values())
+
+        if set(self.INDEX_FIELD_MAP.keys()) != set(LatestValuesDataset.INDEX_FIELDS):
+            raise ValueError("Index fields must match")
+
+        return LatestValuesDataset.from_source(
+            self, fill_missing_state=self.FILL_MISSING_STATE_LEVEL_DATA
+        )

--- a/libs/datasets/data_source.py
+++ b/libs/datasets/data_source.py
@@ -60,12 +60,12 @@ class DataSource(object):
     @lru_cache(None)
     def beds(self) -> LatestValuesDataset:
         """Builds generic beds dataset"""
-        return LatestValuesDataset.build_from_data_source(self)
+        return self.latest_values()
 
     @lru_cache(None)
     def population(self) -> LatestValuesDataset:
         """Builds generic beds dataset"""
-        return LatestValuesDataset.build_from_data_source(self)
+        return self.latest_values()
 
     @lru_cache(None)
     def timeseries(self) -> TimeseriesDataset:

--- a/libs/datasets/data_source.py
+++ b/libs/datasets/data_source.py
@@ -69,5 +69,8 @@ class DataSource(object):
 
     @lru_cache(None)
     def timeseries(self) -> TimeseriesDataset:
-        """Builds generic beds dataset"""
         return TimeseriesDataset.build_from_data_source(self)
+
+    @lru_cache(None)
+    def latest_values(self) -> LatestValuesDataset:
+        return LatestValuesDataset.build_from_data_source(self)

--- a/libs/datasets/dataset_base.py
+++ b/libs/datasets/dataset_base.py
@@ -30,11 +30,6 @@ class DatasetBase(object):
             yield row.where(pd.notnull(row), None).to_dict()
 
     @classmethod
-    def build_from_data_source(cls, source) -> "DatasetBase":
-        """Builds an instance of the dataset from a data source."""
-        raise NotImplementedError("Subsclass must implement")
-
-    @classmethod
     def load_csv(cls, path_or_buf: Union[pathlib.Path, TextIO]):
         raise NotImplementedError()
 

--- a/libs/datasets/dataset_base.py
+++ b/libs/datasets/dataset_base.py
@@ -48,3 +48,14 @@ class DatasetBase(object):
         if self.provenance is not None:
             provenance_path = str(path).replace(".csv", "-provenance.csv")
             self.provenance.sort_index().to_csv(provenance_path)
+
+    def indexed_df(self) -> pd.DataFrame:
+        data_with_index = self.data.set_index(self.COMMON_INDEX_FIELDS)
+        if data_with_index.index.duplicated(keep=False).any():
+            raise ValueError(f"Duplicate found in index")
+        # If any duplicates slip in the following code may help you debug them:
+        # https://stackoverflow.com/a/34297689
+        # datasets[name] = data_with_index.loc[~data_with_index.duplicated(keep="first"), :]
+        # datasets[key] = dataset_obj.data.groupby(target_dataset_cls.COMMON_INDEX_FIELDS).first() fails
+        # due to <NA>s: cannot convert to 'float64'-dtype NumPy array with missing values. Specify an appropriate 'na_value' for this dtype.
+        return data_with_index

--- a/libs/datasets/dataset_base.py
+++ b/libs/datasets/dataset_base.py
@@ -44,7 +44,7 @@ class DatasetBase(object):
             provenance_path = str(path).replace(".csv", "-provenance.csv")
             self.provenance.sort_index().to_csv(provenance_path)
 
-    def indexed_df(self) -> pd.DataFrame:
+    def indexed_data(self) -> pd.DataFrame:
         """Returns all the data in a DataFrame with FIPS or (FIPS, DATE) as the row index."""
         data_with_index = self.data.set_index(self.COMMON_INDEX_FIELDS)
         if data_with_index.index.duplicated(keep=False).any():

--- a/libs/datasets/dataset_base.py
+++ b/libs/datasets/dataset_base.py
@@ -45,6 +45,7 @@ class DatasetBase(object):
             self.provenance.sort_index().to_csv(provenance_path)
 
     def indexed_df(self) -> pd.DataFrame:
+        """Returns all the data in a DataFrame with FIPS or (FIPS, DATE) as the row index."""
         data_with_index = self.data.set_index(self.COMMON_INDEX_FIELDS)
         if data_with_index.index.duplicated(keep=False).any():
             raise ValueError(f"Duplicate found in index")

--- a/libs/datasets/dataset_utils.py
+++ b/libs/datasets/dataset_utils.py
@@ -12,8 +12,8 @@ from libs.us_state_abbrev import US_STATE_ABBREV
 # Slowly changing attributes of a geographical region
 GEO_DATA_COLUMNS = [
     CommonFields.FIPS,
-    CommonFields.AGGREGATE_LEVEL,
     CommonFields.STATE,
+    CommonFields.AGGREGATE_LEVEL,
     CommonFields.COUNTRY,
     CommonFields.COUNTY,
 ]
@@ -368,9 +368,12 @@ def fips_index_geo_data(df: pd.DataFrame) -> pd.DataFrame:
     """
     if df.index.names:
         df = df.reset_index()
+    # Make a list of the GEO_DATA_COLUMNS in df, in GEO_DATA_COLUMNS order. The intersection method returns
+    # values in a different order, which makes comparing the wide dates CSV harder.
+    present_columns = [column for column in GEO_DATA_COLUMNS if column in df.columns]
     # The GEO_DATA_COLUMNS are expected to have a single value for each FIPS. Get the columns
     # from every row of each data source and then keep one of each unique row.
-    all_identifiers = df.loc[:, df.columns.intersection(GEO_DATA_COLUMNS)].drop_duplicates()
+    all_identifiers = df.loc[:, present_columns].drop_duplicates()
     # Make a DataFrame with a unique FIPS index. If multiple rows are found with the same FIPS then there
     # are rows in the input data sources that have different values for county name, state etc.
     fips_indexed = all_identifiers.set_index(CommonFields.FIPS, verify_integrity=True)

--- a/libs/datasets/latest_values_dataset.py
+++ b/libs/datasets/latest_values_dataset.py
@@ -73,19 +73,6 @@ class LatestValuesDataset(dataset_base.DatasetBase):
         return cls(data)
 
     @classmethod
-    def build_from_data_source(cls, source) -> "LatestValuesDataset":
-        from libs.datasets.timeseries import TimeseriesDataset
-
-        if set(source.INDEX_FIELD_MAP.keys()) == set(TimeseriesDataset.INDEX_FIELDS):
-            timeseries = source.timeseries()
-            return cls(timeseries.latest_values())
-
-        if set(source.INDEX_FIELD_MAP.keys()) != set(cls.INDEX_FIELDS):
-            raise ValueError("Index fields must match")
-
-        return cls.from_source(source, fill_missing_state=source.FILL_MISSING_STATE_LEVEL_DATA)
-
-    @classmethod
     def _calculate_puerto_rico_bed_occupancy_rate(cls, data):
         is_pr_county = data[CommonFields.FIPS].str.match("72[0-9][0-9][0-9]")
         pr_data = data.loc[is_pr_county.fillna(False)]

--- a/libs/datasets/latest_values_dataset.py
+++ b/libs/datasets/latest_values_dataset.py
@@ -73,11 +73,11 @@ class LatestValuesDataset(dataset_base.DatasetBase):
         return cls(data)
 
     @classmethod
-    def build_from_data_source(cls, source):
+    def build_from_data_source(cls, source) -> "LatestValuesDataset":
         from libs.datasets.timeseries import TimeseriesDataset
 
         if set(source.INDEX_FIELD_MAP.keys()) == set(TimeseriesDataset.INDEX_FIELDS):
-            timeseries = TimeseriesDataset.build_from_data_source(source)
+            timeseries = source.timeseries()
             return cls(timeseries.latest_values())
 
         if set(source.INDEX_FIELD_MAP.keys()) != set(cls.INDEX_FIELDS):

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -272,14 +272,6 @@ class TimeseriesDataset(dataset_base.DatasetBase):
         data = data.sort_values(CommonFields.DATE)
         return cls(data)
 
-    @classmethod
-    def build_from_data_source(cls, source) -> "TimeseriesDataset":
-        """Build TimeseriesDataset from a data source."""
-        if set(source.INDEX_FIELD_MAP.keys()) != set(cls.INDEX_FIELDS):
-            raise ValueError("Index fields must match")
-
-        return cls.from_source(source, fill_missing_state=source.FILL_MISSING_STATE_LEVEL_DATA)
-
     def summarize(self):
         dataset_utils.summarize(
             self.data,

--- a/libs/notebook_helpers.py
+++ b/libs/notebook_helpers.py
@@ -47,7 +47,7 @@ def load_data_sources_by_name() -> Dict[str, TimeseriesDataset]:
     ]
     source_map = {}
     for source_cls in sources:
-        dataset = TimeseriesDataset.build_from_data_source(source_cls.local())
+        dataset = source_cls.local().timeseries()
         dataset = US_STATES_FILTER.apply(dataset)
         dataset.data["source"] = source_cls.__name__
         source_map[source_cls.__name__] = dataset

--- a/test/combined_dataset_test.py
+++ b/test/combined_dataset_test.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from itertools import chain
 
 import structlog
 
@@ -280,12 +281,17 @@ def test_build_combined_dataset_from_sources_smoke_test():
         CommonFields.RECOVERED: [JHUDataset],
     }
 
+    loaded_data_sources = {
+        data_source_cls.SOURCE_NAME: data_source_cls.local()
+        for data_source_cls in chain.from_iterable(feature_definition.values())
+    }
+
     _build_combined_dataset_from_sources(
-        TimeseriesDataset, feature_definition, filter=US_STATES_FILTER,
+        TimeseriesDataset, loaded_data_sources, feature_definition, filter=US_STATES_FILTER,
     )
 
     _build_combined_dataset_from_sources(
-        LatestValuesDataset, feature_definition, filter=US_STATES_FILTER,
+        LatestValuesDataset, loaded_data_sources, feature_definition, filter=US_STATES_FILTER,
     )
 
 

--- a/test/combined_dataset_test.py
+++ b/test/combined_dataset_test.py
@@ -93,7 +93,7 @@ def test_combined_county_has_some_timeseries_data(fips):
 )
 def test_unique_timeseries(data_source_cls):
     data_source = data_source_cls.local()
-    timeseries = TimeseriesDataset.build_from_data_source(data_source)
+    timeseries = data_source.timeseries()
     timeseries = combined_datasets.US_STATES_FILTER.apply(timeseries)
     # Check for duplicate rows with the same INDEX_FIELDS. Sort by index so duplicates are next to
     # each other in the message if the assert fails.


### PR DESCRIPTION
## This PR

* Moves code that changes a `DataSource` into a `DatasetBase` from combined_datasets, latest_values_dataset.py, timeseries.py to data_source.py.
* Load data sources before calling _build_combined_dataset_from_sources so that the loaded values can be used in multiple calls. Because `DataSource.latest` sometimes calls `DataSource.timeseries` the cache saves a bunch of processing time, reducing time as measured by `/usr/bin/time -v ./run.py data update` from 6 to 5 minutes.
* Make sure geo data columns in the wide-data DataFrame are created in a deterministic manner and sorted to match existing data.

## Tested

`./run.py data update` re-generates the existing contents of `data/` exactly.