### PR TITLE
rm unused dateset methods

### DIFF
--- a/cli/data.py
+++ b/cli/data.py
@@ -61,10 +61,10 @@ def update(summary_filename, wide_dates_filename):
         data_source_cls.SOURCE_NAME: data_source_cls.local()
         for data_source_cls in data_source_classes
     }
-    timeseries_dataset = combined_datasets.build_from_sources(
+    timeseries_dataset: TimeseriesDataset = combined_datasets.build_from_sources(
         TimeseriesDataset, data_sources, ALL_TIMESERIES_FEATURE_DEFINITION, filter=US_STATES_FILTER
     )
-    latest_dataset = combined_datasets.build_from_sources(
+    latest_dataset: LatestValuesDataset = combined_datasets.build_from_sources(
         LatestValuesDataset, data_sources, ALL_FIELDS_FEATURE_DEFINITION, filter=US_STATES_FILTER,
     )
     _, timeseries_pointer = combined_dataset_utils.update_data_public_head(

--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -147,27 +147,17 @@ def get_us_latest_for_fips(fips) -> dict:
     return us_latest.get_record_for_fips(fips)
 
 
-def get_timeseries_for_fips(
-    fips: str, columns: List = None, min_range_with_some_value: bool = False
-) -> TimeseriesDataset:
+def get_timeseries_for_fips(fips: str, columns: List = None) -> TimeseriesDataset:
     """Gets timeseries for a specific FIPS code.
 
     Args:
         fips: FIPS code.  Can be county (5 character) or state (2 character) code.
         columns: List of columns, apart from `TimeseriesDataset.INDEX_FIELDS`, to include.
-        min_range_with_some_value: If True, removes NaNs that pad values at beginning and end of
-            timeseries. Only applicable when columns are specified.
 
     Returns: Timeseries for fips
     """
-
-    state_ts = load_us_timeseries_dataset().get_subset(None, fips=fips)
-    if columns:
-        return state_ts.get_columns_and_date_subset(
-            columns, min_range_with_some_value=min_range_with_some_value
-        )
-
-    return state_ts
+    fips_ts = load_us_timeseries_dataset().get_subset(None, fips=fips, columns=columns)
+    return fips_ts
 
 
 def build_from_sources(

--- a/libs/datasets/dataset_utils.py
+++ b/libs/datasets/dataset_utils.py
@@ -238,7 +238,7 @@ def _clear_common_values(
     data_source.reset_index(inplace=True)
 
 
-def make_binary_array(
+def make_rows_key(
     data: pd.DataFrame,
     aggregation_level: Optional[AggregationLevel] = None,
     country=None,
@@ -249,7 +249,7 @@ def make_binary_array(
     after=None,
     before=None,
 ):
-    """Create a binary array selecting rows in `data` matching the given parameters."""
+    """Create a binary array or slice selecting rows in `data` matching the given parameters."""
     query_parts = []
     # aggregation_level is almost always set. The exception is `DatasetFilter` which is used to
     # get all data in the USA, at all aggregation levels.
@@ -273,6 +273,7 @@ def make_binary_array(
     if query_parts:
         return data.eval(" and ".join(query_parts))
     else:
+        # Select all rows
         return slice(None, None, None)
 
 

--- a/libs/datasets/dataset_utils.py
+++ b/libs/datasets/dataset_utils.py
@@ -269,7 +269,11 @@ def make_binary_array(
         query_parts.append("date > @after")
     if before:
         query_parts.append("date < @before")
-    return data.eval(" and ".join(query_parts))
+
+    if query_parts:
+        return data.eval(" and ".join(query_parts))
+    else:
+        return slice(None, None, None)
 
 
 def fips_index_geo_data(df: pd.DataFrame) -> pd.DataFrame:

--- a/libs/datasets/latest_values_dataset.py
+++ b/libs/datasets/latest_values_dataset.py
@@ -5,7 +5,7 @@ from more_itertools import first
 
 from libs import us_state_abbrev
 import pandas as pd
-from libs.datasets.dataset_utils import AggregationLevel, make_binary_array
+from libs.datasets.dataset_utils import AggregationLevel, make_rows_key
 from libs.datasets import dataset_utils
 from libs.datasets import custom_aggregations
 from libs.datasets import dataset_base
@@ -167,7 +167,7 @@ class LatestValuesDataset(dataset_base.DatasetBase):
         after: Optional[str] = None,
         before: Optional[str] = None,
     ) -> "LatestValuesDataset":
-        rows_binary_array = make_binary_array(
+        rows_key = make_rows_key(
             self.data,
             aggregation_level=aggregation_level,
             country=country,
@@ -178,7 +178,7 @@ class LatestValuesDataset(dataset_base.DatasetBase):
             after=after,
             before=before,
         )
-        return self.__class__(self.data.loc[rows_binary_array, :])
+        return self.__class__(self.data.loc[rows_key, :])
 
     def get_record_for_fips(self, fips) -> dict:
         """Gets all data for a given fips code.

--- a/libs/datasets/latest_values_dataset.py
+++ b/libs/datasets/latest_values_dataset.py
@@ -136,23 +136,6 @@ class LatestValuesDataset(dataset_base.DatasetBase):
         return self.get_subset(aggregation_level=AggregationLevel.COUNTY)
 
     @property
-    def state_data(self) -> pd.DataFrame:
-        """Returns a new BedsDataset containing only state data."""
-
-        is_state = self.data[CommonFields.AGGREGATE_LEVEL] == AggregationLevel.STATE.value
-        return self.data[is_state]
-
-    @property
-    def county_data(self) -> pd.DataFrame:
-        """Returns a new BedsDataset containing only county data."""
-        is_county = self.data[CommonFields.AGGREGATE_LEVEL] == AggregationLevel.COUNTY.value
-        return self.data[is_county]
-
-    @property
-    def states(self):
-        return self.data.state.unique()
-
-    @property
     def all_fips(self) -> List[str]:
         return list(self.data.fips.unique())
 

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -1,4 +1,3 @@
-import warnings
 import pathlib
 from typing import List, Optional, Union, TextIO
 from typing import Sequence
@@ -143,7 +142,7 @@ class TimeseriesDataset(dataset_base.DatasetBase):
         """Fetch a new TimeseriesDataset with a subset of the data in `self`.
 
         Some parameters are only used in ipython notebooks."""
-        row_binary_array = dataset_utils.make_binary_array(
+        rows_key = dataset_utils.make_binary_array(
             self.data,
             aggregation_level=aggregation_level,
             country=country,
@@ -154,20 +153,11 @@ class TimeseriesDataset(dataset_base.DatasetBase):
             after=after,
             before=before,
         )
-        if columns:
-            return self.__class__(self.data.loc[row_binary_array, columns])
-        else:
-            return self.__class__(self.data.loc[row_binary_array, :])
+        columns_key = list(columns) if columns else slice(None, None, None)
+        return self.__class__(self.data.loc[rows_key, columns_key].reset_index(drop=True))
 
-    def get_columns_and_date_subset(
-        self, columns: List[str], min_range_with_some_value: bool
-    ) -> "TimeseriesDataset":
-        subset = self.data.loc[:, TimeseriesDataset.INDEX_FIELDS + columns].reset_index(drop=True)
-
-        if min_range_with_some_value:
-            subset = _remove_padded_nans(subset, columns)
-
-        return self.__class__(subset)
+    def remove_padded_nans(self, columns: List[str]):
+        return self.__class__(_remove_padded_nans(self.data, columns))
 
     def get_data(
         self,

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -53,10 +53,6 @@ class TimeseriesDataset(dataset_base.DatasetBase):
     def all_fips(self):
         return self.data.reset_index().fips.unique()
 
-    @property
-    def states(self) -> List:
-        return self.data[CommonFields.STATE].dropna().unique().tolist()
-
     def has_one_region(self) -> bool:
         return self.data[CommonFields.FIPS].nunique() == 1
 

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -57,33 +57,8 @@ class TimeseriesDataset(dataset_base.DatasetBase):
     def states(self) -> List:
         return self.data[CommonFields.STATE].dropna().unique().tolist()
 
-    @property
-    def state_data(self) -> pd.DataFrame:
-        return self.get_subset(AggregationLevel.STATE).data
-
-    @property
-    def county_data(self) -> pd.DataFrame:
-        return self.get_subset(AggregationLevel.COUNTY).data
-
     def has_one_region(self) -> bool:
         return self.data[CommonFields.FIPS].nunique() == 1
-
-    def county_keys(self) -> List:
-        """Returns a list of all (country, state, county) combinations."""
-        # Check to make sure all values are county values
-        warnings.warn(
-            "Tell Tom you are using this, I'm going to delete it soon.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        county_values = self.data[CommonFields.AGGREGATE_LEVEL] == AggregationLevel.COUNTY.value
-        county_data = self.data[county_values]
-
-        data = county_data.set_index(
-            [CommonFields.COUNTRY, CommonFields.STATE, CommonFields.COUNTY, CommonFields.FIPS,]
-        )
-        values = set(data.index.to_list())
-        return sorted(values)
 
     def latest_values(self) -> pd.DataFrame:
         """Gets the most recent values.
@@ -197,16 +172,6 @@ class TimeseriesDataset(dataset_base.DatasetBase):
             subset = _remove_padded_nans(subset, columns)
 
         return self.__class__(subset)
-
-    def get_records_for_fips(self, fips) -> List[dict]:
-        """Get data for FIPS code.
-
-        Args:
-            fips: 2 digits for a state or 5 digits for a county
-
-        Returns: List of dictionary records with NA values replaced to be None
-        """
-        return list(self.get_subset(fips=fips).yield_records())
 
     def get_data(
         self,

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -142,7 +142,7 @@ class TimeseriesDataset(dataset_base.DatasetBase):
         """Fetch a new TimeseriesDataset with a subset of the data in `self`.
 
         Some parameters are only used in ipython notebooks."""
-        rows_key = dataset_utils.make_binary_array(
+        rows_key = dataset_utils.make_rows_key(
             self.data,
             aggregation_level=aggregation_level,
             country=country,
@@ -171,7 +171,7 @@ class TimeseriesDataset(dataset_base.DatasetBase):
         before: Optional[str] = None,
         columns_slice: Optional[List[str]] = None,
     ) -> pd.DataFrame:
-        rows_binary_array = dataset_utils.make_binary_array(
+        rows_key = dataset_utils.make_rows_key(
             self.data,
             aggregation_level=aggregation_level,
             country=country,
@@ -184,7 +184,7 @@ class TimeseriesDataset(dataset_base.DatasetBase):
         )
         if columns_slice is None:
             columns_slice = slice(None, None, None)
-        return self.data.loc[rows_binary_array, columns_slice]
+        return self.data.loc[rows_key, columns_slice]
 
     @classmethod
     def from_source(

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -159,33 +159,6 @@ class TimeseriesDataset(dataset_base.DatasetBase):
     def remove_padded_nans(self, columns: List[str]):
         return self.__class__(_remove_padded_nans(self.data, columns))
 
-    def get_data(
-        self,
-        aggregation_level=None,
-        country=None,
-        fips: Optional[str] = None,
-        state: Optional[str] = None,
-        states: Optional[List[str]] = None,
-        on: Optional[str] = None,
-        after: Optional[str] = None,
-        before: Optional[str] = None,
-        columns_slice: Optional[List[str]] = None,
-    ) -> pd.DataFrame:
-        rows_key = dataset_utils.make_rows_key(
-            self.data,
-            aggregation_level=aggregation_level,
-            country=country,
-            fips=fips,
-            state=state,
-            states=states,
-            on=on,
-            after=after,
-            before=before,
-        )
-        if columns_slice is None:
-            columns_slice = slice(None, None, None)
-        return self.data.loc[rows_key, columns_slice]
-
     @classmethod
     def from_source(
         cls, source: "DataSource", fill_missing_state: bool = True

--- a/libs/pipelines/api_pipeline.py
+++ b/libs/pipelines/api_pipeline.py
@@ -92,7 +92,11 @@ def generate_metrics_and_latest_for_fips(
 
 
 def build_timeseries_for_fips(
-    intervention, us_latest, us_timeseries, model_output_dir, fips
+    intervention: Intervention,
+    us_latest: LatestValuesDataset,
+    us_timeseries: TimeseriesDataset,
+    model_output_dir: pathlib.Path,
+    fips,
 ) -> Optional[RegionSummaryWithTimeseries]:
     fips_latest = us_latest.get_record_for_fips(fips)
 

--- a/libs/top_level_metrics.py
+++ b/libs/top_level_metrics.py
@@ -57,7 +57,7 @@ def calculate_metrics_for_timeseries(
     require_recent_icu_data: bool = True,
 ) -> Tuple[pd.DataFrame, Metrics]:
     # Making sure that the timeseries object passed in is only for one fips.
-    assert len(timeseries.all_fips) == 1
+    assert timeseries.has_one_region()
     fips = latest[CommonFields.FIPS]
     population = latest[CommonFields.POPULATION]
 

--- a/libs/top_level_metrics.py
+++ b/libs/top_level_metrics.py
@@ -214,15 +214,6 @@ def calculate_contact_tracers(
     return contact_tracers / (smoothed_daily_cases * contact_tracers_per_case)
 
 
-# Example of running calculation for all counties in a state, using the latest dataset
-# to get all fips codes for that state
-def calculate_metrics_for_counties_in_state(state: str):
-    latest = combined_datasets.load_us_latest_dataset()
-    state_latest_values = latest.county.get_subset(state=state)
-    for fips in state_latest_values.all_fips:
-        yield calculate_top_level_metrics_for_fips(fips)
-
-
 def calculate_latest_metrics(
     data: pd.DataFrame,
     icu_metric_details: Optional[ICUHeadroomMetricDetails],

--- a/pyseir/inference/infer_t0.py
+++ b/pyseir/inference/infer_t0.py
@@ -27,8 +27,8 @@ def infer_t0(fips, method="first_case", default=pd.Timestamp("2020-02-01")):
 
     if method == "first_case":
         fips_timeseries = combined_datasets.get_timeseries_for_fips(
-            fips, columns=[CommonFields.CASES], min_range_with_some_value=True
-        )
+            fips, columns=[CommonFields.CASES]
+        ).remove_padded_nans([CommonFields.CASES])
         if not fips_timeseries.empty:
             t0 = fips_timeseries[CommonFields.DATE].min()
         else:

--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -47,7 +47,7 @@ class RegionalInput:
     @staticmethod
     def from_state_region(region: pipeline.Region) -> "RegionalInput":
         """Creates a RegionalInput for given state region."""
-        hospitalization_df = load_data.get_hospitalization_data().get_data(fips=region.fips)
+        hospitalization_df = load_data.get_hospitalization_data().get_subset(fips=region.fips).data
         assert region.is_state()
         return RegionalInput(
             region=region,
@@ -65,7 +65,7 @@ class RegionalInput:
             region: a sub-state region such as a county
             state_fitter: ModelFitter for the state containing region
         """
-        hospitalization_df = load_data.get_hospitalization_data().get_data(fips=region.fips)
+        hospitalization_df = load_data.get_hospitalization_data().get_subset(fips=region.fips).data
         assert region.is_county()
         assert state_fitter
         return RegionalInput(

--- a/pyseir/inference/whitelist.py
+++ b/pyseir/inference/whitelist.py
@@ -45,7 +45,7 @@ class WhitelistGenerator:
         """
         logging.info("Generating county level whitelist...")
 
-        counties = timeseries.get_data(aggregation_level=AggregationLevel.COUNTY)
+        counties = timeseries.get_subset(aggregation_level=AggregationLevel.COUNTY).data
         df_candidates = (
             counties.groupby(CommonFields.FIPS)
             # Use pandarallel. It doesn't support the `name` attribute so leave FIPS as a regular

--- a/pyseir/load_data.py
+++ b/pyseir/load_data.py
@@ -165,9 +165,10 @@ def calculate_new_case_data_by_region(
     """
     assert not region_timeseries.empty
     assert region_timeseries.has_one_region()
-    county_case_timeseries = region_timeseries.get_columns_and_date_subset(
-        columns=[CommonFields.CASES, CommonFields.DEATHS], min_range_with_some_value=True
-    )
+    columns = [CommonFields.CASES, CommonFields.DEATHS]
+    county_case_timeseries = region_timeseries.get_subset(
+        columns=(TimeseriesDataset.INDEX_FIELDS + columns)
+    ).remove_padded_nans(columns)
     county_case_data = county_case_timeseries.data
 
     times_new = (county_case_data["date"] - t0).dt.days.iloc[1:]

--- a/pyseir/load_data.py
+++ b/pyseir/load_data.py
@@ -163,7 +163,7 @@ def calculate_new_case_data_by_region(
     observed_new_deaths: array(int)
         Array of new deaths observed each day.
     """
-    assert not region_timeseries.data.empty
+    assert not region_timeseries.empty
     assert region_timeseries.has_one_region()
     county_case_timeseries = region_timeseries.get_columns_and_date_subset(
         columns=[CommonFields.CASES, CommonFields.DEATHS], min_range_with_some_value=True

--- a/test/combined_dataset_test.py
+++ b/test/combined_dataset_test.py
@@ -114,12 +114,11 @@ def test_unique_timeseries(data_source_cls):
 )
 def test_expected_field_in_sources(data_source_cls):
     data_source = data_source_cls.local()
-    ts = data_source.timeseries()
-    usa_data = ts.get_data(country="USA")
+    ts = data_source.timeseries().get_subset(country="USA")
 
-    assert not usa_data.empty
+    assert not ts.empty
 
-    states = set(usa_data["state"])
+    states = set(ts.data["state"])
 
     if data_source.SOURCE_NAME == "NHA":
         assert states == {"NV"}

--- a/test/dataset_utils_test.py
+++ b/test/dataset_utils_test.py
@@ -267,9 +267,9 @@ def column_as_set(
 ):
     """Return values in selected rows and column of df.
 
-    Exists to call `make_binary_array` without listing all the parameters.
+    Exists to call `make_rows_key` without listing all the parameters.
     """
-    rows_binary_array = dataset_utils.make_binary_array(
+    rows_key = dataset_utils.make_rows_key(
         df,
         aggregation_level,
         country=None,
@@ -280,7 +280,7 @@ def column_as_set(
         after=after,
         before=before,
     )
-    return set(df.loc[rows_binary_array][column])
+    return set(df.loc[rows_key][column])
 
 
 def test_make_binary_array():

--- a/test/pyseir/load_data_test.py
+++ b/test/pyseir/load_data_test.py
@@ -7,7 +7,7 @@ from pyseir.load_data import HospitalizationDataType
 def test_load_hospitalization_data():
     t0 = datetime(year=2020, month=1, day=1)
     fips = "33"
-    hospitalization_df = load_data.get_hospitalization_data().get_data(fips=fips)
+    hospitalization_df = load_data.get_hospitalization_data().get_subset(fips=fips).data
 
     _, _, hosp_type = load_data.calculate_hospitalization_data(
         hospitalization_df, t0, category=HospitalizationCategory.ICU

--- a/test/timeseries_test.py
+++ b/test/timeseries_test.py
@@ -14,7 +14,7 @@ import pytest
 pytestmark = pytest.mark.filterwarnings("error")
 
 
-def test_get_subset_and_get_data():
+def test_get_subset():
     # CSV with a unique FIPS value for every region, even countries. In production countries are removed before
     # TimeseriesDataset is created. A future change may replace FIPS with a more general identifier.
     input_df = pd.read_csv(
@@ -35,23 +35,23 @@ def test_get_subset_and_get_data():
     assert set(ts.get_subset(AggregationLevel.COUNTRY).data["metric"]) == {"you-kee", "you-ess-hey"}
     assert set(ts.get_subset(AggregationLevel.COUNTRY, country="UK").data["country"]) == {"UK"}
     assert set(ts.get_subset(AggregationLevel.STATE).data["metric"]) == {"mystate", "other-state"}
-    assert set(ts.get_data(None, state="ZZ", after="2020-03-23")["metric"]) == {"march24-nyc"}
-    assert set(ts.get_data(None, state="ZZ", after="2020-03-22")["metric"]) == {
+    assert set(ts.get_subset(state="ZZ", after="2020-03-23").data["metric"]) == {"march24-nyc"}
+    assert set(ts.get_subset(state="ZZ", after="2020-03-22").data["metric"]) == {
         "smithville-march23",
         "county-metric",
         "mystate",
         "march24-nyc",
     }
-    assert set(ts.get_data(AggregationLevel.STATE, states=["ZZ", "XY"])["metric"]) == {
+    assert set(ts.get_subset(AggregationLevel.STATE, states=["ZZ", "XY"]).data["metric"]) == {
         "mystate",
         "other-state",
     }
-    assert set(ts.get_data(None, states=["ZZ"], on="2020-03-23")["metric"]) == {
+    assert set(ts.get_subset(states=["ZZ"], on="2020-03-23").data["metric"]) == {
         "smithville-march23",
         "county-metric",
         "mystate",
     }
-    assert set(ts.get_data(None, states=["ZZ"], before="2020-03-23")["metric"]) == {"march22-nyc"}
+    assert set(ts.get_subset(states=["ZZ"], before="2020-03-23").data["metric"]) == {"march22-nyc"}
 
 
 def test_wide_dates():


### PR DESCRIPTION
This PR is part of https://trello.com/c/nYgDEl3M/385-ability-to-query-raw-data-by-msa

* rm some unused methods of LatestValuesDataset and TimeseriesDataset
* replace TimeseriesDataset.get_data calls with get_subset(...).data
* rename make_binary_array to make_rows_key
* add types in a few places
