### PR TITLE
fix template, second try

### DIFF
--- a/.github/workflows/update_repo_datasets.yml
+++ b/.github/workflows/update_repo_datasets.yml
@@ -91,4 +91,4 @@ jobs:
         DATA_AVAILABILITY_URL: http://tiny.cc/candata
       uses: Ilshidur/action-slack@fb92a78
       with:
-        args: 'update-dataset-snapshot succeeded. View Data Availability Report at ${{DATA_AVAILABILITY_URL)}'
+        args: 'update-dataset-snapshot succeeded. View Data Availability Report at ${{DATA_AVAILABILITY_URL}}'


### PR DESCRIPTION
Followup to https://github.com/covid-projections/covid-data-model/pull/613 because https://github.com/covid-projections/covid-data-model/actions/runs/209780506 failed with
```
The workflow is not valid. .github/workflows/update_repo_datasets.yml (Line: 94, Col: 15): The expression is not closed. An unescaped ${{ sequence was found, but the closing }} sequence was not found.
```
