### PR TITLE
Switching github action black formatter to a version that pins black …

### DIFF
--- a/.github/workflows/python_unit_tests.yml
+++ b/.github/workflows/python_unit_tests.yml
@@ -10,9 +10,13 @@ jobs:
     - name: Checkout covid-data-model
       uses: actions/checkout@v2
     - name: Run Black
-      uses: lgeiger/black-action@v1.0.1
+      uses: RojerGS/python-black-check@1.0.1
       with:
-        args: '. --check'
+        # This black github action specifies a default line-length instead of
+        # relying on the pyproject.toml file.  If you're suddenly getting a lot
+        # of black errors, maybe the line-length changed in pyproject.toml and
+        # the below value is out of date?
+        line-length: '100'
 
   build:
     env:


### PR DESCRIPTION
…version

The latest version of black causes a bunch of changes (that I'm not totally sure are correct).  This github action uses a pinned version of black so won't break going forward