### PR TITLE
Setting sentry environment to allow configuration of sentry alerts per environment

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -35,6 +35,9 @@ env:
   # Used by python code that reports errors to sentry.
   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
+  # Sets the sentry environment, controlling how alerts are reported.
+  SENTRY_ENVIRONMENT: ${{ github.event.client_payload.sentry_environment }}
+
   # use a webhook to write to slack channel dev-alerts for QA
   SLACK_DEV_ALERTS_WEBHOOK: ${{ secrets.SLACK_DEV_ALERTS_WEBHOOK }}
 

--- a/cli/api.py
+++ b/cli/api.py
@@ -156,6 +156,4 @@ def generate_top_counties(disable_validation, input_dir, output, state, fips):
     api_pipeline.deploy_json_api_output(
         intervention, bulk_timeseries, output, filename_override="counties_top_100.json"
     )
-    # top_counties_pipeline.deploy_results(county_results_api, "counties_top_100", output)
-
-    # _logger.info("finished top counties job")
+    _logger.info("Finished top counties job")

--- a/tools/build-snapshot.sh
+++ b/tools/build-snapshot.sh
@@ -21,6 +21,14 @@ prepare () {
     echo "https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line"
     exit 1
   fi
+
+  # Set the sentry environment to allow quieting of alerts on
+  # non-master branches.
+  if [[ $BRANCH == "master" ]]; then
+      SENTRY_ENVIRONMENT="production"
+  else
+      SENTRY_ENVIRONMENT="staging"
+  fi
 }
 
 exit_with_usage () {
@@ -31,11 +39,10 @@ exit_with_usage () {
 execute () {
   curl -H "Authorization: token $GITHUB_TOKEN" \
       --request POST \
-      --data "{\"event_type\": \"publish-api\", \"client_payload\": { \"branch\": \"${BRANCH}\" } }" \
+      --data "{\"event_type\": \"publish-api\", \"client_payload\": { \"branch\": \"${BRANCH}\", \"sentry_environment\": \"${SENTRY_ENVIRONMENT}\" } }" \
       https://api.github.com/repos/covid-projections/covid-data-model/dispatches
 
   echo "Publish requested. Go to https://github.com/covid-projections/covid-data-model/actions to monitor progress."
 }
 
 prepare "$@"
-execute


### PR DESCRIPTION
https://github.com/covid-projections/covid-data-public/blob/master/covidactnow/datapublic/common_init.py#L74

We initialize the sentry environment with the `SENTRY_ENVIRONMENT` environment variable.  setting that per branch so that we can control alerts and not send noisy alerts for test builds