### PR TITLE
Switching to use a datetime index to make passing around data more lightweight

### DIFF
--- a/libs/top_level_metrics.py
+++ b/libs/top_level_metrics.py
@@ -53,7 +53,7 @@ def calculate_metrics_for_timeseries(
     fips = latest[CommonFields.FIPS]
     population = latest[CommonFields.POPULATION]
 
-    data = timeseries.data
+    data = timeseries.data.set_index(CommonFields.DATE)
 
     infection_rate = np.nan
     infection_rate_ci90 = np.nan
@@ -66,22 +66,17 @@ def calculate_metrics_for_timeseries(
 
         # Only merging date up to the most recent timeseries date (model data includes
         # future projections for other values and we don't want to pad the end with NaNs).
-        up_to_latest_day = model_output.data[CommonFields.DATE] <= data[CommonFields.DATE].max()
+        up_to_latest_day = model_output.data[schema.DATE] <= data.index.max()
         fields_to_include = [
             schema.DATE,
-            schema.FIPS,
             schema.RT_INDICATOR,
             schema.RT_INDICATOR_CI90,
         ]
         model_data = model_output.data.loc[up_to_latest_day, fields_to_include]
-        data = data.merge(
-            model_data,
-            left_on=[CommonFields.DATE, CommonFields.FIPS],
-            right_on=[schema.DATE, schema.FIPS],
-            how="outer",
-        )
-        infection_rate = data[schema.RT_INDICATOR]
-        infection_rate_ci90 = data[schema.RT_INDICATOR_CI90]
+        model_data = model_data.set_index(schema.DATE)
+
+        infection_rate = model_data[schema.RT_INDICATOR]
+        infection_rate_ci90 = model_data[schema.RT_INDICATOR_CI90]
 
     cumulative_cases = series_utils.interpolate_stalled_values(data[CommonFields.CASES])
     case_density = calculate_case_density(cumulative_cases, population)
@@ -99,7 +94,6 @@ def calculate_metrics_for_timeseries(
         cumulative_cases, data[CommonFields.CONTACT_TRACERS_COUNT]
     )
     top_level_metrics_data = {
-        CommonFields.DATE: data[CommonFields.DATE],
         CommonFields.FIPS: fips,
         MetricsFields.CASE_DENSITY_RATIO: case_density,
         MetricsFields.TEST_POSITIVITY: test_positivity,
@@ -107,9 +101,8 @@ def calculate_metrics_for_timeseries(
         MetricsFields.INFECTION_RATE: infection_rate,
         MetricsFields.INFECTION_RATE_CI90: infection_rate_ci90,
     }
-    metrics = pd.DataFrame(top_level_metrics_data, index=test_positivity.index)
-
-    return metrics.reset_index(drop=True)
+    metrics = pd.DataFrame(top_level_metrics_data)
+    return metrics.reset_index()
 
 
 def calculate_case_density(

--- a/test/libs/series_utils_test.py
+++ b/test/libs/series_utils_test.py
@@ -3,57 +3,62 @@ import numpy as np
 from libs import series_utils
 
 
+def _series_with_date_index(data, date: str = "2020-08-25", **series_kwargs):
+    date_series = pd.date_range(date, periods=len(data), freq="D")
+    return pd.Series(data, index=date_series, **series_kwargs)
+
+
 def test_sliding_window():
     """
     It should average within sliding window.
     """
-    series = pd.Series([1, 2, 4, 5, 0])
+    series = _series_with_date_index([1, 2, 4, 5, 0])
     smoothed = series_utils.smooth_with_rolling_average(series=series, window=2)
-    pd.testing.assert_series_equal(smoothed, pd.Series([1, 1.5, 3, 4.5, 2.5]))
+    pd.testing.assert_series_equal(smoothed, _series_with_date_index([1, 1.5, 3, 4.5, 2.5]))
 
 
 def test_window_exceeds_series():
     """
     It should not average the first value.
     """
-    series = pd.Series([1, 2])
+    series = _series_with_date_index([1, 2])
     smoothed = series_utils.smooth_with_rolling_average(series=series, window=5)
-    pd.testing.assert_series_equal(smoothed, pd.Series([1, 1.5]))
+    pd.testing.assert_series_equal(smoothed, _series_with_date_index([1, 1.5]))
 
 
 def test_exclude_trailing_zeroes():
     """
     It should not average the first value.
     """
-    series = pd.Series([1, 2, 4, 5, 0])
+    series = _series_with_date_index([1, 2, 4, 5, 0])
     smoothed = series_utils.smooth_with_rolling_average(
         series=series, window=2, include_trailing_zeros=False
     )
-    pd.testing.assert_series_equal(smoothed, pd.Series([1, 1.5, 3, 4.5, np.nan]))
+    pd.testing.assert_series_equal(smoothed, _series_with_date_index([1, 1.5, 3, 4.5, np.nan]))
 
 
 def test_interpolation():
 
-    series = pd.Series([np.nan, 1, 2, 2, 4])
+    series = _series_with_date_index([np.nan, 1, 2, 2, 4])
 
     results = series_utils.interpolate_stalled_values(series)
-    expected = pd.Series([np.nan, 1, 2, 3, 4])
+    expected = _series_with_date_index([np.nan, 1, 2, 3, 4])
     pd.testing.assert_series_equal(results, expected)
 
 
 def test_interpolation_bounds():
 
-    series = pd.Series([np.nan, 1, 2, 2, 4, np.nan])
+    series = _series_with_date_index([np.nan, 1, 2, 2, 4, np.nan])
 
     results = series_utils.interpolate_stalled_values(series)
-    expected = pd.Series([np.nan, 1, 2, 3, 4, np.nan])
+    expected = _series_with_date_index([np.nan, 1, 2, 3, 4, np.nan])
     pd.testing.assert_series_equal(results, expected)
 
 
 def test_interpolation_missing_index():
-
-    series = pd.Series([np.nan, 1, 2, 2, 5], index=[0, 1, 2, 3, 5])
+    index = pd.date_range("2020-08-25", periods=6).drop([pd.Timestamp("2020-08-29")])
+    series = pd.Series([np.nan, 1, 2, 2, 5], index=index)
 
     results = series_utils.interpolate_stalled_values(series)
-    expected = pd.Series([np.nan, 1, 2, 3, 5], index=[0, 1, 2, 3, 5])
+    expected = pd.Series([np.nan, 1, 2, 3, 5], index=index)
     pd.testing.assert_series_equal(results, expected)


### PR DESCRIPTION
Wanted to get this in to make some of the testing easier/make it easier to pass around individual series rather than dataframes