### PR TITLE
another workflow syntax fix

### DIFF
--- a/.github/workflows/update_repo_datasets.yml
+++ b/.github/workflows/update_repo_datasets.yml
@@ -91,4 +91,4 @@ jobs:
         DATA_AVAILABILITY_URL: http://tiny.cc/candata
       uses: Ilshidur/action-slack@fb92a78
       with:
-        args: 'update-dataset-snapshot succeeded. View Data Availability Report at ${{DATA_AVAILABILITY_URL}}'
+        args: 'update-dataset-snapshot succeeded. View Data Availability Report at {{DATA_AVAILABILITY_URL}}'


### PR DESCRIPTION
https://github.com/covid-projections/covid-data-model/pull/614 didn't work... https://github.com/covid-projections/covid-data-model/actions/runs/209851636 failed with
```
The workflow is not valid. .github/workflows/update_repo_datasets.yml (Line: 94, Col: 15): Unrecognized named-value: 'DATA_AVAILABILITY_URL'. Located at position 1 within expression: DATA_AVAILABILITY_URL
```
This change copies https://github.com/covid-projections/covid-data-public/blob/master/.github/workflows/update_data.yml#L75 though I don't see that syntax for accessing env documented at https://docs.github.com/en/actions/reference