### PR TITLE
Copy External Forecasts from covid-data-public to covid-data-model

### DIFF
--- a/.github/workflows/update_repo_datasets.yml
+++ b/.github/workflows/update_repo_datasets.yml
@@ -70,6 +70,11 @@ jobs:
       run: |
         ./run.py data update
 
+    - name: Update External Forecasts
+      working-directory: ./covid-data-model
+      run: |
+        ./run.py data update-forecasts
+
     - name: Create Update Commit
       working-directory: ./covid-data-model
       run: ./tools/push-data-update.sh

--- a/cli/data.py
+++ b/cli/data.py
@@ -4,6 +4,7 @@ import logging
 import pathlib
 import os
 import json
+import shutil
 
 import click
 
@@ -21,6 +22,7 @@ from libs.datasets import dataset_utils
 from libs.datasets import combined_dataset_utils
 from libs.datasets import combined_datasets
 from libs.datasets.dataset_utils import AggregationLevel
+from libs.datasets.sources import forecast_hub
 from pyseir import DATA_DIR
 import pyseir.icu.utils
 from pyseir.icu import infer_icu
@@ -42,6 +44,17 @@ def _save_field_summary(timeseries_dataset: TimeseriesDataset, output_path: path
     summary = dataset_summary.summarize_timeseries_fields(timeseries_dataset.data)
     summary.to_csv(output_path)
     _logger.info(f"Saved dataset summary to {output_path}")
+
+
+@main.command()
+@click.option("--filename", default="external_forecasts.csv")
+def update_forecasts(filename):
+    """Updates external forecasts to the current checked out covid data public commit"""
+
+    path_prefix = dataset_utils.DATA_DIRECTORY.relative_to(dataset_utils.REPO_ROOT)
+    data_root = dataset_utils.LOCAL_PUBLIC_DATA_PATH
+    data_path = forecast_hub.ForecastHubDataset.DATA_PATH
+    shutil.copy(data_root / data_path, path_prefix / filename)
 
 
 @main.command()

--- a/cli/data.py
+++ b/cli/data.py
@@ -50,11 +50,11 @@ def _save_field_summary(timeseries_dataset: TimeseriesDataset, output_path: path
 @click.option("--filename", default="external_forecasts.csv")
 def update_forecasts(filename):
     """Updates external forecasts to the current checked out covid data public commit"""
-
     path_prefix = dataset_utils.DATA_DIRECTORY.relative_to(dataset_utils.REPO_ROOT)
     data_root = dataset_utils.LOCAL_PUBLIC_DATA_PATH
     data_path = forecast_hub.ForecastHubDataset.DATA_PATH
     shutil.copy(data_root / data_path, path_prefix / filename)
+    _logger.info(f"Updating External Forecasts at {path_prefix / filename}")
 
 
 @main.command()

--- a/data/external_forecasts.csv
+++ b/data/external_forecasts.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0e73b3e080bf46f70421c062df19220f4db231ec754af2b9e0e9dd4b4cef4cf
+size 1350013

--- a/libs/datasets/sources/forecast_hub.py
+++ b/libs/datasets/sources/forecast_hub.py
@@ -1,0 +1,24 @@
+from covidactnow.datapublic import common_df
+from libs.datasets import data_source
+from libs.datasets import dataset_utils
+
+
+class ForecastHubDataset(data_source.DataSource):
+    SOURCE_NAME = "ForecastHub"
+
+    DATA_PATH = "data/forecast-hub/timeseries-common.csv"
+
+    INDEX_FIELD_MAP = {
+        # Not Yet Implemented -> Currently only a move from covid-data-public to covid-data-model
+    }
+
+    COMMON_FIELD_MAP = {
+        # Not Yet Implemented -> Currently only a move from covid-data-public to covid-data-model
+    }
+
+    @classmethod
+    def local(cls):
+        data_root = dataset_utils.LOCAL_PUBLIC_DATA_PATH
+        input_path = data_root / cls.DATA_PATH
+        data = common_df.read_csv(input_path).reset_index()
+        return cls(cls._rename_to_common_fields(data))

--- a/libs/datasets/sources/forecast_hub.py
+++ b/libs/datasets/sources/forecast_hub.py
@@ -1,5 +1,4 @@
 from covidactnow.datapublic import common_df
-from covidactnow.datapublic.common_fields import CommonFields
 from libs.datasets import data_source
 from libs.datasets import dataset_utils
 

--- a/libs/datasets/sources/forecast_hub.py
+++ b/libs/datasets/sources/forecast_hub.py
@@ -1,4 +1,5 @@
 from covidactnow.datapublic import common_df
+from covidactnow.datapublic.common_fields import CommonFields
 from libs.datasets import data_source
 from libs.datasets import dataset_utils
 
@@ -18,7 +19,14 @@ class ForecastHubDataset(data_source.DataSource):
 
     @classmethod
     def local(cls):
+        """
+        This currently returns an empty DataFrame because _rename_to_common_fields restricts
+        output to only columns found in INDEX_FIELD_MAP and COMMON_FIELD_MAP. This is not yet
+        implemented because it is not required for this dataset to be merged via the combined
+        dataset pathway. Specifically, which quantiles to persist has not finalized and as such
+        they are not included in CommonFields and would be filtered out regardless.
+        """
         data_root = dataset_utils.LOCAL_PUBLIC_DATA_PATH
         input_path = data_root / cls.DATA_PATH
-        data = common_df.read_csv(input_path).reset_index()
+        data = common_df.read_csv(input_path, set_index=False)
         return cls(cls._rename_to_common_fields(data))


### PR DESCRIPTION
Paired with https://github.com/covid-projections/covid-data-public/pull/123.

Makes a copy of the external forecasts (currently only the ensemble from ForecastHub) into the data directory of covid-data-model.

The move is currently a simple copy, since no other external forecast streams are currently being combined.

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [ ] Are tests passing?
