### PR TITLE
mv pipeline.RegionalCombinedData to combined_datasets

### DIFF
--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -366,7 +366,7 @@ def provenance_wide_metrics_to_series(wide: pd.DataFrame, log) -> pd.Series:
 
 
 @dataclass(frozen=True)
-class RegionalCombinedData:
+class RegionalData:
     """Identifies a geographical area and wraps access to `combined_datasets` of it."""
 
     region: Region
@@ -376,17 +376,15 @@ class RegionalCombinedData:
     timeseries: TimeseriesDataset
 
     @staticmethod
-    def from_region(region: Region) -> "RegionalCombinedData":
+    def from_region(region: Region) -> "RegionalData":
 
-        us_latest = combined_datasets.load_us_latest_dataset()
+        us_latest = load_us_latest_dataset()
         region_latest = us_latest.get_record_for_fips(region.fips)
 
-        us_timeseries = combined_datasets.load_us_timeseries_dataset()
+        us_timeseries = load_us_timeseries_dataset()
         region_timeseries = us_timeseries.get_subset(fips=region.fips)
 
-        return RegionalCombinedData(
-            region=region, latest=region_latest, timeseries=region_timeseries
-        )
+        return RegionalData(region=region, latest=region_latest, timeseries=region_timeseries)
 
     @property
     def population(self) -> int:

--- a/libs/pipeline.py
+++ b/libs/pipeline.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 import structlog
 import us
 
-import pyseir.utils
 from covidactnow.datapublic.common_fields import CommonFields
 from libs.datasets import combined_datasets
 from libs.datasets import timeseries
@@ -54,24 +53,6 @@ class Region:
         if len(self.fips) != 5:
             raise ValueError(f"No state for {self}")
         return Region(fips=self.fips[:2])
-
-    def run_artifact_path_to_read(self, run_artifact: pyseir.utils.RunArtifact) -> str:
-        """Returns the path of given artifact, to be used for reading.
-
-        Call this function instead of directly passing a fips to get_run_artifact_path to reduce
-        the amount of code that handles a fips. `run_artifact_path_to_write` has identical
-        behavior but using the appropriate function helps track down inputs and outputs.
-        """
-        return pyseir.utils.get_run_artifact_path(self.fips, run_artifact)
-
-    def run_artifact_path_to_write(self, run_artifact: pyseir.utils.RunArtifact) -> str:
-        """Returns the path of given artifact, to be used for reading.
-
-        Call this function instead of directly passing a fips to get_run_artifact_path to reduce
-        the amount of code that handles a fips. `run_artifact_path_to_read` has identical
-        behavior but using the appropriate function helps track down inputs and outputs.
-        """
-        return pyseir.utils.get_run_artifact_path(self.fips, run_artifact)
 
 
 @dataclass(frozen=True)

--- a/libs/pipeline.py
+++ b/libs/pipeline.py
@@ -2,12 +2,12 @@
 Code that is used to help move information around in the pipeline, starting with `Region` which
 represents a geographical area (state, county, metro area, etc).
 """
+
+# Many other modules import this module. Importing pyseir or dataset code here is likely to create
+# in import cycle.
+
 from dataclasses import dataclass
-
-import structlog
 import us
-
-_log = structlog.get_logger()
 
 
 @dataclass(frozen=True)

--- a/pyseir/cli.py
+++ b/pyseir/cli.py
@@ -9,6 +9,7 @@ from multiprocessing import Pool
 import us
 import pandas as pd
 import click
+
 from covidactnow.datapublic.common_fields import CommonFields
 
 from covidactnow.datapublic import common_init
@@ -88,7 +89,7 @@ class SubStateRegionPipelineInput:
     region: pipeline.Region
     run_fitter: bool
     state_fitter: model_fitter.ModelFitter
-    regional_combined_dataset: pipeline.RegionalCombinedData
+    regional_combined_dataset: combined_datasets.RegionalCombinedData
 
     @staticmethod
     def build_all(
@@ -123,7 +124,9 @@ class SubStateRegionPipelineInput:
                 region=region,
                 run_fitter=(region in whitelist_regions),
                 state_fitter=state_fitter_map.get(region.get_state_region()),
-                regional_combined_dataset=pipeline.RegionalCombinedData.from_region(region),
+                regional_combined_dataset=combined_datasets.RegionalCombinedData.from_region(
+                    region
+                ),
             )
             for region in (infer_rt_regions | whitelist_regions)
         ]
@@ -136,7 +139,7 @@ class SubStatePipeline:
 
     region: pipeline.Region
     infer_df: pd.DataFrame
-    _combined_data: pipeline.RegionalCombinedData
+    _combined_data: combined_datasets.RegionalCombinedData
     fitter: Optional[model_fitter.ModelFitter] = None
     ensemble: Optional[ensemble_runner.EnsembleRunner] = None
 

--- a/pyseir/cli.py
+++ b/pyseir/cli.py
@@ -89,7 +89,7 @@ class SubStateRegionPipelineInput:
     region: pipeline.Region
     run_fitter: bool
     state_fitter: model_fitter.ModelFitter
-    regional_combined_dataset: combined_datasets.RegionalCombinedData
+    regional_combined_dataset: combined_datasets.RegionalData
 
     @staticmethod
     def build_all(
@@ -124,9 +124,7 @@ class SubStateRegionPipelineInput:
                 region=region,
                 run_fitter=(region in whitelist_regions),
                 state_fitter=state_fitter_map.get(region.get_state_region()),
-                regional_combined_dataset=combined_datasets.RegionalCombinedData.from_region(
-                    region
-                ),
+                regional_combined_dataset=combined_datasets.RegionalData.from_region(region),
             )
             for region in (infer_rt_regions | whitelist_regions)
         ]
@@ -139,7 +137,7 @@ class SubStatePipeline:
 
     region: pipeline.Region
     infer_df: pd.DataFrame
-    _combined_data: combined_datasets.RegionalCombinedData
+    _combined_data: combined_datasets.RegionalData
     fitter: Optional[model_fitter.ModelFitter] = None
     ensemble: Optional[ensemble_runner.EnsembleRunner] = None
 

--- a/pyseir/deployment/webui_data_adaptor_v1.py
+++ b/pyseir/deployment/webui_data_adaptor_v1.py
@@ -373,7 +373,7 @@ class WebUIDataAdaptorV1:
             intervention = Intervention.from_webui_data_adaptor(suppression_policy)
             output_model[schema.INTERVENTION] = intervention.value
             output_path = get_run_artifact_path(
-                regional_input.fips, RunArtifact.WEB_UI_RESULT, output_dir=self.output_dir
+                regional_input, RunArtifact.WEB_UI_RESULT, output_dir=self.output_dir
             )
             output_path = output_path.replace("__INTERVENTION_IDX__", str(intervention.value))
             output_model.to_json(output_path, orient=OUTPUT_JSON_ORIENT)

--- a/pyseir/deployment/webui_data_adaptor_v1.py
+++ b/pyseir/deployment/webui_data_adaptor_v1.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 from libs.datasets.timeseries import TimeseriesDataset
 from libs.pipeline import Region
-from libs.pipeline import RegionalCombinedData
+from libs.datasets import combined_datasets
 from pyseir.deployment import model_to_observed_shim as shim
 from pyseir.ensembles import ensemble_runner
 from pyseir.icu import infer_icu
@@ -31,8 +31,8 @@ class RegionalInput:
 
     region: Region
 
-    _combined_data: RegionalCombinedData
-    _state_combined_data: Optional[RegionalCombinedData]
+    _combined_data: combined_datasets.RegionalCombinedData
+    _state_combined_data: Optional[combined_datasets.RegionalCombinedData]
     _mle_fit_result: Mapping[str, Any]
     _ensemble_results: Mapping[str, Any]
     _infection_rate: Optional[pd.DataFrame]
@@ -45,7 +45,7 @@ class RegionalInput:
     ) -> "RegionalInput":
         region = fitter.region
         state_combined_data = (
-            RegionalCombinedData.from_region(region.get_state_region())
+            combined_datasets.RegionalCombinedData.from_region(region.get_state_region())
             if region.is_county()
             else None
         )

--- a/pyseir/deployment/webui_data_adaptor_v1.py
+++ b/pyseir/deployment/webui_data_adaptor_v1.py
@@ -31,8 +31,8 @@ class RegionalInput:
 
     region: Region
 
-    _combined_data: combined_datasets.RegionalCombinedData
-    _state_combined_data: Optional[combined_datasets.RegionalCombinedData]
+    _combined_data: combined_datasets.RegionalData
+    _state_combined_data: Optional[combined_datasets.RegionalData]
     _mle_fit_result: Mapping[str, Any]
     _ensemble_results: Mapping[str, Any]
     _infection_rate: Optional[pd.DataFrame]
@@ -45,7 +45,7 @@ class RegionalInput:
     ) -> "RegionalInput":
         region = fitter.region
         state_combined_data = (
-            combined_datasets.RegionalCombinedData.from_region(region.get_state_region())
+            combined_datasets.RegionalData.from_region(region.get_state_region())
             if region.is_county()
             else None
         )

--- a/pyseir/ensembles/ensemble_runner.py
+++ b/pyseir/ensembles/ensemble_runner.py
@@ -31,7 +31,7 @@ compartment_to_capacity_attr_map = {
 class RegionalInput:
     region: pipeline.Region
 
-    _combined_data: combined_datasets.RegionalCombinedData
+    _combined_data: combined_datasets.RegionalData
     _mle_fit_model: seir_model.SEIRModel
     _mle_fit_result: Mapping[str, Any]
     _state_mle_fit_model: Optional[seir_model.SEIRModel] = None

--- a/pyseir/ensembles/ensemble_runner.py
+++ b/pyseir/ensembles/ensemble_runner.py
@@ -8,6 +8,7 @@ import structlog
 import copy
 from collections import defaultdict
 
+from libs.datasets import combined_datasets
 from libs import pipeline
 from pyseir.inference import model_fitter
 from pyseir.models import seir_model
@@ -30,7 +31,7 @@ compartment_to_capacity_attr_map = {
 class RegionalInput:
     region: pipeline.Region
 
-    _combined_data: pipeline.RegionalCombinedData
+    _combined_data: combined_datasets.RegionalCombinedData
     _mle_fit_model: seir_model.SEIRModel
     _mle_fit_result: Mapping[str, Any]
     _state_mle_fit_model: Optional[seir_model.SEIRModel] = None

--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -42,7 +42,7 @@ def load_pyseir_fitter_initial_conditions_df():
 class RegionalInput:
     region: pipeline.Region
 
-    _combined_data: combined_datasets.RegionalCombinedData
+    _combined_data: combined_datasets.RegionalData
     _hospitalization_df: pd.DataFrame
     _state_mle_fit_result: Optional[Mapping[str, Any]] = None
 
@@ -53,7 +53,7 @@ class RegionalInput:
         assert region.is_state()
         return RegionalInput(
             region=region,
-            _combined_data=combined_datasets.RegionalCombinedData.from_region(region),
+            _combined_data=combined_datasets.RegionalData.from_region(region),
             _hospitalization_df=hospitalization_df,
         )
 
@@ -72,7 +72,7 @@ class RegionalInput:
         assert state_fitter
         return RegionalInput(
             region=region,
-            _combined_data=combined_datasets.RegionalCombinedData.from_region(region),
+            _combined_data=combined_datasets.RegionalData.from_region(region),
             _state_mle_fit_result=state_fitter.fit_results,
             _hospitalization_df=hospitalization_df,
         )

--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -12,6 +12,8 @@ from datetime import datetime, timedelta
 import numpy as np
 import pandas as pd
 import iminuit
+
+from libs.datasets import combined_datasets
 from libs import pipeline
 
 from pyseir.inference import model_plotting
@@ -40,7 +42,7 @@ def load_pyseir_fitter_initial_conditions_df():
 class RegionalInput:
     region: pipeline.Region
 
-    _combined_data: pipeline.RegionalCombinedData
+    _combined_data: combined_datasets.RegionalCombinedData
     _hospitalization_df: pd.DataFrame
     _state_mle_fit_result: Optional[Mapping[str, Any]] = None
 
@@ -51,7 +53,7 @@ class RegionalInput:
         assert region.is_state()
         return RegionalInput(
             region=region,
-            _combined_data=pipeline.RegionalCombinedData.from_region(region),
+            _combined_data=combined_datasets.RegionalCombinedData.from_region(region),
             _hospitalization_df=hospitalization_df,
         )
 
@@ -70,7 +72,7 @@ class RegionalInput:
         assert state_fitter
         return RegionalInput(
             region=region,
-            _combined_data=pipeline.RegionalCombinedData.from_region(region),
+            _combined_data=combined_datasets.RegionalCombinedData.from_region(region),
             _state_mle_fit_result=state_fitter.fit_results,
             _hospitalization_df=hospitalization_df,
         )

--- a/pyseir/rt/infer_rt.py
+++ b/pyseir/rt/infer_rt.py
@@ -25,7 +25,7 @@ rt_log = structlog.get_logger(__name__)
 class RegionalInput:
     region: pipeline.Region
 
-    _combined_data: combined_datasets.RegionalCombinedData
+    _combined_data: combined_datasets.RegionalData
 
     @property
     def display_name(self) -> str:
@@ -38,8 +38,7 @@ class RegionalInput:
     @staticmethod
     def from_region(region: pipeline.Region) -> "RegionalInput":
         return RegionalInput(
-            region=region,
-            _combined_data=combined_datasets.RegionalCombinedData.from_region(region),
+            region=region, _combined_data=combined_datasets.RegionalData.from_region(region),
         )
 
     @staticmethod

--- a/pyseir/rt/infer_rt.py
+++ b/pyseir/rt/infer_rt.py
@@ -13,6 +13,7 @@ from libs import pipeline
 from libs.datasets import timeseries
 from pyseir import load_data
 from pyseir.utils import TimeseriesType, RunArtifact
+import pyseir.utils
 from pyseir.rt.constants import InferRtConstants
 from pyseir.rt import plotting, utils
 
@@ -188,7 +189,9 @@ def filter_and_smooth_input_data(
                 plt.xlim(min(dates[-len(df[column]) :]), max(dates) + timedelta(days=2))
 
                 if not figure_collector:
-                    plot_path = region.run_artifact_path_to_write(RunArtifact.RT_SMOOTHING_REPORT)
+                    plot_path = pyseir.utils.get_run_artifact_path(
+                        region, RunArtifact.RT_SMOOTHING_REPORT
+                    )
                     plt.savefig(plot_path, bbox_inches="tight")
                     plt.close(fig)
                 else:
@@ -720,8 +723,8 @@ class RtInferenceEngine:
                 display_name=self.display_name,
             )
             if self.figure_collector is None:
-                output_path = self.regional_input.region.run_artifact_path_to_write(
-                    RunArtifact.RT_INFERENCE_REPORT
+                output_path = pyseir.utils.get_run_artifact_path(
+                    self.regional_input.region, RunArtifact.RT_INFERENCE_REPORT
                 )
                 fig.savefig(output_path, bbox_inches="tight")
             else:

--- a/pyseir/rt/infer_rt.py
+++ b/pyseir/rt/infer_rt.py
@@ -9,6 +9,7 @@ import pandas as pd
 from scipy import stats as sps
 from matplotlib import pyplot as plt
 
+from libs.datasets import combined_datasets
 from libs import pipeline
 from libs.datasets import timeseries
 from pyseir import load_data
@@ -24,7 +25,7 @@ rt_log = structlog.get_logger(__name__)
 class RegionalInput:
     region: pipeline.Region
 
-    _combined_data: pipeline.RegionalCombinedData
+    _combined_data: combined_datasets.RegionalCombinedData
 
     @property
     def display_name(self) -> str:
@@ -37,7 +38,8 @@ class RegionalInput:
     @staticmethod
     def from_region(region: pipeline.Region) -> "RegionalInput":
         return RegionalInput(
-            region=region, _combined_data=pipeline.RegionalCombinedData.from_region(region),
+            region=region,
+            _combined_data=combined_datasets.RegionalCombinedData.from_region(region),
         )
 
     @staticmethod

--- a/pyseir/utils.py
+++ b/pyseir/utils.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from enum import Enum
 from scipy import signal
 from covidactnow.datapublic.common_fields import CommonFields
+from libs.pipeline import Region
 
 from pyseir import OUTPUT_DIR
 from libs.datasets import combined_datasets
@@ -64,7 +65,7 @@ def get_summary_artifact_path(artifact: SummaryArtifact, output_dir=None) -> str
     return os.path.join(output_dir, "pyseir", artifact.value)
 
 
-def get_run_artifact_path(fips: str, artifact, output_dir=None) -> str:
+def get_run_artifact_path(region: Region, artifact, output_dir=None) -> str:
     """
     Get an artifact path for a given locale and artifact type.
 
@@ -83,6 +84,7 @@ def get_run_artifact_path(fips: str, artifact, output_dir=None) -> str:
     path: str
         Location of the artifact.
     """
+    fips = region.fips
     state_obj = us.states.lookup(fips[:2])
     if not state_obj:
         raise AssertionError(f"No state_obj for {fips}")

--- a/test/infer_rt_test.py
+++ b/test/infer_rt_test.py
@@ -3,6 +3,8 @@ import pathlib
 import pytest
 import pandas as pd
 import structlog
+
+from libs.datasets import combined_datasets
 from covidactnow.datapublic.common_fields import CommonFields
 from libs import pipeline
 from pyseir import cli
@@ -276,7 +278,7 @@ def test_patch_substatepipeline_nola_infection_rate():
             cli.SubStatePipeline(
                 region=region,
                 infer_df=infection_rate_df,
-                _combined_data=pipeline.RegionalCombinedData.from_region(region),
+                _combined_data=combined_datasets.RegionalCombinedData.from_region(region),
             )
         )
 

--- a/test/infer_rt_test.py
+++ b/test/infer_rt_test.py
@@ -278,7 +278,7 @@ def test_patch_substatepipeline_nola_infection_rate():
             cli.SubStatePipeline(
                 region=region,
                 infer_df=infection_rate_df,
-                _combined_data=combined_datasets.RegionalCombinedData.from_region(region),
+                _combined_data=combined_datasets.RegionalData.from_region(region),
             )
         )
 

--- a/test/pyseir/icu/infer_icu_test.py
+++ b/test/pyseir/icu/infer_icu_test.py
@@ -17,10 +17,8 @@ from pyseir.icu import infer_icu
 )
 def test_get_icu(fips):
     region = pipeline.Region.from_fips(fips)
-    regional_combined_data = combined_datasets.RegionalCombinedData.from_region(region)
-    state_combined_data = combined_datasets.RegionalCombinedData.from_region(
-        region.get_state_region()
-    )
+    regional_combined_data = combined_datasets.RegionalData.from_region(region)
+    state_combined_data = combined_datasets.RegionalData.from_region(region.get_state_region())
     result_series = infer_icu.get_icu_timeseries(
         region,
         regional_combined_data=regional_combined_data.timeseries,

--- a/test/pyseir/icu/infer_icu_test.py
+++ b/test/pyseir/icu/infer_icu_test.py
@@ -1,4 +1,6 @@
 import pytest
+
+from libs.datasets import combined_datasets
 from covidactnow.datapublic.common_fields import CommonFields
 
 from libs import pipeline
@@ -15,8 +17,10 @@ from pyseir.icu import infer_icu
 )
 def test_get_icu(fips):
     region = pipeline.Region.from_fips(fips)
-    regional_combined_data = pipeline.RegionalCombinedData.from_region(region)
-    state_combined_data = pipeline.RegionalCombinedData.from_region(region.get_state_region())
+    regional_combined_data = combined_datasets.RegionalCombinedData.from_region(region)
+    state_combined_data = combined_datasets.RegionalCombinedData.from_region(
+        region.get_state_region()
+    )
     result_series = infer_icu.get_icu_timeseries(
         region,
         regional_combined_data=regional_combined_data.timeseries,

--- a/test/pyseir_end_to_end_test.py
+++ b/test/pyseir_end_to_end_test.py
@@ -3,6 +3,7 @@ import unittest
 
 from libs import pipeline
 from libs.datasets import combined_datasets
+from libs.pipeline import Region
 from pyseir import cli
 from pyseir.inference import whitelist
 from pyseir.utils import get_run_artifact_path, RunArtifact
@@ -22,9 +23,10 @@ def test_pyseir_end_to_end_idaho(tmp_path):
     # This covers a lot of edge cases.
     with unittest.mock.patch("pyseir.utils.OUTPUT_DIR", str(tmp_path)):
         fips = "16001"
+        region = Region.from_fips(fips)
         pipelines = cli._build_all_for_states(states=["ID"], fips=fips)
         cli._write_pipeline_output(pipelines, tmp_path)
-        path = get_run_artifact_path(fips, RunArtifact.WEB_UI_RESULT).replace(
+        path = get_run_artifact_path(region, RunArtifact.WEB_UI_RESULT).replace(
             "__INTERVENTION_IDX__", "2"
         )
         path = pathlib.Path(path)


### PR DESCRIPTION
This PR is part of https://trello.com/c/nYgDEl3M/385-ability-to-query-raw-data-by-msa

I ran into some gnarly import loops when using `Region` in more places. This refactor will hopefully break them and simplify a followup PR.

* mv pipeline.RegionalCombinedData to combined_datasets.RegionalData
* change access to the class to always use name `combined_datasets.RegionalData`