### PR TITLE
Fix for PR 678

### DIFF
--- a/pyseir/deployment/webui_data_adaptor_v1.py
+++ b/pyseir/deployment/webui_data_adaptor_v1.py
@@ -373,7 +373,7 @@ class WebUIDataAdaptorV1:
             intervention = Intervention.from_webui_data_adaptor(suppression_policy)
             output_model[schema.INTERVENTION] = intervention.value
             output_path = get_run_artifact_path(
-                regional_input, RunArtifact.WEB_UI_RESULT, output_dir=self.output_dir
+                regional_input.region, RunArtifact.WEB_UI_RESULT, output_dir=self.output_dir
             )
             output_path = output_path.replace("__INTERVENTION_IDX__", str(intervention.value))
             output_model.to_json(output_path, orient=OUTPUT_JSON_ORIENT)

--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -674,21 +674,15 @@ class ModelFitter:
         self.mle_model = self.run_model(**{k: self.fit_results[k] for k in self.model_fit_keys})
 
     @classmethod
-    def run_for_region(cls, regional_input: RegionalInput, n_retries=3):
+    def run_for_region(cls, regional_input: RegionalInput, n_retries=3) -> Optional["ModelFitter"]:
         """
         Run the model fitter for a regional_input.
 
-        Parameters
-        ----------
-        region: pipeline.Region
-        n_retries: int
-            The model fitter is stochastic in nature and a seed cannot be set.
-            This is a bandaid until more sophisticated retries can be
-            implemented.
-
-        Returns
-        -------
-        : ModelFitter
+        Args:
+            regional_input
+            n_retries: The model fitter is stochastic in nature and a seed cannot be set.
+                This is a bandaid until more sophisticated retries can be
+                implemented.
         """
         # Assert that there are some cases for counties
         if regional_input.region.is_county():

--- a/pyseir/inference/model_plotting.py
+++ b/pyseir/inference/model_plotting.py
@@ -5,13 +5,14 @@ import matplotlib.pyplot as plt
 
 from pyseir.load_data import HospitalizationDataType  # Do we still need this?
 from pyseir.utils import RunArtifact
+import pyseir.utils
 
 
 def plot_fitting_results(result: "pyseir.inference.ModelFitter") -> None:
     """
     Entry point from model_fitter. Generate and save all PySEIR related Figures.
     """
-    output_file = result.region.run_artifact_path_to_write(RunArtifact.MLE_FIT_REPORT)
+    output_file = pyseir.utils.get_run_artifact_path(result.region, RunArtifact.MLE_FIT_REPORT)
 
     # Save the mle fitter
     mle_fig = result.mle_model.plot_results()

--- a/test/pyseir_end_to_end_test.py
+++ b/test/pyseir_end_to_end_test.py
@@ -13,8 +13,6 @@ from libs.functions import generate_api
 import pytest
 
 # turns all warnings into errors for this module
-
-
 # Suppressing Matplotlib RuntimeWarning for Figure Gen Count right now. The regex for message isn't
 # (https://stackoverflow.com/questions/27476642/matplotlib-get-rid-of-max-open-warning-output)
 @pytest.mark.filterwarnings("error", "ignore::RuntimeWarning")


### PR DESCRIPTION
fix errors seen in https://github.com/covid-projections/covid-data-model/runs/1113246179

PR 678 removed run_artifact_path_to_read and run_artifact_path_to_write but I missed a caller. The tests don't run model_plotter code because of some weird multiprocessing issues with matplotlib on macs.