### PR TITLE
Setting the index to always be named date in top level metrics

### DIFF
--- a/libs/top_level_metrics.py
+++ b/libs/top_level_metrics.py
@@ -102,6 +102,7 @@ def calculate_metrics_for_timeseries(
         MetricsFields.INFECTION_RATE_CI90: infection_rate_ci90,
     }
     metrics = pd.DataFrame(top_level_metrics_data)
+    metrics.index.name = CommonFields.DATE
     return metrics.reset_index()
 
 
@@ -148,6 +149,7 @@ def calculate_test_positivity(
 
     if any(last_n_positive) and last_n_negative.isna().all():
         return pd.Series([], dtype="float64")
+
     return positive_smoothed / (negative_smoothed + positive_smoothed)
 
 

--- a/test/libs/api_pipeline_test.py
+++ b/test/libs/api_pipeline_test.py
@@ -67,6 +67,3 @@ def test_build_api_output_for_intervention(nyc_fips, nyc_model_output_path, tmp_
         str(path.relative_to(tmp_path)) for path in tmp_path.glob("**/*") if not path.is_dir()
     ]
     assert sorted(output_paths) == sorted(expected_outputs)
-
-
-# def test_generate_metrics_and_latest_for_fips():

--- a/test/libs/top_level_metrics_test.py
+++ b/test/libs/top_level_metrics_test.py
@@ -100,6 +100,30 @@ def test_top_level_metrics_basic():
     pd.testing.assert_frame_equal(expected, results)
 
 
+def test_top_level_metrics_no_test_positivity():
+    data = io.StringIO(
+        "date,fips,cases,positive_tests,negative_tests,contact_tracers_count\n"
+        "2020-08-17,36,10,,,1\n"
+        "2020-08-18,36,20,,,2\n"
+        "2020-08-19,36,30,,,3\n"
+        "2020-08-20,36,40,,,4\n"
+    )
+    timeseries = TimeseriesDataset.load_csv(data)
+    latest = {
+        CommonFields.POPULATION: 100_000,
+        CommonFields.FIPS: "36",
+    }
+    results = top_level_metrics.calculate_metrics_for_timeseries(timeseries, latest, None)
+
+    expected = _build_metrics_df(
+        "2020-08-17,36,,,,,\n"
+        "2020-08-18,36,10,,0.04,,\n"
+        "2020-08-19,36,10,,0.06,,\n"
+        "2020-08-20,36,10,,0.08,,\n"
+    )
+    pd.testing.assert_frame_equal(expected, results)
+
+
 def test_top_level_metrics_with_rt():
     data = io.StringIO(
         "date,fips,cases,positive_tests,negative_tests,contact_tracers_count\n"


### PR DESCRIPTION
caused this:

https://sentry.io/organizations/covidactnow/issues/1861469979/?project=5203044&query=is%3Aunresolved
