### PR TITLE
Update New York City Test Cases

### DIFF
--- a/test/libs/generate_api_test.py
+++ b/test/libs/generate_api_test.py
@@ -75,15 +75,15 @@ def test_build_summary_for_fips(include_projections, rt_null, nyc_model_output_p
                 # Manually calculated from capacity calculation in generate_api.py
                 "capacity": 12763,
                 "totalCapacity": nyc_latest["max_bed_count"],
-                "currentUsageCovid": 0,
+                "currentUsageCovid": None,
                 "currentUsageTotal": None,
                 "typicalUsageRate": nyc_latest["all_beds_occupancy_rate"],
             },
             ICUBeds={
                 "capacity": nyc_latest["icu_beds"],
                 "totalCapacity": nyc_latest["icu_beds"],
-                "currentUsageCovid": 0,
-                "currentUsageTotal": 0,
+                "currentUsageCovid": None,
+                "currentUsageTotal": None,
                 "typicalUsageRate": nyc_latest["icu_occupancy_rate"],
             },
             contactTracers=nyc_latest["contact_tracers_count"],


### PR DESCRIPTION
This PR addresses a broken test due to a change in the New York County merge. A sum of NaN now returns NaN instead of 0, which is reflected in the actuals used for the assertion comparison.

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [x] Are tests passing?
