### PR TITLE
add Region.run_artifact_path_to_read/write

### DIFF
--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -236,6 +236,10 @@ class ModelFitter:
     def display_name(self) -> str:
         return self.regional_input.display_name
 
+    @property
+    def region(self) -> pipeline.Region:
+        return self.regional_input.region
+
     def set_inference_parameters(self):
         """
         Setup inference parameters based on data availability and manual

--- a/pyseir/inference/model_plotting.py
+++ b/pyseir/inference/model_plotting.py
@@ -7,11 +7,11 @@ from pyseir.load_data import HospitalizationDataType  # Do we still need this?
 from pyseir.utils import get_run_artifact_path, RunArtifact
 
 
-def plot_fitting_results(result) -> None:
+def plot_fitting_results(result: "pyseir.inference.ModelFitter") -> None:
     """
     Entry point from model_fitter. Generate and save all PySEIR related Figures.
     """
-    output_file = get_run_artifact_path(result.fips, RunArtifact.MLE_FIT_REPORT)
+    output_file = result.region.run_artifact_path_to_write(RunArtifact.MLE_FIT_REPORT)
 
     # Save the mle fitter
     mle_fig = result.mle_model.plot_results()


### PR DESCRIPTION
## This PR

This PR is part of https://trello.com/c/nYgDEl3M/385-ability-to-query-raw-data-by-msa . It fixes a breakage introduced when https://github.com/covid-projections/covid-data-model/pull/625 removed `ModelFitter.fips`.

`Region.run_artifact_path_to_read` and `Region.run_artifact_path_to_write` wrap `get_run_artifact_path` to reduce the amount of code that handles a `fips` and make paths used for input vs output explicit.


