### PR TITLE
make summary from memory instead of disk

### DIFF
--- a/cli/data.py
+++ b/cli/data.py
@@ -101,8 +101,7 @@ def update(summary_filename, wide_dates_filename):
         )
 
     if summary_filename:
-        dataset = timeseries_pointer.load_dataset()
-        _save_field_summary(dataset, path_prefix / summary_filename)
+        _save_field_summary(timeseries_dataset, path_prefix / summary_filename)
 
 
 @main.command()

--- a/libs/datasets/sources/covid_tracking_source.py
+++ b/libs/datasets/sources/covid_tracking_source.py
@@ -79,22 +79,6 @@ class CovidTrackingDataSource(data_source.DataSource):
         CommonFields.NEGATIVE_TESTS: Fields.NEGATIVE_TESTS,
     }
 
-    TESTS_ONLY_FIELDS = [
-        Fields.DATE,
-        Fields.POSITIVE_TESTS,
-        Fields.NEGATIVE_TESTS,
-    ]
-
-    TEST_FIELDS = [
-        Fields.DATE,
-        Fields.STATE,
-        Fields.POSITIVE_TESTS,
-        Fields.NEGATIVE_TESTS,
-        Fields.POSITIVE_INCREASE,
-        Fields.NEGATIVE_INCREASE,
-        Fields.AGGREGATE_LEVEL,
-    ]
-
     def __init__(self, input_path):
         data = pd.read_csv(
             input_path,
@@ -115,15 +99,6 @@ class CovidTrackingDataSource(data_source.DataSource):
         data[cls.Fields.COUNTY] = None
         data[cls.Fields.COUNTRY] = "USA"
         data[cls.Fields.AGGREGATE_LEVEL] = AggregationLevel.STATE.value
-
-        dtypes = {
-            cls.Fields.POSITIVE_TESTS: "Int64",
-            cls.Fields.NEGATIVE_TESTS: "Int64",
-            cls.Fields.POSITIVE_INCREASE: "Int64",
-            cls.Fields.NEGATIVE_INCREASE: "Int64",
-        }
-
-        data = data.astype(dtypes)
 
         # Removing bad data from Delaware.
         # Once that is resolved we can remove this while keeping the assert below.


### PR DESCRIPTION
## This PR 

* in CovidTrackingDataSource don't change data to Int64 because it causes "TypeError: reduction operation 'argmax' not allowed for this dtype" when the data is passed to _save_field_summary without taking a round-trip to disk.
* remove roundtrip to disk.


## Tested

Making only the data.py change caused the error and a run of `python ./run.py data update` with the `covid_tracking_source.py` change re-generated identical data in `data/`.
