### PR TITLE
Remove unused imports

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -4,3 +4,11 @@
 # is as it pydantic.BaseModel definitely exists.
 ignored-modules=pydantic
 ignore=src
+
+
+[MESSAGES CONTROL]
+disable=all
+
+enable=E,
+       F,
+       unused-import

--- a/.pylintrc
+++ b/.pylintrc
@@ -7,8 +7,11 @@ ignore=src
 
 
 [MESSAGES CONTROL]
+
+# The following options disable all errors and only enable ones we want to track.
 disable=all
 
+# To enable linting for more warnings, add to this list here.
 enable=E,
        F,
        unused-import

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ unittest:
 	pytest -n 2 test/
 
 lint:
-	pytest --pylint -m pylint --pylint-error-types=EF .
+	pytest --pylint -m pylint --pylint-jobs=2 .
 
 # Run unittests then linting
 test: unittest lint

--- a/cli/api.py
+++ b/cli/api.py
@@ -1,7 +1,6 @@
 import logging
 import pathlib
 import click
-import itertools
 import us
 
 import pydantic

--- a/cli/data.py
+++ b/cli/data.py
@@ -6,11 +6,9 @@ import os
 import json
 
 import click
-import gspread
 
 from libs import google_sheet_helpers, wide_dates_df
 from libs.datasets.combined_datasets import (
-    build_from_sources,
     ALL_TIMESERIES_FEATURE_DEFINITION,
     US_STATES_FILTER,
     ALL_FIELDS_FEATURE_DEFINITION,
@@ -22,7 +20,6 @@ from libs.datasets.timeseries import TimeseriesDataset
 from libs.datasets import dataset_utils
 from libs.datasets import combined_dataset_utils
 from libs.datasets import combined_datasets
-from libs.datasets.combined_dataset_utils import DatasetType
 from libs.datasets.dataset_utils import AggregationLevel
 from pyseir import DATA_DIR
 import pyseir.icu.utils

--- a/libs/build_params.py
+++ b/libs/build_params.py
@@ -3,7 +3,8 @@ Constants to use for a build. In a separate file to avoid
 auto-importing a dataset when we don't necessarily need to.
 """
 
-from datetime import datetime, timedelta, date
+from datetime import datetime
+from datetime import timedelta
 
 
 def get_interventions(start_date=datetime.now().date()):

--- a/libs/datasets/combined_dataset_utils.py
+++ b/libs/datasets/combined_dataset_utils.py
@@ -1,26 +1,15 @@
-from typing import Type, Tuple
-import os
-import tempfile
+from typing import Tuple
 import pathlib
-import functools
 import datetime
-import enum
-from urllib.parse import urlparse
 
 import structlog
-import numpy as np
-import pandas as pd
-import pydantic
-from covidactnow.datapublic import common_df
 
 from libs.datasets import dataset_base
-from libs.datasets import combined_datasets
 from libs.datasets import timeseries
 from libs.datasets import latest_values_dataset
 from libs.datasets import dataset_utils
 from libs.datasets.dataset_utils import DatasetType
 from libs.datasets.dataset_pointer import DatasetPointer
-from libs.datasets import dataset_pointer
 from libs.github_utils import GitSummary
 
 _logger = structlog.getLogger(__name__)

--- a/libs/datasets/data_version.py
+++ b/libs/datasets/data_version.py
@@ -1,5 +1,4 @@
 import click
-import dataclasses
 from contextlib import contextmanager
 from datetime import datetime
 import git

--- a/libs/datasets/dataset_base.py
+++ b/libs/datasets/dataset_base.py
@@ -1,4 +1,4 @@
-from typing import List, Union, TextIO, Mapping, Iterable, Optional
+from typing import List, Union, TextIO, Iterable, Optional
 import pathlib
 
 import structlog

--- a/libs/datasets/dataset_filter.py
+++ b/libs/datasets/dataset_filter.py
@@ -1,11 +1,8 @@
-from typing import Union, List
+from typing import List
 
 from pydantic.dataclasses import dataclass
 
 from libs.datasets.dataset_base import DatasetBase
-from libs.datasets.dataset_utils import AggregationLevel
-from libs.datasets.timeseries import TimeseriesDataset
-from libs.datasets.latest_values_dataset import LatestValuesDataset
 
 
 @dataclass

--- a/libs/datasets/dataset_pointer.py
+++ b/libs/datasets/dataset_pointer.py
@@ -1,10 +1,7 @@
-from typing import Type, Tuple
-import os
 import io
 import pathlib
 import datetime
 
-import git
 import structlog
 import pydantic
 

--- a/libs/datasets/latest_values_dataset.py
+++ b/libs/datasets/latest_values_dataset.py
@@ -1,13 +1,10 @@
-from typing import Type, List, Optional, Iterable, Union, TextIO
+from typing import List, Optional, Union, TextIO
 import pathlib
 
-import structlog
 from more_itertools import first
 
-from covidactnow.datapublic import common_df
 from libs import us_state_abbrev
 import pandas as pd
-import numpy as np
 from libs.datasets.dataset_utils import AggregationLevel, make_binary_array
 from libs.datasets import dataset_utils
 from libs.datasets import custom_aggregations

--- a/libs/datasets/sources/cds_dataset.py
+++ b/libs/datasets/sources/cds_dataset.py
@@ -1,5 +1,4 @@
 import logging
-import numpy
 import pandas as pd
 
 from covidactnow.datapublic import common_df
@@ -7,8 +6,6 @@ from covidactnow.datapublic.common_fields import CommonFields
 from libs.datasets import data_source
 from libs.datasets import dataset_utils
 from libs.datasets.timeseries import TimeseriesDataset
-from libs.us_state_abbrev import US_STATE_ABBREV
-from libs.datasets.common_fields import CommonIndexFields
 
 _logger = logging.getLogger(__name__)
 

--- a/libs/datasets/sources/fips_population.py
+++ b/libs/datasets/sources/fips_population.py
@@ -5,7 +5,6 @@ from covidactnow.datapublic.common_fields import CommonFields
 from libs.datasets import dataset_utils
 from libs.datasets import data_source
 from libs.us_state_abbrev import US_STATE_ABBREV, ABBREV_US_FIPS, ABBREV_US_UNKNOWN_COUNTY_FIPS
-from libs import enums
 from libs.datasets.dataset_utils import AggregationLevel
 from libs.datasets.common_fields import CommonIndexFields
 

--- a/libs/datasets/sources/kinsa.py
+++ b/libs/datasets/sources/kinsa.py
@@ -1,7 +1,6 @@
 import pandas as pd
 from libs.datasets import data_source
-from libs.datasets import dataset_utils
-from libs.datasets.common_fields import CommonFields, CommonIndexFields
+from libs.datasets.common_fields import CommonIndexFields
 import requests
 import structlog
 import us
@@ -11,7 +10,7 @@ log = structlog.get_logger()
 
 class KinsaDataset(data_source.DataSource):
     """
-    Wrapper class for accessing kinsa data via their api. 
+    Wrapper class for accessing kinsa data via their api.
     Data is not included in covid-data-public right now and is accessed directly from the kinsa API.
 
     """

--- a/libs/datasets/sources/nytimes_dataset.py
+++ b/libs/datasets/sources/nytimes_dataset.py
@@ -1,8 +1,5 @@
-import pandas as pd
-
 from covidactnow.datapublic import common_df
 from covidactnow.datapublic.common_fields import CommonFields
-from libs import enums
 from libs.datasets import data_source
 from libs.datasets import dataset_utils
 

--- a/libs/datasets/sources/texas_hospitalizations.py
+++ b/libs/datasets/sources/texas_hospitalizations.py
@@ -1,5 +1,3 @@
-import pandas as pd
-
 from covidactnow.datapublic.common_fields import CommonFields
 from covidactnow.datapublic import common_df
 from libs.datasets import data_source

--- a/libs/functions/generate_api.py
+++ b/libs/functions/generate_api.py
@@ -1,7 +1,5 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Optional
-
-import pandas as pd
 
 from api.can_api_definition import (
     Actuals,
@@ -9,7 +7,6 @@ from api.can_api_definition import (
     AggregateFlattenedTimeseries,
     AggregateRegionSummary,
     Metrics,
-    MetricsTimeseriesRow,
     PredictionTimeseriesRow,
     PredictionTimeseriesRowWithHeader,
     Projections,
@@ -20,12 +17,10 @@ from api.can_api_definition import (
 from covidactnow.datapublic.common_fields import CommonFields
 from libs import us_state_abbrev
 from libs.datasets import can_model_output_schema as can_schema
-from libs.datasets.latest_values_dataset import LatestValuesDataset
 from libs.datasets.sources.can_pyseir_location_output import CANPyseirLocationOutput
 from libs.datasets.timeseries import TimeseriesDataset
 from libs.enums import Intervention
 from libs.functions import get_can_projection
-from libs.top_level_metrics import calculate_top_level_metrics_for_timeseries
 
 
 def _generate_api_for_projections(model_output: CANPyseirLocationOutput):

--- a/libs/functions/get_can_projection.py
+++ b/libs/functions/get_can_projection.py
@@ -1,11 +1,5 @@
-import os
-import json
 import requests
-import pandas as pd
 from libs.enums import Intervention
-from libs.datasets.dataset_utils import AggregationLevel
-from libs.datasets import CovidCareMapBeds
-from libs.datasets.can_model_output_schema import CAN_MODEL_OUTPUT_SCHEMA
 import functools
 
 

--- a/libs/git_lfs_object_helpers.py
+++ b/libs/git_lfs_object_helpers.py
@@ -7,7 +7,6 @@ Provides a surface for easy loading of previous versions of Git LFS data.
 from typing import Optional
 import datetime
 import subprocess
-import re
 import pathlib
 import structlog
 import git

--- a/libs/pipeline.py
+++ b/libs/pipeline.py
@@ -3,12 +3,10 @@ Code that is used to help move information around in the pipeline, starting with
 represents a geographical area (state, county, metro area, etc).
 """
 
-
+from typing import Optional, Mapping, Any
 import json
 import os
 from dataclasses import dataclass
-from datetime import datetime
-from typing import Optional, Mapping, List, Any
 
 import pandas as pd
 import structlog
@@ -16,8 +14,6 @@ import structlog
 import pyseir
 from covidactnow.datapublic.common_fields import CommonFields
 from libs.datasets import combined_datasets
-from pyseir import load_data
-from pyseir.load_data import HospitalizationCategory
 from pyseir.rt.utils import NEW_ORLEANS_FIPS
 from pyseir.utils import RunArtifact
 

--- a/libs/pipelines/api_pipeline.py
+++ b/libs/pipelines/api_pipeline.py
@@ -1,27 +1,19 @@
+from typing import Iterator, List, Optional
 import functools
-import logging
 import multiprocessing
 import pathlib
-from collections import namedtuple
-from typing import Iterator, List, Optional, Tuple
 
 import pydantic
-import simplejson
 import structlog
 
 from api.can_api_definition import (
-    AggregateFlattenedTimeseries,
     AggregateRegionSummary,
     AggregateRegionSummaryWithTimeseries,
     MetricsTimeseriesRow,
-    PredictionTimeseriesRowWithHeader,
-    RegionSummary,
     RegionSummaryWithTimeseries,
 )
 from libs import dataset_deployer
-from libs.datasets import CommonFields, combined_datasets
-from libs.datasets import results_schema as rc
-from libs.datasets.dataset_utils import AggregationLevel
+from libs.datasets import CommonFields
 from libs.datasets.latest_values_dataset import LatestValuesDataset
 from libs.datasets.sources.can_pyseir_location_output import CANPyseirLocationOutput
 from libs.datasets.timeseries import TimeseriesDataset
@@ -29,7 +21,6 @@ from libs.enums import Intervention
 from libs.functions import generate_api as api
 from libs.functions import get_can_projection
 from libs.top_level_metrics import calculate_top_level_metrics_for_timeseries
-from libs.us_state_abbrev import US_STATE_ABBREV
 
 logger = structlog.getLogger()
 PROD_BUCKET = "data.covidactnow.org"

--- a/libs/qa/comparitor.py
+++ b/libs/qa/comparitor.py
@@ -1,5 +1,3 @@
-import csv
-import requests
 from datetime import datetime, timedelta
 from sentry_sdk import capture_event
 
@@ -74,10 +72,10 @@ class Comparitor(object):
                     "actualTimeseries": {'population': None, 'intervention': 'STRONG_INTERVENTION', 'cumulativeConfirmedCases': 2, 'cumulativePositiveTests': None, 'cumulativeNegativeTests': None, 'cumulativeDeaths': None, 'hospitalBeds': {'capacity': None, 'totalCapacity': None, 'currentUsageCovid': None, 'currentUsageTotal': None, 'typicalUsageRate': None
                     }, 'ICUBeds': {'capacity': None, 'totalCapacity': None, 'currentUsageCovid': None, 'currentUsageTotal': None, 'typicalUsageRate': None
                     }, 'date': '2020-01-26'
-                    }, 
+                    },
                     ...
                     "timeseries": {...}
-                }, 
+                },
                 286: {},
             }}
         """

--- a/libs/series_utils.py
+++ b/libs/series_utils.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 import pandas as pd
 import numpy as np
 

--- a/libs/top_level_metrics.py
+++ b/libs/top_level_metrics.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pandas as pd
 from covidactnow.datapublic.common_fields import CommonFields
 from libs.datasets import combined_datasets

--- a/libs/top_level_metrics.py
+++ b/libs/top_level_metrics.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pandas as pd
-from datetime import timedelta
 from covidactnow.datapublic.common_fields import CommonFields
 from libs.datasets import combined_datasets
 from libs.datasets.timeseries import TimeseriesDataset

--- a/libs/update_readme_schemas.py
+++ b/libs/update_readme_schemas.py
@@ -1,7 +1,5 @@
 from typing import Dict
 import tabulate
-import pydantic
-import api
 import pathlib
 
 

--- a/libs/us_state_abbrev.py
+++ b/libs/us_state_abbrev.py
@@ -9,8 +9,6 @@
 # Roger Allen has waived all copyright and related or neighboring
 # rights to this code.
 
-import us
-
 US_STATE_ABBREV = {
     "Alabama": "AL",
     "Alaska": "AK",

--- a/pyseir/cli.py
+++ b/pyseir/cli.py
@@ -16,7 +16,6 @@ from pyseir.ensembles import ensemble_runner
 from pyseir.inference import model_fitter
 from pyseir.deployment.webui_data_adaptor_v1 import WebUIDataAdaptorV1
 from libs.datasets import combined_datasets
-from libs.us_state_abbrev import ABBREV_US_STATE
 from pyseir.inference.whitelist_generator import WhitelistGenerator
 
 

--- a/pyseir/inference/model_plotting.py
+++ b/pyseir/inference/model_plotting.py
@@ -4,7 +4,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from pyseir.load_data import HospitalizationDataType  # Do we still need this?
-from pyseir.utils import get_run_artifact_path, RunArtifact
+from pyseir.utils import RunArtifact
 
 
 def plot_fitting_results(result: "pyseir.inference.ModelFitter") -> None:

--- a/pyseir/load_data.py
+++ b/pyseir/load_data.py
@@ -17,7 +17,6 @@ import numpy as np
 from covidactnow.datapublic.common_fields import CommonFields
 from libs.datasets import combined_datasets
 from libs.datasets.timeseries import TimeseriesDataset
-from libs.datasets.dataset_utils import AggregationLevel
 import pyseir.utils
 
 # from pyseir.utils import get_run_artifact_path, RunArtifact, ewma_smoothing
@@ -257,7 +256,7 @@ def load_hospitalization_data(
         relative_days = (hospitalization_data["date"].dt.date - t0.date()).dt.days.values
         cumulative = hospitalization_data[f"cumulative_{category}"].values.clip(min=0)
         # Some minor glitches for a few states..
-        for i, val in enumerate(cumulative[1:]):
+        for i in range(cumulative[1:]):
             if cumulative[i] > cumulative[i + 1]:
                 cumulative[i] = cumulative[i + 1]
         return relative_days, cumulative, HospitalizationDataType.CUMULATIVE_HOSPITALIZATIONS

--- a/pyseir/models/suppression_policies.py
+++ b/pyseir/models/suppression_policies.py
@@ -3,10 +3,8 @@ import pandas as pd
 import numpy as np
 from scipy.interpolate import interp1d
 from libs.datasets import combined_datasets
-from libs import us_state_abbrev
 from pyseir import load_data
 from pyseir.inference.infer_t0 import infer_t0
-from pyseir.inference import fit_results
 
 
 # Fig 4 of Imperial college.

--- a/pyseir/optimization/policy_optimizer.py
+++ b/pyseir/optimization/policy_optimizer.py
@@ -1,5 +1,5 @@
 import matplotlib.pyplot as plt
-from scipy.optimize import minimize, dual_annealing, basinhopping, differential_evolution
+from scipy.optimize import minimize
 
 
 class PolicyOptimizer:

--- a/pyseir/parameters/parameter_ensemble_generator.py
+++ b/pyseir/parameters/parameter_ensemble_generator.py
@@ -1,12 +1,7 @@
 import numpy as np
 import pandas as pd
-import us
 
 from covidactnow.datapublic.common_fields import CommonFields
-from libs import pipeline
-from pyseir import load_data
-from libs.datasets import combined_datasets
-from libs.datasets.dataset_utils import AggregationLevel
 
 
 class ParameterEnsembleGenerator:

--- a/pyseir/rt/utils.py
+++ b/pyseir/rt/utils.py
@@ -1,16 +1,8 @@
 import logging
-import os
-from typing import Optional
-
 import numpy as np
-import pandas as pd
 from scipy import signal
 
 from pyseir.rt.constants import InferRtConstants
-import pyseir.utils
-import pyseir.rt.patches
-
-# from pyseir.utils import get_run_artifact_path, RunArtifact
 
 utils_log = logging.getLogger(__name__)
 

--- a/pyseir/utils.py
+++ b/pyseir/utils.py
@@ -6,9 +6,8 @@ from scipy import signal
 from covidactnow.datapublic.common_fields import CommonFields
 
 from pyseir import OUTPUT_DIR
-from pyseir import load_data
-from libs.datasets.dataset_utils import AggregationLevel
 from libs.datasets import combined_datasets
+from libs.datasets.dataset_utils import AggregationLevel
 
 REPORTS_FOLDER = lambda output_dir, state_name: os.path.join(
     output_dir, "pyseir", state_name, "reports"

--- a/raw_data_QA/check_raw_case_death_data.py
+++ b/raw_data_QA/check_raw_case_death_data.py
@@ -1,13 +1,17 @@
 import logging
 import tempfile
-import json
 import pandas as pd
 import matplotlib.pyplot as plt
 import numpy as np
 from sklearn.metrics import mean_squared_error
-from datetime import datetime
-import calendar, argparse, pdb, os, shutil, requests, io, zipfile, shutil, glob, re, subprocess, sentry_sdk
-from subprocess import Popen, PIPE
+import argparse
+import os
+import shutil
+import requests
+import shutil
+import glob
+import subprocess
+import sentry_sdk
 
 _logger = logging.getLogger(__name__)
 

--- a/test/api/test_can_predictions.py
+++ b/test/api/test_can_predictions.py
@@ -1,4 +1,3 @@
-from datetime import date
 from api.can_api_definition import AggregateRegionSummaryWithTimeseries
 
 from libs import dataset_deployer

--- a/test/combined_dataset_test.py
+++ b/test/combined_dataset_test.py
@@ -4,7 +4,6 @@ from itertools import chain
 
 import structlog
 
-from covidactnow.datapublic.common_fields import COMMON_FIELDS_TIMESERIES_KEYS
 from libs.datasets import combined_datasets, CommonFields
 from libs.datasets.combined_datasets import (
     _build_data_and_provenance,

--- a/test/common_df_diff_test.py
+++ b/test/common_df_diff_test.py
@@ -1,6 +1,5 @@
 import pandas as pd
 
-from covidactnow.datapublic.common_test_helpers import to_dict
 from libs.qa.common_df_diff import DatasetDiff
 from covidactnow.datapublic.common_fields import COMMON_FIELDS_TIMESERIES_KEYS
 

--- a/test/infer_rt_test.py
+++ b/test/infer_rt_test.py
@@ -3,11 +3,9 @@ import pathlib
 import pytest
 import pandas as pd
 import structlog
-from matplotlib import pyplot as plt
 
 from pyseir.rt import utils
 from pyseir.rt import infer_rt
-from pyseir.utils import get_run_artifact_path, RunArtifact
 from test.mocks.inference import load_data
 from test.mocks.inference.load_data import RateChange
 

--- a/test/libs/api_pipeline_test.py
+++ b/test/libs/api_pipeline_test.py
@@ -1,16 +1,8 @@
-import datetime
-import pathlib
-import tempfile
-
 import pytest
 
-from api.can_api_definition import Actuals, Projections, RegionSummary, ResourceUsageProjection
 from libs.datasets import combined_datasets
-from libs.datasets.sources.can_pyseir_location_output import CANPyseirLocationOutput
 from libs.enums import Intervention
-from libs.functions import generate_api
 from libs.pipelines import api_pipeline
-from pyseir import cli
 
 NYC_FIPS = "36061"
 

--- a/test/libs/dataset_summary_test.py
+++ b/test/libs/dataset_summary_test.py
@@ -6,7 +6,6 @@ import libs.qa.dataset_summary_gen
 from covidactnow.datapublic.common_fields import CommonFields
 from libs.datasets.sources.covid_county_data import CovidCountyDataDataSource
 from libs.datasets.timeseries import TimeseriesDataset
-from libs.qa import dataset_summary
 from libs.qa.dataset_summary import summarize_timeseries_fields
 
 

--- a/test/libs/datasets/sources/can_pyseir_location_output_test.py
+++ b/test/libs/datasets/sources/can_pyseir_location_output_test.py
@@ -1,5 +1,4 @@
 import datetime
-import pathlib
 import pandas as pd
 import pytest
 from libs.datasets import can_model_output_schema as schema

--- a/test/libs/datasets/sources/covid_county_data_test.py
+++ b/test/libs/datasets/sources/covid_county_data_test.py
@@ -1,14 +1,9 @@
-import datetime
-import pathlib
 import pandas as pd
 import pytest
 
 from covidactnow.datapublic.common_fields import CommonFields
 from covidactnow.datapublic.common_test_helpers import to_dict
-from libs.datasets import can_model_output_schema as schema
-from libs.datasets.sources.can_pyseir_location_output import CANPyseirLocationOutput
 from libs.datasets.sources.covid_county_data import CovidCountyDataDataSource
-from libs.enums import Intervention
 
 
 # turns all warnings into errors for this module

--- a/test/libs/generate_api_test.py
+++ b/test/libs/generate_api_test.py
@@ -1,15 +1,11 @@
 import datetime
-import pathlib
-import tempfile
 
 import pytest
 
 from api.can_api_definition import (
     Actuals,
-    Metrics,
     Projections,
     RegionSummary,
-    RegionSummaryWithTimeseries,
     ResourceUsageProjection,
 )
 from libs.datasets import can_model_output_schema as schema

--- a/test/libs/top_level_metrics_test.py
+++ b/test/libs/top_level_metrics_test.py
@@ -1,5 +1,3 @@
-import unittest
-
 import numpy as np
 import pandas as pd
 

--- a/test/libs/top_level_metrics_test.py
+++ b/test/libs/top_level_metrics_test.py
@@ -1,7 +1,6 @@
 import io
 import numpy as np
 import pandas as pd
-from covidactnow.datapublic import common_df
 from covidactnow.datapublic.common_fields import CommonFields
 from libs import top_level_metrics
 from libs.datasets.timeseries import TimeseriesDataset

--- a/test/mocks/inference/load_data.py
+++ b/test/mocks/inference/load_data.py
@@ -5,7 +5,6 @@ from enum import Enum
 
 import pandas as pd
 
-from pyseir.load_data import HospitalizationDataType
 from pyseir.rt.constants import InferRtConstants
 
 """

--- a/test/pyseir_end_to_end_test.py
+++ b/test/pyseir_end_to_end_test.py
@@ -1,7 +1,4 @@
-import os
 import pathlib
-import json
-import pandas as pd
 from pyseir import cli
 from pyseir.utils import get_run_artifact_path, RunArtifact
 import libs.datasets.can_model_output_schema as schema

--- a/test/timeseries_test.py
+++ b/test/timeseries_test.py
@@ -4,7 +4,6 @@ import structlog
 
 from libs.datasets.combined_datasets import provenance_wide_metrics_to_series
 from libs.datasets.dataset_utils import AggregationLevel
-from libs.datasets.sources import cds_dataset
 from libs.datasets.timeseries import TimeseriesDataset
 from test.dataset_utils_test import to_dict, read_csv_and_index_fips_date
 import pandas as pd


### PR DESCRIPTION
Something that's been bothering me for a while - just adding a lint rule to enforce no unused imports.  

This helps keep files a bit more clean and consistent. It can be misleading to know what dependencies a module actually has if a bunch of the imports aren't being used. 