### PR TITLE
Ensure that NaNs accross all fields stay NaN

### DIFF
--- a/libs/datasets/custom_aggregations.py
+++ b/libs/datasets/custom_aggregations.py
@@ -43,7 +43,8 @@ def calculate_combined_new_york_counties(data, group, are_boroughs_zero=False):
             if not non_ny_county[column].isna().all():
                 assert sum(grouped[column]) != 0, f"{column} is unexpectedly zero."
 
-    aggregated = new_york_county.groupby(group).sum().reset_index()
+    # Setting min count to 1 to preserve fields with all nans.
+    aggregated = new_york_county.groupby(group).sum(min_count=1).reset_index()
     aggregated["fips"] = NEW_YORK_COUNTY_FIPS
 
     without_nyc = data[~is_nyc_fips]

--- a/test/data_validation_test.py
+++ b/test/data_validation_test.py
@@ -16,6 +16,7 @@ def default_timeseries_row(**updates):
         "cases": 10.0,
         "deaths": 1.0,
         "recovered": 0.0,
+        "current_icu": None,
         "source": "JHU",
         "county": "Richland Parish",
     }
@@ -58,3 +59,4 @@ def test_nyc_aggregation(are_boroughs_zero):
         assert nyc_result["cases"] == nyc_cases
     else:
         assert nyc_result["cases"] == nyc_cases + borough_cases
+        assert pd.isna(nyc_result["current_icu"])


### PR DESCRIPTION
By setting min_count to 1, it requires 1 non-na number to be present to produce a value.