### PR TITLE
Pass around hospitalization data in a raw DataFrame

### DIFF
--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -15,7 +15,6 @@ import iminuit
 
 from libs.datasets import combined_datasets
 from libs import pipeline
-from libs.datasets.timeseries import OneRegionTimeseriesDataset
 
 from pyseir.inference import model_plotting
 from pyseir.models import suppression_policies

--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -51,7 +51,7 @@ class RegionalInput:
     def from_state_region(region: pipeline.Region) -> "RegionalInput":
         """Creates a RegionalInput for given state region."""
         assert region.is_state()
-        hospitalization_dataset = load_data.get_hospitalization_data().loc[region.location_id, :]
+        hospitalization_dataset = load_data.get_hospitalization_data_for_region(region)
         return RegionalInput(
             region=region,
             _combined_data=combined_datasets.RegionalData.from_region(region),
@@ -70,7 +70,7 @@ class RegionalInput:
         """
         assert region.is_county()
         assert state_fitter
-        hospitalization_dataset = load_data.get_hospitalization_data().loc[region.location_id, :]
+        hospitalization_dataset = load_data.get_hospitalization_data_for_region(region)
         return RegionalInput(
             region=region,
             _combined_data=combined_datasets.RegionalData.from_region(region),

--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -44,14 +44,14 @@ class RegionalInput:
     region: pipeline.Region
 
     _combined_data: combined_datasets.RegionalData
-    _hospitalization_dataset: OneRegionTimeseriesDataset
+    _hospitalization_dataset: pd.DataFrame
     _state_mle_fit_result: Optional[Mapping[str, Any]] = None
 
     @staticmethod
     def from_state_region(region: pipeline.Region) -> "RegionalInput":
         """Creates a RegionalInput for given state region."""
         assert region.is_state()
-        hospitalization_dataset = load_data.get_hospitalization_data().get_one_region(region)
+        hospitalization_dataset = load_data.get_hospitalization_data().loc[region.location_id, :]
         return RegionalInput(
             region=region,
             _combined_data=combined_datasets.RegionalData.from_region(region),
@@ -70,7 +70,7 @@ class RegionalInput:
         """
         assert region.is_county()
         assert state_fitter
-        hospitalization_dataset = load_data.get_hospitalization_data().get_one_region(region)
+        hospitalization_dataset = load_data.get_hospitalization_data().loc[region.location_id, :]
         return RegionalInput(
             region=region,
             _combined_data=combined_datasets.RegionalData.from_region(region),

--- a/pyseir/inference/model_fitter.py
+++ b/pyseir/inference/model_fitter.py
@@ -44,18 +44,18 @@ class RegionalInput:
     region: pipeline.Region
 
     _combined_data: combined_datasets.RegionalData
-    _hospitalization_dataset: pd.DataFrame
+    _hospitalization_df: pd.DataFrame
     _state_mle_fit_result: Optional[Mapping[str, Any]] = None
 
     @staticmethod
     def from_state_region(region: pipeline.Region) -> "RegionalInput":
         """Creates a RegionalInput for given state region."""
         assert region.is_state()
-        hospitalization_dataset = load_data.get_hospitalization_data_for_region(region)
+        hospitalization_df = load_data.get_hospitalization_data_for_region(region)
         return RegionalInput(
             region=region,
             _combined_data=combined_datasets.RegionalData.from_region(region),
-            _hospitalization_dataset=hospitalization_dataset,
+            _hospitalization_df=hospitalization_df,
         )
 
     @staticmethod
@@ -70,12 +70,12 @@ class RegionalInput:
         """
         assert region.is_county()
         assert state_fitter
-        hospitalization_dataset = load_data.get_hospitalization_data_for_region(region)
+        hospitalization_df = load_data.get_hospitalization_data_for_region(region)
         return RegionalInput(
             region=region,
             _combined_data=combined_datasets.RegionalData.from_region(region),
             _state_mle_fit_result=state_fitter.fit_results,
-            _hospitalization_dataset=hospitalization_dataset,
+            _hospitalization_df=hospitalization_df,
         )
 
     @property
@@ -96,7 +96,7 @@ class RegionalInput:
         self, t0: datetime, category: HospitalizationCategory = HospitalizationCategory.HOSPITALIZED
     ) -> Tuple[np.array, np.array, HospitalizationDataType]:
         return load_data.calculate_hospitalization_data(
-            self._hospitalization_dataset, t0, category=category
+            self._hospitalization_df, t0, category=category
         )
 
     @property

--- a/pyseir/load_data.py
+++ b/pyseir/load_data.py
@@ -195,13 +195,15 @@ def calculate_new_case_data_by_region(
 @lru_cache(maxsize=None)
 def get_hospitalization_data() -> pd.DataFrame:
     """
+    Creates a DataFrame of hospitalization timeseries with non-unique LOCATION_ID index.
+
     Since we're using this data for hospitalized data only, only returning
     values with hospitalization data.  I think as the use cases of this data source
     expand, we may not want to drop. For context, as of 4/8 607/1821 rows contained
     hospitalization data.
     """
-    # TODO(tom): Change this function to accept the combined TimeseriesDataset as a parameter
-    # and call it once so the cache can be removed.
+    # TODO(tom): Change this function to accept the combined data as a parameter and call it once
+    # so the cache can be removed.
     data = combined_datasets.load_us_timeseries_dataset().data  # processing rows, ignoring indexes
     has_current_hospital = data[CommonFields.CURRENT_HOSPITALIZED].notnull()
     has_cumulative_hospital = data[CommonFields.CUMULATIVE_HOSPITALIZED].notnull()
@@ -230,7 +232,7 @@ def calculate_hospitalization_data(
     tiny so we just make downstream easier to work with by clipping.
 
     Args:
-    hospitalization_df: one region of data returned by `get_hospitalization_data`
+    hospitalization_df: one region of data returned by `get_hospitalization_data_for_region`
     t0: Datetime to offset by.
     category: HospitalizationCategory
 

--- a/pyseir/load_data.py
+++ b/pyseir/load_data.py
@@ -20,7 +20,6 @@ import numpy as np
 from covidactnow.datapublic.common_fields import CommonFields
 from libs import pipeline
 from libs.datasets import combined_datasets
-from libs.datasets.timeseries import MultiRegionTimeseriesDataset
 from libs.datasets.timeseries import OneRegionTimeseriesDataset
 from libs.datasets.timeseries import TimeseriesDataset
 import pyseir.utils

--- a/pyseir/load_data.py
+++ b/pyseir/load_data.py
@@ -18,6 +18,7 @@ import pandas as pd
 import numpy as np
 
 from covidactnow.datapublic.common_fields import CommonFields
+from libs import pipeline
 from libs.datasets import combined_datasets
 from libs.datasets.timeseries import MultiRegionTimeseriesDataset
 from libs.datasets.timeseries import OneRegionTimeseriesDataset
@@ -210,6 +211,12 @@ def get_hospitalization_data() -> pd.DataFrame:
         .set_index(CommonFields.LOCATION_ID)
         .sort_index()
     )
+
+
+def get_hospitalization_data_for_region(region: pipeline.Region) -> pd.DataFrame:
+    """Returns a DataFrame of data in region or an empty DataFrame"""
+    all_data = get_hospitalization_data()
+    return all_data.loc[all_data.index.intersection([region.location_id])]
 
 
 def calculate_hospitalization_data(

--- a/test/pyseir/inference/model_fitter_test.py
+++ b/test/pyseir/inference/model_fitter_test.py
@@ -1,7 +1,11 @@
+import dataclasses
+from typing import Optional
+
 import pytest
 
 from libs import pipeline
 from pyseir.inference import model_fitter
+import pandas as pd
 
 # turns all warnings into errors for this module
 pytestmark = pytest.mark.filterwarnings("error", "ignore::libs.pipeline.BadFipsWarning")
@@ -39,10 +43,17 @@ def test_get_pyseir_fitter_initial_conditions_none():
         "test_fraction",
         "hosp_fraction",
     ]
+    # A mock of model_fitter.ModelFitter
+    MockModelFitter = dataclasses.make_dataclass(
+        "MockModelFitter",
+        [("fit_results", Optional[pd.DataFrame], dataclasses.field(default=None))],
+    )
+    mock_state_fitter = MockModelFitter()
 
-    region = pipeline.Region.from_fips("99")
-    mapping = model_fitter.RegionalInput.from_state_region(
-        region
+    # Loving County, Texas (population 169) does not have initial conditions in our data file
+    region = pipeline.Region.from_fips("48301")
+    mapping = model_fitter.RegionalInput.from_substate_region(
+        region, state_fitter=mock_state_fitter,
     ).get_pyseir_fitter_initial_conditions(params)
 
     assert mapping == {}

--- a/test/pyseir/load_data_test.py
+++ b/test/pyseir/load_data_test.py
@@ -1,18 +1,29 @@
 from datetime import datetime
 
+import pytest
+
 from libs.pipeline import Region
 from pyseir import load_data
 from pyseir.load_data import HospitalizationCategory
 from pyseir.load_data import HospitalizationDataType
 
+# turns all warnings into errors for this module
+pytestmark = pytest.mark.filterwarnings("error", "ignore::libs.pipeline.BadFipsWarning")
+
 
 def test_load_hospitalization_data():
     t0 = datetime(year=2020, month=1, day=1)
     region = Region.from_fips("33")
-    hospitalization_df = load_data.get_hospitalization_data().loc[region.location_id, :]
+    hospitalization_df = load_data.get_hospitalization_data_for_region(region)
 
     _, _, hosp_type = load_data.calculate_hospitalization_data(
         hospitalization_df, t0, category=HospitalizationCategory.ICU
     )
     # Double check that data loads and it went throughh the cumulative hosps
     assert hosp_type is HospitalizationDataType.CUMULATIVE_HOSPITALIZATIONS
+
+
+def test_load_hospitalization_data_not_found():
+    region = Region.from_fips("98")
+    hospitalization_df = load_data.get_hospitalization_data_for_region(region)
+    assert hospitalization_df.empty

--- a/test/pyseir/load_data_test.py
+++ b/test/pyseir/load_data_test.py
@@ -9,10 +9,10 @@ from pyseir.load_data import HospitalizationDataType
 def test_load_hospitalization_data():
     t0 = datetime(year=2020, month=1, day=1)
     region = Region.from_fips("33")
-    hospitalization_dataset = load_data.get_hospitalization_data().get_one_region(region)
+    hospitalization_df = load_data.get_hospitalization_data().loc[region.location_id, :]
 
     _, _, hosp_type = load_data.calculate_hospitalization_data(
-        hospitalization_dataset, t0, category=HospitalizationCategory.ICU
+        hospitalization_df, t0, category=HospitalizationCategory.ICU
     )
     # Double check that data loads and it went throughh the cumulative hosps
     assert hosp_type is HospitalizationDataType.CUMULATIVE_HOSPITALIZATIONS


### PR DESCRIPTION
This PR changes get_hospitalization_data to return a raw DataFrame instead of MultiRegionTimeseriesDataset. This reduces the number of ways MultiRegionTimeseriesDataset is used, making changing it easier.

Change `test_get_pyseir_fitter_initial_conditions_none` to use a real FIPS so a future change is easier.