### PR TITLE
Revert "Dont skip output if timeseries is empty (#659)"

### DIFF
--- a/libs/us_state_abbrev.py
+++ b/libs/us_state_abbrev.py
@@ -192,14 +192,3 @@ ABBREV_US_UNKNOWN_COUNTY_FIPS = {abbrev: f"{fips}999" for abbrev, fips in ABBREV
 
 # thank you to @kinghelix and @trevormarburger for this idea
 ABBREV_US_STATE = dict(map(reversed, US_STATE_ABBREV.items()))
-
-
-def is_unknown_county(fips: str) -> bool:
-    """Checks if fips is an unknown county.
-
-    Args:
-        fips: fips code to check.
-
-    Returns: True if unkown, false otherwise.
-    """
-    return len(fips) == 5 and fips.endswith("999")

--- a/test/infer_rt_test.py
+++ b/test/infer_rt_test.py
@@ -110,13 +110,13 @@ def test_constant_cases_high_count(tmp_path):
         ratechange2=RateChange(80, 1.5),  # To avoid plotting issues
     )
     rt1, rt2, t_switch, rt = run_individual(
-        "20", data_spec, "test_constant_cases_high_count"  # Kansas
+        "20", data_spec, "test_constant_cases_high_count", output_dir=tmp_path  # Kansas
     )
     check_standard_assertions(rt1, rt2, t_switch, rt)
 
 
 @pytest.mark.slow
-def test_med_scale_strong_growth_and_decay():
+def test_med_scale_strong_growth_and_decay(tmp_path):
     """Track cases growing strongly and then decaying strongly"""
     (rt1, rt2, t_switch, rt) = run_individual(
         "36",  # New York
@@ -128,13 +128,14 @@ def test_med_scale_strong_growth_and_decay():
             ratechange2=RateChange(50, 0.7),
         ),
         "test_med_scale_strong_growth_and_decay",
+        output_dir=tmp_path,
     )
     check_standard_assertions(rt1, rt2, t_switch, rt)
 
 
 @pytest.mark.skip(reason="From Alex: Test is failing rt = .84 instead of rt1")
 @pytest.mark.slow
-def test_low_cases_weak_growth():
+def test_low_cases_weak_growth(tmp_path):
     """Track with low scale (count = 5) and slow growth"""
     (rt1, rt2, t_switch, rt) = run_individual(
         "50",  # Vermont
@@ -146,12 +147,13 @@ def test_low_cases_weak_growth():
             ratechange2=RateChange(70, 1.2),
         ),
         "test_low_cases_weak_growth",
+        output_dir=tmp_path,
     )
     check_standard_assertions(rt1, rt2, t_switch, rt)
 
 
 @pytest.mark.slow
-def test_high_scale_late_growth():
+def test_high_scale_late_growth(tmp_path):
     """Track decaying from high initial count to low number then strong growth"""
     (rt1, rt2, t_switch, rt) = run_individual(
         "02",  # Alaska
@@ -163,12 +165,13 @@ def test_high_scale_late_growth():
             ratechange2=RateChange(70, 1.5),
         ),
         "test_high_scale_late_growth",
+        output_dir=tmp_path,
     )
     check_standard_assertions(rt1, rt2, t_switch, rt)
 
 
 @pytest.mark.slow
-def test_low_scale_two_decays():
+def test_low_scale_two_decays(tmp_path):
     """Track low scale decay at two different rates"""
     (rt1, rt2, t_switch, rt) = run_individual(
         "06",  # California
@@ -180,12 +183,13 @@ def test_low_scale_two_decays():
             ratechange2=RateChange(50, 0.7),
         ),
         "test_low_scale_two_decays",
+        output_dir=tmp_path,
     )
     check_standard_assertions(rt1, rt2, t_switch, rt)
 
 
 @pytest.mark.slow
-def test_smoothing_and_causality():
+def test_smoothing_and_causality(tmp_path):
     run_individual(
         "56",  # Wyoming
         load_data.DataSpec(
@@ -196,6 +200,7 @@ def test_smoothing_and_causality():
             ratechange2=RateChange(95, 5.0),
         ),
         "test_smoothing_and_causality",
+        output_dir=tmp_path,
     )
 
 

--- a/test/infer_rt_test.py
+++ b/test/infer_rt_test.py
@@ -110,13 +110,13 @@ def test_constant_cases_high_count(tmp_path):
         ratechange2=RateChange(80, 1.5),  # To avoid plotting issues
     )
     rt1, rt2, t_switch, rt = run_individual(
-        "20", data_spec, "test_constant_cases_high_count", output_dir=tmp_path  # Kansas
+        "20", data_spec, "test_constant_cases_high_count"  # Kansas
     )
     check_standard_assertions(rt1, rt2, t_switch, rt)
 
 
 @pytest.mark.slow
-def test_med_scale_strong_growth_and_decay(tmp_path):
+def test_med_scale_strong_growth_and_decay():
     """Track cases growing strongly and then decaying strongly"""
     (rt1, rt2, t_switch, rt) = run_individual(
         "36",  # New York
@@ -128,14 +128,13 @@ def test_med_scale_strong_growth_and_decay(tmp_path):
             ratechange2=RateChange(50, 0.7),
         ),
         "test_med_scale_strong_growth_and_decay",
-        output_dir=tmp_path,
     )
     check_standard_assertions(rt1, rt2, t_switch, rt)
 
 
 @pytest.mark.skip(reason="From Alex: Test is failing rt = .84 instead of rt1")
 @pytest.mark.slow
-def test_low_cases_weak_growth(tmp_path):
+def test_low_cases_weak_growth():
     """Track with low scale (count = 5) and slow growth"""
     (rt1, rt2, t_switch, rt) = run_individual(
         "50",  # Vermont
@@ -147,13 +146,12 @@ def test_low_cases_weak_growth(tmp_path):
             ratechange2=RateChange(70, 1.2),
         ),
         "test_low_cases_weak_growth",
-        output_dir=tmp_path,
     )
     check_standard_assertions(rt1, rt2, t_switch, rt)
 
 
 @pytest.mark.slow
-def test_high_scale_late_growth(tmp_path):
+def test_high_scale_late_growth():
     """Track decaying from high initial count to low number then strong growth"""
     (rt1, rt2, t_switch, rt) = run_individual(
         "02",  # Alaska
@@ -165,13 +163,12 @@ def test_high_scale_late_growth(tmp_path):
             ratechange2=RateChange(70, 1.5),
         ),
         "test_high_scale_late_growth",
-        output_dir=tmp_path,
     )
     check_standard_assertions(rt1, rt2, t_switch, rt)
 
 
 @pytest.mark.slow
-def test_low_scale_two_decays(tmp_path):
+def test_low_scale_two_decays():
     """Track low scale decay at two different rates"""
     (rt1, rt2, t_switch, rt) = run_individual(
         "06",  # California
@@ -183,13 +180,12 @@ def test_low_scale_two_decays(tmp_path):
             ratechange2=RateChange(50, 0.7),
         ),
         "test_low_scale_two_decays",
-        output_dir=tmp_path,
     )
     check_standard_assertions(rt1, rt2, t_switch, rt)
 
 
 @pytest.mark.slow
-def test_smoothing_and_causality(tmp_path):
+def test_smoothing_and_causality():
     run_individual(
         "56",  # Wyoming
         load_data.DataSpec(
@@ -200,7 +196,6 @@ def test_smoothing_and_causality(tmp_path):
             ratechange2=RateChange(95, 5.0),
         ),
         "test_smoothing_and_causality",
-        output_dir=tmp_path,
     )
 
 

--- a/test/libs/api_pipeline_test.py
+++ b/test/libs/api_pipeline_test.py
@@ -67,33 +67,3 @@ def test_build_api_output_for_intervention(nyc_fips, nyc_model_output_path, tmp_
         str(path.relative_to(tmp_path)) for path in tmp_path.glob("**/*") if not path.is_dir()
     ]
     assert sorted(output_paths) == sorted(expected_outputs)
-
-
-def test_latest_values_no_unknown_fips(tmp_path):
-    unknown_fips = "69999"
-    us_latest = combined_datasets.load_us_latest_dataset()
-    us_timeseries = combined_datasets.load_us_timeseries_dataset()
-    latest = us_latest.get_subset(fips=unknown_fips)
-    timeseries = us_timeseries.get_subset(fips=unknown_fips)
-    all_timeseries_api = api_pipeline.run_on_all_fips_for_intervention(
-        latest, timeseries, Intervention.OBSERVED_INTERVENTION, tmp_path
-    )
-    assert not all_timeseries_api
-
-
-def test_output_no_timeseries_rows(nyc_fips, tmp_path):
-    us_latest = combined_datasets.load_us_latest_dataset()
-    us_timeseries = combined_datasets.load_us_timeseries_dataset()
-    latest = us_latest.get_subset(fips=nyc_fips)
-    timeseries = us_timeseries.get_subset(fips=nyc_fips)
-
-    # Clearing out all rows, testing that a region with no rows still has an API output.
-    timeseries.data = timeseries.data.loc[timeseries.data.fips.isna()]
-
-    assert timeseries.empty
-
-    all_timeseries_api = api_pipeline.run_on_all_fips_for_intervention(
-        latest, timeseries, Intervention.OBSERVED_INTERVENTION, tmp_path
-    )
-
-    assert all_timeseries_api


### PR DESCRIPTION
This seems to break the update location summaries script on the front end. (it doesn't properly handle the actuals timeseries being empty) I'm going to revert until that is fixed