### PR TITLE
add TimeseriesDataset.get_columns_and_date_subset

### DIFF
--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -148,16 +148,6 @@ def get_us_latest_for_fips(fips) -> dict:
     return us_latest.get_record_for_fips(fips)
 
 
-def _remove_padded_nans(df, columns):
-    if df[columns].isna().all().all():
-        return df.loc[[False] * len(df), :].reset_index(drop=True)
-
-    first_valid_index = min(df[column].first_valid_index() for column in columns)
-    last_valid_index = max(df[column].last_valid_index() for column in columns)
-    df = df.iloc[first_valid_index : last_valid_index + 1]
-    return df.reset_index(drop=True)
-
-
 def get_timeseries_for_fips(
     fips: str, columns: List = None, min_range_with_some_value: bool = False
 ) -> TimeseriesDataset:
@@ -174,14 +164,9 @@ def get_timeseries_for_fips(
 
     state_ts = load_us_timeseries_dataset().get_subset(None, fips=fips)
     if columns:
-        subset = state_ts.data.loc[:, TimeseriesDataset.INDEX_FIELDS + columns].reset_index(
-            drop=True
+        return state_ts.get_columns_and_date_subset(
+            columns, min_range_with_some_value=min_range_with_some_value
         )
-
-        if min_range_with_some_value:
-            subset = _remove_padded_nans(subset, columns)
-
-        state_ts = TimeseriesDataset(subset)
 
     return state_ts
 
@@ -202,14 +187,9 @@ def get_timeseries_for_state(
 
     state_ts = load_us_timeseries_dataset().get_subset(AggregationLevel.STATE, state=state)
     if columns:
-        subset = state_ts.data.loc[:, TimeseriesDataset.INDEX_FIELDS + columns].reset_index(
-            drop=True
+        return state_ts.get_columns_and_date_subset(
+            columns, min_range_with_some_value=min_range_with_some_value
         )
-
-        if min_range_with_some_value:
-            subset = _remove_padded_nans(subset, columns)
-
-        state_ts = TimeseriesDataset(subset)
 
     return state_ts
 

--- a/test/combined_dataset_test.py
+++ b/test/combined_dataset_test.py
@@ -26,7 +26,6 @@ from libs.datasets import NevadaHospitalAssociationData
 from libs.datasets.dataset_utils import AggregationLevel
 from libs.datasets.timeseries import TimeseriesDataset
 from test.dataset_utils_test import read_csv_and_index_fips, read_csv_and_index_fips_date, to_dict
-import pandas as pd
 import numpy as np
 import pytest
 

--- a/test/combined_dataset_test.py
+++ b/test/combined_dataset_test.py
@@ -134,27 +134,6 @@ def test_expected_field_in_sources(data_source_cls):
         assert len(good_state) >= 48
 
 
-@pytest.mark.parametrize("include_na_at_end", [False, True])
-def test_remove_padded_nans(include_na_at_end):
-    rows = [
-        {"date": "2020-02-01", "cases": pd.NA},
-        {"date": "2020-02-02", "cases": pd.NA},
-        {"date": "2020-02-03", "cases": 1},
-        {"date": "2020-02-04", "cases": pd.NA},
-        {"date": "2020-02-05", "cases": 2},
-        {"date": "2020-02-06", "cases": 3},
-    ]
-    if include_na_at_end:
-        rows += [{"date": "2020-02-07", "cases": pd.NA}]
-
-    df = pd.DataFrame(rows)
-
-    results = combined_datasets._remove_padded_nans(df, ["cases"])
-    expected_series = pd.Series([1, pd.NA, 2, 3], name="cases")
-
-    pd.testing.assert_series_equal(results.cases, expected_series)
-
-
 def test_build_timeseries():
     data_a = read_csv_and_index_fips_date(
         "county,state,fips,country,aggregate_level,date,cases\n"

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -1,0 +1,25 @@
+import pytest
+import pandas as pd
+
+from libs.datasets import timeseries
+
+
+@pytest.mark.parametrize("include_na_at_end", [False, True])
+def test_remove_padded_nans(include_na_at_end):
+    rows = [
+        {"date": "2020-02-01", "cases": pd.NA},
+        {"date": "2020-02-02", "cases": pd.NA},
+        {"date": "2020-02-03", "cases": 1},
+        {"date": "2020-02-04", "cases": pd.NA},
+        {"date": "2020-02-05", "cases": 2},
+        {"date": "2020-02-06", "cases": 3},
+    ]
+    if include_na_at_end:
+        rows += [{"date": "2020-02-07", "cases": pd.NA}]
+
+    df = pd.DataFrame(rows)
+
+    results = timeseries._remove_padded_nans(df, ["cases"])
+    expected_series = pd.Series([1, pd.NA, 2, 3], name="cases")
+
+    pd.testing.assert_series_equal(results.cases, expected_series)


### PR DESCRIPTION
This PR is part of https://trello.com/c/nYgDEl3M/385-ability-to-query-raw-data-by-msa

This PR moves combined_datasets.get_timeseries_for_fips columns and min_range_with_some_value logic to TimeseriesDataset.get_columns_and_date_subset so it can be run on data not read with combined_datasets
