### PR TITLE
Fixing JHU failing tests

### DIFF
--- a/libs/datasets/sources/jhu_dataset.py
+++ b/libs/datasets/sources/jhu_dataset.py
@@ -22,7 +22,7 @@ class JHUDataset(data_source.DataSource):
 
     DATA_FOLDER = "data/cases-jhu/csse_covid_19_daily_reports"
     SOURCE_NAME = "JHU"
-    HAS_AGGREGATED_NYC_BOROUGH = True
+    HAS_AGGREGATED_NYC_BOROUGH = False
 
     class Fields(object):
         FIPS = "FIPS"
@@ -59,7 +59,6 @@ class JHUDataset(data_source.DataSource):
     COMMON_FIELD_MAP = {
         CommonFields.CASES: Fields.CONFIRMED,
         CommonFields.DEATHS: Fields.DEATHS,
-        CommonFields.RECOVERED: Fields.RECOVERED,
     }
 
     def __init__(self, input_dir):

--- a/test/combined_dataset_test.py
+++ b/test/combined_dataset_test.py
@@ -18,6 +18,7 @@ from libs.datasets.sources.covid_county_data import CovidCountyDataDataSource
 from libs.datasets.sources.texas_hospitalizations import TexasHospitalizations
 
 from libs.datasets import NYTimesDataset
+from libs.datasets import JHUDataset
 from libs.datasets import CDSDataset
 from libs.datasets import CovidTrackingDataSource
 from libs.datasets import NevadaHospitalAssociationData
@@ -80,9 +81,7 @@ def test_combined_county_has_some_timeseries_data(fips):
 @pytest.mark.parametrize(
     "data_source_cls",
     [
-        # Skipping JHU dataset for now, to be fixed by
-        # https://trello.com/c/86CCmWcR/415-jhu-dataset-failing-combined-dataset-tests
-        # JHUDataset,
+        JHUDataset,
         CDSDataset,
         CovidTrackingDataSource,
         NevadaHospitalAssociationData,
@@ -106,9 +105,7 @@ def test_unique_timeseries(data_source_cls):
 @pytest.mark.parametrize(
     "data_source_cls",
     [
-        # Skipping JHU dataset for now, to be fixed by
-        # https://trello.com/c/86CCmWcR/415-jhu-dataset-failing-combined-dataset-tests
-        # JHUDataset,
+        JHUDataset,
         CDSDataset,
         CovidTrackingDataSource,
         NevadaHospitalAssociationData,


### PR DESCRIPTION
Recovered was still causing a problem because all values are zero.  There's a more elegant approach, but since we don't actually use them, i'm excluding it as a column