### PR TITLE
Dont fill NAs with zeros in WebUI output

### DIFF
--- a/api/can_api_definition.py
+++ b/api/can_api_definition.py
@@ -233,7 +233,7 @@ class PredictionTimeseriesRow(base_model.APIBaseModel):
         ...,
         description="Number of hospital beds projected to be in-use or actually in use (if in the past)",
     )
-    ICUBedsInUse: int = pydantic.Field(
+    ICUBedsInUse: Optional[int] = pydantic.Field(
         ...,
         description="Number of ICU beds projected to be in-use or that were actually in use (if in the past)",
     )
@@ -245,8 +245,8 @@ class PredictionTimeseriesRow(base_model.APIBaseModel):
         ..., description="Number of ventilators projected to be in-use."
     )
     ventilatorCapacity: int = pydantic.Field(..., description="Total ventilator capacity.")
-    RtIndicator: float = pydantic.Field(..., description="Historical or Inferred Rt")
-    RtIndicatorCI90: float = pydantic.Field(..., description="Rt standard deviation")
+    RtIndicator: Optional[float] = pydantic.Field(..., description="Historical or Inferred Rt")
+    RtIndicatorCI90: Optional[float] = pydantic.Field(..., description="Rt standard deviation")
     cumulativeDeaths: int = pydantic.Field(..., description="Number of cumulative deaths")
     cumulativeInfected: Optional[int] = pydantic.Field(
         ..., description="Number of cumulative infections"

--- a/libs/datasets/sources/can_pyseir_location_output.py
+++ b/libs/datasets/sources/can_pyseir_location_output.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Iterable
 import pathlib
 import datetime
 
@@ -87,3 +87,9 @@ class CANPyseirLocationOutput(object):
             return None
 
         return self.data.loc[last_idx][schema.RT_INDICATOR_CI90]
+
+    def yield_records(self) -> Iterable[dict]:
+        # It'd be faster to use self.data.itertuples or find a way to avoid yield_records, but that
+        # needs larger changes in code calling this.
+        for idx, row in self.data.iterrows():
+            yield row.where(pd.notnull(row), None).to_dict()

--- a/libs/functions/generate_api.py
+++ b/libs/functions/generate_api.py
@@ -83,7 +83,6 @@ def _generate_actuals(actual_data: dict, intervention: Intervention) -> Actuals:
 
 
 def _generate_prediction_timeseries_row(json_data_row) -> PredictionTimeseriesRow:
-
     return PredictionTimeseriesRow(
         date=json_data_row[can_schema.DATE].to_pydatetime(),
         hospitalBedsRequired=json_data_row[can_schema.ALL_HOSPITALIZED],
@@ -156,8 +155,7 @@ def generate_region_timeseries(
     model_timeseries = []
     if model_output:
         model_timeseries = [
-            _generate_prediction_timeseries_row(row)
-            for row in model_output.data.to_dict(orient="records")
+            _generate_prediction_timeseries_row(row) for row in model_output.yield_records()
         ]
 
     region_summary_data = {key: getattr(region_summary, key) for (key, _) in region_summary}

--- a/libs/icu_headroom_metric.py
+++ b/libs/icu_headroom_metric.py
@@ -147,6 +147,7 @@ class ICUMetricData:
             return self.actual_current_icu_covid, source
 
         source = CovidPatientsMethod.ESTIMATED
+
         return self.estimated_current_icu_covid, source
 
 
@@ -196,6 +197,7 @@ def calculate_icu_utilization_metric(
         return np.nan, None
 
     current_covid_patients, covid_source = icu_data.current_icu_covid_with_source
+
     if current_covid_patients is None:
         return np.nan, None
 

--- a/pyseir/deployment/webui_data_adaptor_v1.py
+++ b/pyseir/deployment/webui_data_adaptor_v1.py
@@ -284,7 +284,6 @@ class WebUIDataAdaptorV1:
                 (output_dates >= datetime(month=3, day=3, year=2020))
                 & (output_dates < datetime.today() + timedelta(days=90))
             ]
-            output_model = output_model.fillna(0)
 
             # Fill in results for the Rt indicator.
             rt_results = regional_input.inferred_infection_rate()
@@ -329,14 +328,16 @@ class WebUIDataAdaptorV1:
                     schema.FIPS,
                 )
             ]
+            # Casing floats to ints and then replacing filled in zeros with NaN values instead of
+            # propagating zeros.
+            na_int_columns = output_model.loc[:, int_columns].isna()
             output_model.loc[:, int_columns] = output_model[int_columns].fillna(0).astype(int)
+            output_model[na_int_columns] = np.nan
             output_model.loc[
                 :, [schema.Rt, schema.Rt_ci90, schema.RT_INDICATOR, schema.RT_INDICATOR_CI90]
             ] = output_model[
                 [schema.Rt, schema.Rt_ci90, schema.RT_INDICATOR, schema.RT_INDICATOR_CI90]
-            ].fillna(
-                0
-            )
+            ]
 
             output_model[schema.FIPS] = regional_input.fips
             intervention = Intervention.from_webui_data_adaptor(suppression_policy)


### PR DESCRIPTION
The origin of this PR is I was seeing zeros for the latest estimated current icu count in the API.  I looked into it, and saw that the estimated icu series (taken from pyseir webui output) has 0s after the icu calc data ended rather than NAs.  We were treating this as a value and reporting that "current icu covid patients" were 0. 

We were filling nan's with 0s, so it was not possible to tell where the estimated icu value ended when computing the top level metrics.  

I feel pretty okay with this - I think we filled with zeros initially because of the weird output format we were writing. this should help us disambiguate between values with 0 and missing values