### PR TITLE
rm RunMode

### DIFF
--- a/pyseir/cli.py
+++ b/pyseir/cli.py
@@ -162,8 +162,7 @@ def _build_all_for_states(
         ensemble_inputs = [
             ensemble_runner.RegionalInput.from_model_fitter(f) for f in county_fitters
         ]
-        ensemble_func = ensemble_runner
-        p.map(ensemble_func, ensemble_inputs)
+        p.map(ensemble_runner.run_region, ensemble_inputs)
 
     # output it all
     output_interval_days = int(output_interval_days)

--- a/pyseir/cli.py
+++ b/pyseir/cli.py
@@ -28,7 +28,6 @@ sys.path.insert(0, os.path.join(os.path.abspath(os.path.dirname(__file__)), ".."
 
 root = logging.getLogger()
 
-DEFAULT_RUN_MODE = "can-inference-derived"
 ALL_STATES: List[str] = [state_obj.abbr for state_obj in us.STATES] + ["PR"]
 
 
@@ -75,20 +74,19 @@ def _states_region_list(state: Optional[str], default: List[str]) -> List[pipeli
 
 
 def _state_only_pipeline(
-    region: pipeline.Region, run_mode=DEFAULT_RUN_MODE, output_interval_days=1, output_dir=None,
+    region: pipeline.Region, output_interval_days=1, output_dir=None,
 ) -> model_fitter.ModelFitter:
     assert region.is_state()
 
     infer_rt.run_rt(infer_rt.RegionalInput.from_region(region))
     fitter = model_fitter.run_state(region)
     ensembles_input = ensemble_runner.RegionalInput.from_model_fitter(fitter)
-    ensemble_runner.run_region(ensembles_input, ensemble_kwargs={"run_mode": run_mode})
+    ensemble_runner.run_region(ensembles_input)
     return fitter
 
 
 def _build_all_for_states(
     states: List[str],
-    run_mode=DEFAULT_RUN_MODE,
     output_interval_days=4,
     output_dir=None,
     skip_whitelist=False,
@@ -101,10 +99,7 @@ def _build_all_for_states(
     # do everything for just states in parallel
     with Pool(maxtasksperchild=1) as p:
         states_only_func = partial(
-            _state_only_pipeline,
-            run_mode=run_mode,
-            output_interval_days=output_interval_days,
-            output_dir=output_dir,
+            _state_only_pipeline, output_interval_days=output_interval_days, output_dir=output_dir,
         )
         states_regions = [pipeline.Region.from_state(s) for s in states]
         state_fitters: List[model_fitter.ModelFitter] = p.map(states_only_func, states_regions)
@@ -167,9 +162,7 @@ def _build_all_for_states(
         ensemble_inputs = [
             ensemble_runner.RegionalInput.from_model_fitter(f) for f in county_fitters
         ]
-        ensemble_func = partial(
-            ensemble_runner.run_region, ensemble_kwargs=dict(run_mode=run_mode),
-        )
+        ensemble_func = ensemble_runner
         p.map(ensemble_func, ensemble_inputs)
 
     # output it all
@@ -182,7 +175,7 @@ def _build_all_for_states(
     # TODO: Remove intermediate artifacts and paralellize artifacts creation better
     # Approximately 40% of the processing time is taken on this step
     web_ui_mapper = WebUIDataAdaptorV1(
-        output_interval_days=output_interval_days, run_mode=run_mode, output_dir=output_dir,
+        output_interval_days=output_interval_days, output_dir=output_dir,
     )
 
     webui_inputs = [
@@ -235,64 +228,10 @@ def run_mle_fits(state, states_only):
 
 @entry_point.command()
 @click.option(
-    "--state", help="State to generate files for. If no state is given, all states are computed."
-)
-@click.option(
-    "--run-mode",
-    default=DEFAULT_RUN_MODE,
-    type=click.Choice([run_mode.value for run_mode in ensemble_runner.RunMode]),
-    help="State to generate files for. If no state is given, all states are computed.",
-)
-@click.option("--states-only", default=False, is_flag=True, type=bool, help="Only model states")
-def run_ensembles(state, run_mode, states_only):
-    run_region = partial(ensemble_runner.run_region, ensemble_kwargs={"run_mode": run_mode})
-    for region in _states_region_list(state=state, default=ALL_STATES):
-        state_regional_input = ensemble_runner.RegionalInput.from_region(region)
-        run_region(state_regional_input)
-        if not states_only:
-            # Run county level
-            with Pool(maxtasksperchild=1) as p:
-                p.map(run_region, state_regional_input.get_counties_regional_input())
-
-
-@entry_point.command()
-@click.option(
-    "--state", help="State to generate files for. If no state is given, all states are computed."
-)
-@click.option(
-    "--output-interval-days",
-    default=1,
-    type=int,
-    help="Number of days between outputs for the WebUI payload.",
-)
-@click.option(
-    "--run-mode",
-    default=DEFAULT_RUN_MODE,
-    type=click.Choice([run_mode.value for run_mode in ensemble_runner.RunMode]),
-    help="State to generate files for. If no state is given, all states are computed.",
-)
-@click.option("--states-only", default=False, is_flag=True, type=bool, help="Only model states")
-def map_outputs(state, output_interval_days, run_mode, states_only):
-    web_ui_mapper = WebUIDataAdaptorV1(
-        output_interval_days=int(output_interval_days), run_mode=run_mode,
-    )
-    for region in _states_region_list(state=state, default=ALL_STATES):
-        state_input = webui_data_adaptor_v1.RegionalInput.from_region(region)
-        web_ui_mapper.write_region(state_input)
-
-
-@entry_point.command()
-@click.option(
     "--states",
     "-s",
     multiple=True,
     help="a list of states to generate files for. If no state is given, all states are computed.",
-)
-@click.option(
-    "--run-mode",
-    default=DEFAULT_RUN_MODE,
-    type=click.Choice([run_mode.value for run_mode in ensemble_runner.RunMode]),
-    help="State to generate files for. If no state is given, all states are computed.",
 )
 @click.option(
     "--output-interval-days",
@@ -314,7 +253,7 @@ def map_outputs(state, output_interval_days, run_mode, states_only):
 @click.option("--states-only", is_flag=True, help="If set, only runs on states.")
 @click.option("--output-dir", default=None, type=str, help="Directory to deploy webui output.")
 def build_all(
-    states, run_mode, output_interval_days, output_dir, skip_whitelist, states_only, fips,
+    states, output_interval_days, output_dir, skip_whitelist, states_only, fips,
 ):
     # split columns by ',' and remove whitespace
     states = [c.strip() for c in states]
@@ -325,7 +264,6 @@ def build_all(
 
     _build_all_for_states(
         states,
-        run_mode=DEFAULT_RUN_MODE,
         output_interval_days=output_interval_days,
         output_dir=output_dir,
         skip_whitelist=skip_whitelist,

--- a/pyseir/deployment/webui_data_adaptor_v1.py
+++ b/pyseir/deployment/webui_data_adaptor_v1.py
@@ -19,7 +19,7 @@ from pyseir.icu import infer_icu
 from pyseir.inference import model_fitter
 from pyseir.rt.utils import NEW_ORLEANS_FIPS
 from pyseir.rt.utils import NEW_ORLEANS_FIPS
-from pyseir.utils import get_run_artifact_path, RunArtifact, RunMode
+from pyseir.utils import get_run_artifact_path, RunArtifact
 from libs.enums import Intervention
 from libs.datasets import CommonFields
 import libs.datasets.can_model_output_schema as schema
@@ -120,10 +120,9 @@ class WebUIDataAdaptorV1:
     """
 
     def __init__(
-        self, output_interval_days=4, run_mode="can-before", output_dir=None, include_imputed=False,
+        self, output_interval_days=4, output_dir=None, include_imputed=False,
     ):
         self.output_interval_days = output_interval_days
-        self.run_mode = RunMode(run_mode)
         self.include_imputed = include_imputed
         self.output_dir = output_dir
 

--- a/pyseir/ensembles/ensemble_runner.py
+++ b/pyseir/ensembles/ensemble_runner.py
@@ -165,11 +165,11 @@ class EnsembleRunner:
 
         self.suppression_policies = None
         self.override_params = dict()
-        self.init()
+        self.initialize_suppression_policies()
 
         self.all_outputs = {}
 
-    def init(self):
+    def initialize_suppression_policies(self):
         """
         Based on the run mode, generate suppression policies and ensemble
         parameters.  This enables different model combinations and project

--- a/pyseir/ensembles/ensemble_runner.py
+++ b/pyseir/ensembles/ensemble_runner.py
@@ -17,7 +17,7 @@ from pyseir.models import seir_model
 from pyseir.models.seir_model import SEIRModel
 from pyseir.parameters.parameter_ensemble_generator import ParameterEnsembleGenerator
 import pyseir.models.suppression_policies as sp
-from pyseir.utils import RunArtifact, RunMode
+from pyseir.utils import RunArtifact
 from libs.datasets import combined_datasets
 
 
@@ -121,8 +121,6 @@ class EnsembleRunner:
     output_percentiles: list
         List of output percentiles desired. These will be computed for each
         compartment.
-    run_mode: str
-        Individual parameters can be overridden here.
     min_hospitalization_threshold: int
         Require this number of hospitalizations before initializing based on
         observations. Fallback to cases otherwise.
@@ -139,7 +137,6 @@ class EnsembleRunner:
         suppression_policy=(0.35, 0.5, 0.75, 1),
         skip_plots=False,
         output_percentiles=(5, 25, 32, 50, 75, 68, 95),
-        run_mode=RunMode.DEFAULT,
         min_hospitalization_threshold=5,
         hospitalization_to_confirmed_case_ratio=1 / 4,
     ):
@@ -148,7 +145,6 @@ class EnsembleRunner:
 
         self.t_list = np.linspace(0, int(365 * n_years), int(365 * n_years) + 1)
         self.skip_plots = skip_plots
-        self.run_mode = RunMode(run_mode)
         self.hospitalizations_for_state = None
         self.min_hospitalization_threshold = min_hospitalization_threshold
         self.hospitalization_to_confirmed_case_ratio = hospitalization_to_confirmed_case_ratio
@@ -169,11 +165,11 @@ class EnsembleRunner:
 
         self.suppression_policies = None
         self.override_params = dict()
-        self.init_run_mode()
+        self.init()
 
         self.all_outputs = {}
 
-    def init_run_mode(self):
+    def init(self):
         """
         Based on the run mode, generate suppression policies and ensemble
         parameters.  This enables different model combinations and project
@@ -181,31 +177,14 @@ class EnsembleRunner:
         """
         self.suppression_policies = dict()
 
-        if self.run_mode is RunMode.CAN_INFERENCE_DERIVED:
-            self.n_samples = 1
-            for scenario in [
-                "no_intervention",
-                "flatten_the_curve",
-                "inferred",
-                "social_distancing",
-            ]:
-                self.suppression_policies[f"suppression_policy__{scenario}"] = scenario
-
-        elif self.run_mode is RunMode.DEFAULT:
-            for suppression_policy in self.suppression_policy:
-                raise NotImplementedError(
-                    "Oh, this code is used? Ask Tom to add MSA support and a test."
-                )
-                self.suppression_policies[
-                    f"suppression_policy__{suppression_policy}"
-                ] = sp.generate_empirical_distancing_policy(
-                    t_list=self.t_list,
-                    fips=self.regional_input.fips,
-                    future_suppression=suppression_policy,
-                )
-            self.override_params = dict()
-        else:
-            raise ValueError("Invalid run mode.")
+        self.n_samples = 1
+        for scenario in [
+            "no_intervention",
+            "flatten_the_curve",
+            "inferred",
+            "social_distancing",
+        ]:
+            self.suppression_policies[f"suppression_policy__{scenario}"] = scenario
 
     @staticmethod
     def _run_single_simulation(parameter_set):
@@ -297,11 +276,7 @@ class EnsembleRunner:
                 region=self.regional_input.region,
             )
 
-            if self.run_mode is RunMode.CAN_INFERENCE_DERIVED:
-                model_ensemble = [self._load_model_for_region(scenario=suppression_policy)]
-
-            else:
-                raise ValueError(f"Run mode {self.run_mode.value} not supported.")
+            model_ensemble = [self._load_model_for_region(scenario=suppression_policy)]
 
             self.all_outputs[
                 f"{suppression_policy_name}"
@@ -463,7 +438,7 @@ class EnsembleRunner:
         return outputs
 
 
-def run_region(regional_input: RegionalInput, ensemble_kwargs):
+def run_region(regional_input: RegionalInput):
     """
     Run the EnsembleRunner for each county in a state.
 
@@ -471,9 +446,7 @@ def run_region(regional_input: RegionalInput, ensemble_kwargs):
     ----------
     regional_input: RegionalInput
         Region to run against.
-    ensemble_kwargs: dict
-        Kwargs passed to the EnsembleRunner object.
     """
     # Run the state level
-    runner = EnsembleRunner(regional_input=regional_input, **ensemble_kwargs)
+    runner = EnsembleRunner(regional_input=regional_input)
     runner.run_ensemble()

--- a/pyseir/utils.py
+++ b/pyseir/utils.py
@@ -28,13 +28,6 @@ class TimeseriesType(Enum):
     NEW_TESTS = "new_tests"
 
 
-class RunMode(Enum):
-    DEFAULT = "default"
-
-    # Inference based + future suppression policy.
-    CAN_INFERENCE_DERIVED = "can-inference-derived"
-
-
 class RunArtifact(Enum):
     RT_INFERENCE_RESULT = "rt_inference_result"
     RT_INFERENCE_REPORT = "rt_inference_report"


### PR DESCRIPTION
This PR is part of https://trello.com/c/nYgDEl3M/385-ability-to-query-raw-data-by-msa

Removes `RunMode`, no longer used. This change is extracted from https://github.com/covid-projections/covid-data-model/pull/652