### PR TITLE
combined_datasets small cleanups

### DIFF
--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from enum import Enum
 from itertools import chain
 from typing import Any
 from typing import Dict, Type, List, NewType, Mapping, MutableMapping, Tuple
@@ -7,7 +6,6 @@ import functools
 import pathlib
 import pandas as pd
 import structlog
-from structlog.threadlocal import tmp_bind
 
 from covidactnow.datapublic.common_fields import CommonFields
 from libs.datasets import dataset_utils
@@ -192,25 +190,8 @@ def build_from_sources(
     )
 
 
-class Override(Enum):
-    """How data sources override each other when combined."""
-
-    # For each <fips, date>, if a row in a higher priority datasource exists it is used, even
-    # for columns with NaN. This is the unexpected behavior from before July 16th that blends
-    # timeseries from different sources into a single output timeseries.
-    BY_ROW = 1
-    # For each <fips, variable>, use the entire timeseries of the highest priority datasource
-    # with at least one real (not NaN) value.
-    BY_TIMESERIES = 2
-    # For each <fips, variable, date>, use the highest priority datasource that has a real
-    # (not NaN) value.
-    BY_TIMESERIES_POINT = 3  # Deprecated
-
-
 def _build_data_and_provenance(
-    feature_definitions: Mapping[str, List[str]],
-    datasource_dataframes: Mapping[str, pd.DataFrame],
-    override=Override.BY_TIMESERIES,
+    feature_definitions: Mapping[str, List[str]], datasource_dataframes: Mapping[str, pd.DataFrame]
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
     fips_indexed = dataset_utils.fips_index_geo_data(pd.concat(datasource_dataframes.values()))
 
@@ -233,9 +214,7 @@ def _build_data_and_provenance(
     # else:
     #     raise ValueError("bad new_index.names")
 
-    data, provenance = _merge_data(
-        datasource_dataframes, feature_definitions, _log, new_index, override
-    )
+    data, provenance = _merge_data(datasource_dataframes, feature_definitions, _log, new_index)
 
     if not fips_indexed.empty:
         # See https://pandas.pydata.org/pandas-docs/stable/user_guide/merging.html#joining-with-two-multiindexes
@@ -244,13 +223,11 @@ def _build_data_and_provenance(
     return data, provenance
 
 
-def _merge_data(datasource_dataframes, feature_definitions, log, new_index, override):
-    if override is Override.BY_ROW:
-        return _merge_data_by_row(datasource_dataframes, feature_definitions, log, new_index)
-    if override is not Override.BY_TIMESERIES:
-        raise ValueError("Invalid override")
+def _merge_data(datasource_dataframes, feature_definitions, log, new_index):
+    # For each <fips, variable>, use the entire timeseries of the highest priority datasource
+    # with at least one real (not NaN) value.
 
-    # Not going BY_ROW so reindex the inputs now to avoid reindexing for each field below.
+    # Reindex the inputs now to avoid reindexing for each field below.
     datasource_dataframes = {
         name: df.reindex(new_index, copy=False) for name, df in datasource_dataframes.items()
     }
@@ -262,14 +239,16 @@ def _merge_data(datasource_dataframes, feature_definitions, log, new_index, over
             (name, datasource_dataframes[name][field_name]) for name in data_source_names
         ]
         field_out, field_provenance = _merge_field(
-            log.bind(field=field_name), datasource_series, new_index
+            datasource_series, new_index, log.bind(field=field_name),
         )
         data.loc[:, field_name] = field_out
         provenance.loc[:, field_name] = field_provenance
     return data, provenance
 
 
-def _merge_field(log, datasource_series: List[Tuple[str, pd.Series]], new_index):
+def _merge_field(
+    datasource_series: List[Tuple[str, pd.Series]], new_index, log: structlog.BoundLoggerBase
+):
     log.info("Working field")
     field_out = None
     field_provenance = pd.Series(index=new_index, dtype="object")
@@ -293,48 +272,6 @@ def _merge_field(log, datasource_series: List[Tuple[str, pd.Series]], new_index)
             log_datasource.error("Found duplicates in index")
             raise ValueError()  # This is bad, somehow the input /still/ has duplicates
     return field_out, field_provenance
-
-
-def _merge_data_by_row(datasource_dataframes, feature_definitions, log, new_index):
-    # Override.BY_ROW needs to preserve the rows datasource_dataframes
-
-    # Build feature columns from feature_definitions.
-    data = pd.DataFrame(index=new_index)
-    provenance = pd.DataFrame(index=new_index)
-    for field_name, data_source_names in feature_definitions.items():
-        log.info("Working field", field=field_name)
-        field_out = None
-        # A list of Series, that when concatanted, will match 1-1 with the series in field_out
-        field_provenance = []
-        # Go through the data sources, starting with the highest priority.
-        for datasource_name in reversed(data_source_names):
-            with tmp_bind(log, dataset_name=datasource_name, field=field_name) as log:
-                datasource_field_in = datasource_dataframes[datasource_name][field_name]
-                if field_out is None:
-                    # Copy all values from the highest priority input to the output
-                    field_out = datasource_field_in
-                    field_provenance.append(
-                        pd.Series(index=datasource_field_in.index, dtype="object").fillna(
-                            datasource_name
-                        )
-                    )
-                else:
-                    # Copy from datasource_field_in rows that are not yet in field_out
-                    this_not_in_result = ~datasource_field_in.index.isin(field_out.index)
-                    values_to_append = datasource_field_in.loc[this_not_in_result]
-                    field_out = field_out.append(values_to_append)
-                    field_provenance.append(
-                        pd.Series(index=values_to_append.index, dtype="object").fillna(
-                            datasource_name
-                        )
-                    )
-                dups = field_out.index.duplicated(keep=False)
-                if dups.any():
-                    log.error("Found duplicates in index")
-                    raise ValueError()  # This is bad, somehow the input /still/ has duplicates
-        data.loc[:, field_name] = field_out
-        provenance.loc[:, field_name] = pd.concat(field_provenance)
-    return data, provenance
 
 
 def provenance_wide_metrics_to_series(wide: pd.DataFrame, log) -> pd.Series:

--- a/test/combined_dataset_test.py
+++ b/test/combined_dataset_test.py
@@ -7,7 +7,6 @@ import structlog
 from libs.datasets import combined_datasets, CommonFields
 from libs.datasets.combined_datasets import (
     _build_data_and_provenance,
-    Override,
     build_from_sources,
     US_STATES_FILTER,
     FeatureDataSourceMap,
@@ -187,9 +186,7 @@ def test_build_timeseries_override():
     datasets = {"source_a": data_a, "source_b": data_b}
 
     # The combined m1 timeseries is copied from the timeseries in source_b; source_a is not used for m1
-    combined, provenance = _build_data_and_provenance(
-        {"m1": ["source_a", "source_b"]}, datasets, override=Override.BY_TIMESERIES
-    )
+    combined, provenance = _build_data_and_provenance({"m1": ["source_a", "source_b"]}, datasets,)
     assert combined.loc["97123", "m1"].replace({np.nan: None}).tolist() == [None, 2, None]
     assert provenance.loc["97123", "m1"].replace({np.nan: None}).tolist() == [
         None,
@@ -199,26 +196,13 @@ def test_build_timeseries_override():
 
     # The combined m1 timeseries is the highest priority value for each date; source_b is higher priority for
     # both 2020-04-01 and 2020-04-02.
-    combined, provenance = _build_data_and_provenance(
-        {"m1": ["source_a", "source_b"]}, datasets, override=Override.BY_ROW
-    )
-    assert combined.loc["97123", "m1"].replace({np.nan: None}).tolist() == [None, 2, 3]
-    assert provenance.loc["97123", "m1"].tolist() == ["source_b", "source_b", "source_a"]
-
-    combined, provenance = _build_data_and_provenance(
-        {"m1": ["source_b", "source_a"]}, datasets, override=Override.BY_TIMESERIES
-    )
+    combined, provenance = _build_data_and_provenance({"m1": ["source_b", "source_a"]}, datasets)
     assert combined.loc["97123", "m1"].replace({np.nan: None}).tolist() == [1, None, 3]
     assert provenance.loc["97123", "m1"].replace({np.nan: None}).tolist() == [
         "source_a",
         None,
         "source_a",
     ]
-
-    combined, _ = _build_data_and_provenance(
-        {"m1": ["source_b", "source_a"]}, datasets, override=Override.BY_ROW
-    )
-    assert combined.loc["97123", "m1"].replace({np.nan: None}).tolist() == [1, None, 3]
 
 
 def test_build_and_and_provenance_missing_fips():
@@ -232,9 +216,7 @@ def test_build_and_and_provenance_missing_fips():
 
     # The combined m1 timeseries is copied from the timeseries in source_b; source_a is not used for m1
     combined, provenance = _build_data_and_provenance(
-        {"m1": ["source_a", "source_b"], "m2": ["source_a", "source_b"]},
-        datasets,
-        override=Override.BY_TIMESERIES,
+        {"m1": ["source_a", "source_b"], "m2": ["source_a", "source_b"]}, datasets
     )
     assert combined.loc["97444", "m1"].dropna().tolist() == [4]
     assert provenance.loc["97444", "m1"].dropna().tolist() == ["source_b"]

--- a/test/dataset_utils_test.py
+++ b/test/dataset_utils_test.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from covidactnow.datapublic.common_fields import COMMON_FIELDS_TIMESERIES_KEYS, CommonFields
 from libs.datasets import dataset_utils
-from libs.datasets.combined_datasets import _build_data_and_provenance, Override
+from libs.datasets.combined_datasets import _build_data_and_provenance
 from libs.datasets.dataset_utils import AggregationLevel
 import pytest
 
@@ -74,7 +74,6 @@ def read_csv_and_index_fips_date(csv_str: str) -> pd.DataFrame:
 
 
 def test_fill_fields_and_timeseries_from_column():
-    # Timeseries in existing_df and new_df are merged together.
     existing_df = read_csv_and_index_fips_date(
         "fips,state,aggregate_level,county,cnt,date,foo\n"
         "55005,ZZ,county,North County,1,2020-05-01,ab\n"
@@ -88,120 +87,26 @@ def test_fill_fields_and_timeseries_from_column():
         "fips,state,aggregate_level,county,cnt,date\n"
         "55006,ZZ,county,South County,44,2020-05-04\n"
         "55007,ZZ,county,West County,28,2020-05-03\n"
-        "55005,ZZ,county,North County,3,2020-05-03\n"
         "55,ZZ,state,Grand State,42,2020-05-02\n"
     )
 
     datasets = {"existing": existing_df, "new": new_df}
 
     result, _ = _build_data_and_provenance(
-        {"cnt": ["existing", "new"], "foo": ["existing"]}, datasets, Override.BY_TIMESERIES
+        {"cnt": ["existing", "new"], "foo": ["existing"]}, datasets
     )
 
     expected = read_csv_and_index_fips_date(
         "fips,state,aggregate_level,county,cnt,date,foo\n"
-        "55005,ZZ,county,North County,,2020-05-01,ab\n"
-        "55005,ZZ,county,North County,,2020-05-02,cd\n"
-        "55005,ZZ,county,North County,3,2020-05-03,ef\n"
+        "55005,ZZ,county,North County,1,2020-05-01,ab\n"
+        "55005,ZZ,county,North County,2,2020-05-02,cd\n"
+        "55005,ZZ,county,North County,,2020-05-03,ef\n"
         "55006,ZZ,county,South County,44,2020-05-04,gh\n"
         "55007,ZZ,county,West County,28,2020-05-03,\n"
         "55,ZZ,state,Grand State,,2020-05-01,ij\n"
         "55,ZZ,state,Grand State,42,2020-05-02,\n"
         "55,ZZ,state,Grand State,,2020-05-03,kl\n"
     )
-    assert to_dict(["fips", "date"], result) == to_dict(["fips", "date"], expected)
-
-
-def test_fill_fields_with_data_source():
-    existing_df = read_csv_and_index_fips(
-        "fips,state,aggregate_level,county,current_icu,preserved\n"
-        "55005,ZZ,county,North County,43,ab\n"
-        "55006,ZZ,county,South County,,cd\n"
-        "55,ZZ,state,Grand State,46,ef\n"
-    )
-    new_df = read_csv_and_index_fips(
-        "fips,state,aggregate_level,county,current_icu\n"
-        "55006,ZZ,county,South County,27\n"
-        "55007,ZZ,county,West County,28\n"
-        "55,ZZ,state,Grand State,64\n"
-    )
-
-    datasets = {"existing": existing_df, "new": new_df}
-
-    result, _ = _build_data_and_provenance(
-        {"current_icu": ["existing", "new"], "preserved": ["existing"]}, datasets, Override.BY_ROW
-    )
-
-    expected = read_csv_and_index_fips(
-        "fips,state,aggregate_level,county,current_icu,preserved\n"
-        "55005,ZZ,county,North County,43,ab\n"
-        "55006,ZZ,county,South County,27,cd\n"
-        "55007,ZZ,county,West County,28,\n"
-        "55,ZZ,state,Grand State,64,ef\n"
-    )
-
-    assert to_dict(["fips"], result) == to_dict(["fips"], expected)
-
-
-def test_fill_fields_with_data_source_nan_overwrite():
-    existing_df = read_csv_and_index_fips(
-        "fips,state,aggregate_level,county,current_icu,preserved\n"
-        "55,ZZ,state,Grand State,46,ef\n"
-    )
-    new_df = read_csv_and_index_fips(
-        "fips,state,aggregate_level,county,current_icu\n" "55,ZZ,state,Grand State,\n"
-    )
-
-    datasets = {"existing": existing_df, "new": new_df}
-
-    result, _ = _build_data_and_provenance(
-        {"current_icu": ["existing", "new"], "preserved": ["existing"]}, datasets, Override.BY_ROW
-    )
-
-    expected = read_csv_and_index_fips(
-        "fips,state,aggregate_level,county,current_icu,preserved\n" "55,ZZ,state,Grand State,,ef\n"
-    )
-
-    assert to_dict(["fips"], result) == to_dict(["fips"], expected)
-
-
-def test_fill_fields_with_data_source_timeseries():
-    # Timeseries in existing_df and new_df are merged together.
-    existing_df = read_csv_and_index_fips_date(
-        "fips,state,aggregate_level,county,cnt,date,foo\n"
-        "55005,ZZ,county,North County,1,2020-05-01,ab\n"
-        "55005,ZZ,county,North County,2,2020-05-02,cd\n"
-        "55005,ZZ,county,North County,,2020-05-03,ef\n"
-        "55006,ZZ,county,South County,4,2020-05-04,gh\n"
-        "55,ZZ,state,Grand State,41,2020-05-01,ij\n"
-        "55,ZZ,state,Grand State,43,2020-05-03,kl\n"
-    )
-    new_df = read_csv_and_index_fips_date(
-        "fips,state,aggregate_level,county,cnt,date\n"
-        "55006,ZZ,county,South County,44,2020-05-04\n"
-        "55007,ZZ,county,West County,28,2020-05-03\n"
-        "55005,ZZ,county,North County,3,2020-05-03\n"
-        "55,ZZ,state,Grand State,42,2020-05-02\n"
-    )
-
-    datasets = {"existing": existing_df, "new": new_df}
-
-    result, _ = _build_data_and_provenance(
-        {"cnt": ["existing", "new"], "foo": ["existing"]}, datasets, Override.BY_ROW
-    )
-
-    expected = read_csv_and_index_fips_date(
-        "fips,state,aggregate_level,county,cnt,date,foo\n"
-        "55005,ZZ,county,North County,1,2020-05-01,ab\n"
-        "55005,ZZ,county,North County,2,2020-05-02,cd\n"
-        "55005,ZZ,county,North County,3,2020-05-03,ef\n"
-        "55006,ZZ,county,South County,44,2020-05-04,gh\n"
-        "55007,ZZ,county,West County,28,2020-05-03,\n"
-        "55,ZZ,state,Grand State,41,2020-05-01,ij\n"
-        "55,ZZ,state,Grand State,42,2020-05-02,\n"
-        "55,ZZ,state,Grand State,43,2020-05-03,kl\n"
-    )
-
     assert to_dict(["fips", "date"], result) == to_dict(["fips", "date"], expected)
 
 
@@ -221,7 +126,7 @@ def test_fill_fields_with_data_source_add_column():
     datasets = {"existing": existing_df, "new": new_df}
 
     result, _ = _build_data_and_provenance(
-        {"current_icu": ["new"], "preserved": ["existing"]}, datasets, Override.BY_ROW
+        {"current_icu": ["new"], "preserved": ["existing"]}, datasets
     )
 
     expected = read_csv_and_index_fips(
@@ -244,7 +149,7 @@ def test_fill_fields_with_data_source_no_rows_input():
     datasets = {"existing": existing_df, "new": new_df}
 
     result, _ = _build_data_and_provenance(
-        {"current_icu": ["new"], "preserved": ["existing"]}, datasets, Override.BY_ROW
+        {"current_icu": ["new"], "preserved": ["existing"]}, datasets
     )
 
     expected = read_csv_and_index_fips(


### PR DESCRIPTION
* factors out _merge_field from combined_datasets._merge_data
* fixes 'Working field' log that included previous dataset name
* removes `combined_datasets.Override` since we seem to only use BY_TIMESERIES
