### PR TITLE
Adding api auth

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -29,7 +29,8 @@ def find_public_model_classes(include_api_v2: bool = False) -> List[Type[base_mo
     # This allows us to then enumerate base_model.APIBaseModel.__subclasses__
     # to find all our model classes.
     root = pathlib.Path(__file__).parent
-    for path in root.rglob("*.py"):
+
+    for path in root.glob("*.py"):
         relative = path.relative_to(root.parent)
         module_name = str(relative).replace("\\", "/").replace("/", ".")[:-3]
 

--- a/api/awsauth/.gitignore
+++ b/api/awsauth/.gitignore
@@ -1,0 +1,21 @@
+# Distribution / packaging
+.Python
+*.pyc
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Serverless directories
+.serverless

--- a/api/awsauth/README.md
+++ b/api/awsauth/README.md
@@ -1,0 +1,19 @@
+# API Authentication Docs
+
+## Setup
+
+We deploy the lambda functions using the [Serverless Framework](https://www.serverless.com/framework/docs/).
+
+Install serverless:
+
+```
+npm install -g serverless
+```
+
+
+## Deploy
+
+Currently we have a `dev` and `prod` stage.
+```
+sls deploy --stage {dev,prod}
+```

--- a/api/awsauth/api_key_repo.py
+++ b/api/awsauth/api_key_repo.py
@@ -1,0 +1,65 @@
+from typing import Optional, Dict, Any
+import os
+
+import dynamo_client
+
+
+API_KEY_TABLE_NAME = os.environ["API_KEYS_TABLE"]
+API_KEY_INDEX_NAME = "apiKeys"
+
+
+class APIKeyRepo:
+    """Logic for handling API Key functionality."""
+
+    @staticmethod
+    def add_api_key(email: str, api_key: str):
+        """Adds an email and api_key to database.
+
+        Args:
+            email: Email Address.
+            api_key: API Key to add.
+        """
+        # TODO: Client should only be initialized once
+        client = dynamo_client.DynamoDBClient()
+        obj = {"email": email, "api_key": api_key}
+        client.put_item(API_KEY_TABLE_NAME, obj)
+
+    @staticmethod
+    def get_api_key(email) -> Optional[str]:
+        """Fetches API Key for email, returning none if not found.
+
+        Args:
+            email: Email address.
+
+        Returns: API Key if exists, None if missing.
+        """
+        # TODO: Client should only be initialized once
+        client = dynamo_client.DynamoDBClient()
+
+        key = {"email": email}
+        api_key_item = client.get_item(API_KEY_TABLE_NAME, key)
+
+        if not api_key_item:
+            return None
+
+        return api_key_item["api_key"]
+
+    @staticmethod
+    def get_record_for_api_key(api_key) -> Optional[Dict[str, Any]]:
+        """Fetches record for API Key.
+
+        Args:
+            api_key: API Key to query.
+
+        Returns: Dict if exists, None if not found.
+        """
+        # TODO: Client should only be initialized once
+        client = dynamo_client.DynamoDBClient()
+        items = client.query_index(API_KEY_TABLE_NAME, API_KEY_INDEX_NAME, "api_key", api_key)
+        if not items:
+            return None
+
+        if len(items) > 1:
+            raise Exception("Multiple emails found for API key")
+
+        return items[0]

--- a/api/awsauth/auth_app.py
+++ b/api/awsauth/auth_app.py
@@ -1,0 +1,315 @@
+from typing import Dict, Any
+import os
+import re
+import uuid
+import json
+import logging
+import boto3
+from boto3.dynamodb.conditions import Key
+
+_logger = logging.getLogger(__name__)
+
+API_KEY_TABLE_NAME = os.environ["API_KEYS_TABLE"]
+API_KEY_INDEX_NAME = "apiKeys"
+
+
+class DynamoDBClient:
+    def __init__(self, client=None):
+        self._client = client or boto3.resource("dynamodb")
+
+    def get_item(self, table, key):
+        table = self._client.Table(table)
+        result = table.get_item(Key=key)
+
+        if "Item" not in result:
+            return None
+
+        return result["Item"]
+
+    def query_index(self, table, index, key, value):
+        table = self._client.Table(table)
+
+        result = table.query(IndexName=index, KeyConditionExpression=Key(key).eq(value))
+        return result["Items"]
+
+    def put_item(self, table: str, item: Dict[str, Any]):
+        table = self._client.Table(table)
+        return table.put_item(Item=item)
+
+
+class APIKeyRepo:
+    @staticmethod
+    def add_api_key(email, api_key):
+        client = DynamoDBClient()
+        obj = {"email": email, "api_key": api_key}
+        client.put_item(API_KEY_TABLE_NAME, obj)
+
+    @staticmethod
+    def get_api_key(email):
+        client = DynamoDBClient()
+
+        key = {"email": email}
+        api_key_item = client.get_item(API_KEY_TABLE_NAME, key)
+
+        if not api_key_item:
+            return None
+
+        return api_key_item["api_key"]
+
+    @staticmethod
+    def get_record_for_api_key(api_key):
+        client = DynamoDBClient()
+        items = client.query_index(API_KEY_TABLE_NAME, API_KEY_INDEX_NAME, "api_key", api_key)
+        if not items:
+            return None
+
+        if len(items) > 1:
+            raise Exception("Multiple emails found for API key")
+
+        return items[0]
+
+
+class InvalidAPIKey(Exception):
+    def __init__(self, api_key):
+        super().__init__(f"Invalid API Key: {api_key}")
+        self.api_key = api_key
+
+
+def _create_api_key(email: str) -> str:
+    return uuid.uuid4().hex
+
+
+def _get_or_create_api_key(email):
+    api_key = APIKeyRepo.get_api_key(email)
+    if api_key:
+        return api_key
+
+    _logger.info(f"No API Key found for email {email}, creating new key")
+
+    api_key = _create_api_key(email)
+    APIKeyRepo.add_api_key(email, api_key)
+
+    return api_key
+
+
+def _check_api_key(api_key):
+    if not APIKeyRepo.get_record_for_api_key(api_key):
+        raise InvalidAPIKey(api_key)
+
+
+def register(event, context):
+
+    if not "email" in event:
+        raise ValueError("Missing email parameter")
+
+    email = event["email"]
+    api_key = _get_or_create_api_key(email)
+    body = {"api_key": api_key, "email": email}
+
+    response = {"statusCode": 200, "body": json.dumps(body)}
+
+    return response
+
+    # Use this code if you don't use the http event with the LAMBDA-PROXY
+    # integration
+    """
+    return {
+        "message": "Go Serverless v1.0! Your function executed successfully!",
+        "event": event
+    }
+    """
+
+
+def check_api_key(event, context):
+    if not event["queryStringParameters"]["apiKey"]:
+        raise Exception("Must have api key")
+    api_key = event["queryStringParameters"]["apiKey"]
+    record = APIKeyRepo.get_record_for_api_key(api_key)
+    if not record:
+        raise InvalidAPIKey(api_key)
+
+    principalId = record["email"]
+
+    tmp = event["methodArn"].split(":")
+    apiGatewayArnTmp = tmp[5].split("/")
+    awsAccountId = tmp[4]
+    policy = AuthPolicy(principalId, awsAccountId)
+    policy.restApiId = apiGatewayArnTmp[0]
+    policy.region = tmp[3]
+    policy.stage = apiGatewayArnTmp[1]
+    policy.allowAllMethods()
+
+    return policy.build()
+
+    # event.get('queryStringParameters')
+    # body = {
+    #     "message": "Go Serverless v1.0! Your function executed successfully!",
+    #     "input": event
+    # }
+    response = {"statusCode": 200, "body": json.dumps(body)}
+
+    return response
+
+
+class HttpVerb:
+    GET = "GET"
+    POST = "POST"
+    PUT = "PUT"
+    PATCH = "PATCH"
+    HEAD = "HEAD"
+    DELETE = "DELETE"
+    OPTIONS = "OPTIONS"
+    ALL = "*"
+
+
+class AuthPolicy(object):
+    awsAccountId = ""
+    """The AWS account id the policy will be generated for. This is used to create the method ARNs."""
+    principalId = ""
+    """The principal used for the policy, this should be a unique identifier for the end user."""
+    version = "2012-10-17"
+    """The policy version used for the evaluation. This should always be '2012-10-17'"""
+    pathRegex = "^[/.a-zA-Z0-9-\*]+$"
+    """The regular expression used to validate resource paths for the policy"""
+
+    """these are the internal lists of allowed and denied methods. These are lists
+    of objects and each object has 2 properties: A resource ARN and a nullable
+    conditions statement.
+    the build method processes these lists and generates the approriate
+    statements for the final policy"""
+    allowMethods = []
+    denyMethods = []
+
+    restApiId = "*"
+    """The API Gateway API id. By default this is set to '*'"""
+    region = "*"
+    """The region where the API is deployed. By default this is set to '*'"""
+    stage = "*"
+    """The name of the stage used in the policy. By default this is set to '*'"""
+
+    def __init__(self, principal, awsAccountId):
+        self.awsAccountId = awsAccountId
+        self.principalId = principal
+        self.allowMethods = []
+        self.denyMethods = []
+
+    def _addMethod(self, effect, verb, resource, conditions):
+        """Adds a method to the internal lists of allowed or denied methods. Each object in
+        the internal list contains a resource ARN and a condition statement. The condition
+        statement can be null."""
+        if verb != "*" and not hasattr(HttpVerb, verb):
+            raise NameError("Invalid HTTP verb " + verb + ". Allowed verbs in HttpVerb class")
+        resourcePattern = re.compile(self.pathRegex)
+        if not resourcePattern.match(resource):
+            raise NameError(
+                "Invalid resource path: " + resource + ". Path should match " + self.pathRegex
+            )
+
+        if resource[:1] == "/":
+            resource = resource[1:]
+
+        resourceArn = (
+            "arn:aws:execute-api:"
+            + self.region
+            + ":"
+            + self.awsAccountId
+            + ":"
+            + self.restApiId
+            + "/"
+            + self.stage
+            + "/"
+            + verb
+            + "/"
+            + resource
+        )
+
+        if effect.lower() == "allow":
+            self.allowMethods.append({"resourceArn": resourceArn, "conditions": conditions})
+        elif effect.lower() == "deny":
+            self.denyMethods.append({"resourceArn": resourceArn, "conditions": conditions})
+
+    def _getEmptyStatement(self, effect):
+        """Returns an empty statement object prepopulated with the correct action and the
+        desired effect."""
+        statement = {
+            "Action": "execute-api:Invoke",
+            "Effect": effect[:1].upper() + effect[1:].lower(),
+            "Resource": [],
+        }
+
+        return statement
+
+    def _getStatementForEffect(self, effect, methods):
+        """This function loops over an array of objects containing a resourceArn and
+        conditions statement and generates the array of statements for the policy."""
+        statements = []
+
+        if len(methods) > 0:
+            statement = self._getEmptyStatement(effect)
+
+            for curMethod in methods:
+                if curMethod["conditions"] is None or len(curMethod["conditions"]) == 0:
+                    statement["Resource"].append(curMethod["resourceArn"])
+                else:
+                    conditionalStatement = self._getEmptyStatement(effect)
+                    conditionalStatement["Resource"].append(curMethod["resourceArn"])
+                    conditionalStatement["Condition"] = curMethod["conditions"]
+                    statements.append(conditionalStatement)
+
+            statements.append(statement)
+
+        return statements
+
+    def allowAllMethods(self):
+        """Adds a '*' allow to the policy to authorize access to all methods of an API"""
+        self._addMethod("Allow", HttpVerb.ALL, "*", [])
+
+    def denyAllMethods(self):
+        """Adds a '*' allow to the policy to deny access to all methods of an API"""
+        self._addMethod("Deny", HttpVerb.ALL, "*", [])
+
+    def allowMethod(self, verb, resource):
+        """Adds an API Gateway method (Http verb + Resource path) to the list of allowed
+        methods for the policy"""
+        self._addMethod("Allow", verb, resource, [])
+
+    def denyMethod(self, verb, resource):
+        """Adds an API Gateway method (Http verb + Resource path) to the list of denied
+        methods for the policy"""
+        self._addMethod("Deny", verb, resource, [])
+
+    def allowMethodWithConditions(self, verb, resource, conditions):
+        """Adds an API Gateway method (Http verb + Resource path) to the list of allowed
+        methods and includes a condition for the policy statement. More on AWS policy
+        conditions here: http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#Condition"""
+        self._addMethod("Allow", verb, resource, conditions)
+
+    def denyMethodWithConditions(self, verb, resource, conditions):
+        """Adds an API Gateway method (Http verb + Resource path) to the list of denied
+        methods and includes a condition for the policy statement. More on AWS policy
+        conditions here: http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#Condition"""
+        self._addMethod("Deny", verb, resource, conditions)
+
+    def build(self):
+        """Generates the policy document based on the internal lists of allowed and denied
+        conditions. This will generate a policy with two main statements for the effect:
+        one statement for Allow and one statement for Deny.
+        Methods that includes conditions will have their own statement in the policy."""
+        if (self.allowMethods is None or len(self.allowMethods) == 0) and (
+            self.denyMethods is None or len(self.denyMethods) == 0
+        ):
+            raise NameError("No statements defined for the policy")
+
+        policy = {
+            "principalId": self.principalId,
+            "policyDocument": {"Version": self.version, "Statement": []},
+        }
+
+        policy["policyDocument"]["Statement"].extend(
+            self._getStatementForEffect("Allow", self.allowMethods)
+        )
+        policy["policyDocument"]["Statement"].extend(
+            self._getStatementForEffect("Deny", self.denyMethods)
+        )
+
+        return policy

--- a/api/awsauth/auth_app.py
+++ b/api/awsauth/auth_app.py
@@ -120,196 +120,31 @@ def register(event, context):
     """
 
 
+def _generate_accept_policy(user_record: dict, method_arn):
+    *first, last = method_arn.split("/")
+    method_arn = "/".join([*first, "*"])
+    return {
+        "principalId": user_record["email"],
+        "policyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+                {"Action": "execute-api:Invoke", "Effect": "Allow", "Resource": method_arn}
+            ],
+        },
+        "usageIdentifierKey": user_record["api_key"],
+    }
+
+
 def check_api_key(event, context):
     if not event["queryStringParameters"]["apiKey"]:
         raise Exception("Must have api key")
+
     api_key = event["queryStringParameters"]["apiKey"]
+
     record = APIKeyRepo.get_record_for_api_key(api_key)
     if not record:
         raise InvalidAPIKey(api_key)
 
-    principalId = record["email"]
+    policy = _generate_accept_policy(record, event["methodArn"])
 
-    tmp = event["methodArn"].split(":")
-    apiGatewayArnTmp = tmp[5].split("/")
-    awsAccountId = tmp[4]
-    policy = AuthPolicy(principalId, awsAccountId)
-    policy.restApiId = apiGatewayArnTmp[0]
-    policy.region = tmp[3]
-    policy.stage = apiGatewayArnTmp[1]
-    policy.allowAllMethods()
-
-    return policy.build()
-
-    # event.get('queryStringParameters')
-    # body = {
-    #     "message": "Go Serverless v1.0! Your function executed successfully!",
-    #     "input": event
-    # }
-    response = {"statusCode": 200, "body": json.dumps(body)}
-
-    return response
-
-
-class HttpVerb:
-    GET = "GET"
-    POST = "POST"
-    PUT = "PUT"
-    PATCH = "PATCH"
-    HEAD = "HEAD"
-    DELETE = "DELETE"
-    OPTIONS = "OPTIONS"
-    ALL = "*"
-
-
-class AuthPolicy(object):
-    awsAccountId = ""
-    """The AWS account id the policy will be generated for. This is used to create the method ARNs."""
-    principalId = ""
-    """The principal used for the policy, this should be a unique identifier for the end user."""
-    version = "2012-10-17"
-    """The policy version used for the evaluation. This should always be '2012-10-17'"""
-    pathRegex = "^[/.a-zA-Z0-9-\*]+$"
-    """The regular expression used to validate resource paths for the policy"""
-
-    """these are the internal lists of allowed and denied methods. These are lists
-    of objects and each object has 2 properties: A resource ARN and a nullable
-    conditions statement.
-    the build method processes these lists and generates the approriate
-    statements for the final policy"""
-    allowMethods = []
-    denyMethods = []
-
-    restApiId = "*"
-    """The API Gateway API id. By default this is set to '*'"""
-    region = "*"
-    """The region where the API is deployed. By default this is set to '*'"""
-    stage = "*"
-    """The name of the stage used in the policy. By default this is set to '*'"""
-
-    def __init__(self, principal, awsAccountId):
-        self.awsAccountId = awsAccountId
-        self.principalId = principal
-        self.allowMethods = []
-        self.denyMethods = []
-
-    def _addMethod(self, effect, verb, resource, conditions):
-        """Adds a method to the internal lists of allowed or denied methods. Each object in
-        the internal list contains a resource ARN and a condition statement. The condition
-        statement can be null."""
-        if verb != "*" and not hasattr(HttpVerb, verb):
-            raise NameError("Invalid HTTP verb " + verb + ". Allowed verbs in HttpVerb class")
-        resourcePattern = re.compile(self.pathRegex)
-        if not resourcePattern.match(resource):
-            raise NameError(
-                "Invalid resource path: " + resource + ". Path should match " + self.pathRegex
-            )
-
-        if resource[:1] == "/":
-            resource = resource[1:]
-
-        resourceArn = (
-            "arn:aws:execute-api:"
-            + self.region
-            + ":"
-            + self.awsAccountId
-            + ":"
-            + self.restApiId
-            + "/"
-            + self.stage
-            + "/"
-            + verb
-            + "/"
-            + resource
-        )
-
-        if effect.lower() == "allow":
-            self.allowMethods.append({"resourceArn": resourceArn, "conditions": conditions})
-        elif effect.lower() == "deny":
-            self.denyMethods.append({"resourceArn": resourceArn, "conditions": conditions})
-
-    def _getEmptyStatement(self, effect):
-        """Returns an empty statement object prepopulated with the correct action and the
-        desired effect."""
-        statement = {
-            "Action": "execute-api:Invoke",
-            "Effect": effect[:1].upper() + effect[1:].lower(),
-            "Resource": [],
-        }
-
-        return statement
-
-    def _getStatementForEffect(self, effect, methods):
-        """This function loops over an array of objects containing a resourceArn and
-        conditions statement and generates the array of statements for the policy."""
-        statements = []
-
-        if len(methods) > 0:
-            statement = self._getEmptyStatement(effect)
-
-            for curMethod in methods:
-                if curMethod["conditions"] is None or len(curMethod["conditions"]) == 0:
-                    statement["Resource"].append(curMethod["resourceArn"])
-                else:
-                    conditionalStatement = self._getEmptyStatement(effect)
-                    conditionalStatement["Resource"].append(curMethod["resourceArn"])
-                    conditionalStatement["Condition"] = curMethod["conditions"]
-                    statements.append(conditionalStatement)
-
-            statements.append(statement)
-
-        return statements
-
-    def allowAllMethods(self):
-        """Adds a '*' allow to the policy to authorize access to all methods of an API"""
-        self._addMethod("Allow", HttpVerb.ALL, "*", [])
-
-    def denyAllMethods(self):
-        """Adds a '*' allow to the policy to deny access to all methods of an API"""
-        self._addMethod("Deny", HttpVerb.ALL, "*", [])
-
-    def allowMethod(self, verb, resource):
-        """Adds an API Gateway method (Http verb + Resource path) to the list of allowed
-        methods for the policy"""
-        self._addMethod("Allow", verb, resource, [])
-
-    def denyMethod(self, verb, resource):
-        """Adds an API Gateway method (Http verb + Resource path) to the list of denied
-        methods for the policy"""
-        self._addMethod("Deny", verb, resource, [])
-
-    def allowMethodWithConditions(self, verb, resource, conditions):
-        """Adds an API Gateway method (Http verb + Resource path) to the list of allowed
-        methods and includes a condition for the policy statement. More on AWS policy
-        conditions here: http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#Condition"""
-        self._addMethod("Allow", verb, resource, conditions)
-
-    def denyMethodWithConditions(self, verb, resource, conditions):
-        """Adds an API Gateway method (Http verb + Resource path) to the list of denied
-        methods and includes a condition for the policy statement. More on AWS policy
-        conditions here: http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#Condition"""
-        self._addMethod("Deny", verb, resource, conditions)
-
-    def build(self):
-        """Generates the policy document based on the internal lists of allowed and denied
-        conditions. This will generate a policy with two main statements for the effect:
-        one statement for Allow and one statement for Deny.
-        Methods that includes conditions will have their own statement in the policy."""
-        if (self.allowMethods is None or len(self.allowMethods) == 0) and (
-            self.denyMethods is None or len(self.denyMethods) == 0
-        ):
-            raise NameError("No statements defined for the policy")
-
-        policy = {
-            "principalId": self.principalId,
-            "policyDocument": {"Version": self.version, "Statement": []},
-        }
-
-        policy["policyDocument"]["Statement"].extend(
-            self._getStatementForEffect("Allow", self.allowMethods)
-        )
-        policy["policyDocument"]["Statement"].extend(
-            self._getStatementForEffect("Deny", self.denyMethods)
-        )
-
-        return policy
+    return policy

--- a/api/awsauth/auth_app.py
+++ b/api/awsauth/auth_app.py
@@ -1,4 +1,5 @@
 import uuid
+import re
 import json
 import logging
 
@@ -8,10 +9,19 @@ from api_key_repo import APIKeyRepo
 _logger = logging.getLogger(__name__)
 
 
+EMAIL_REGEX = "^[a-z0-9]+[\._]?[a-z0-9]+[@]\w+[.]\w{2,3}$"
+
+
 class InvalidAPIKey(Exception):
     def __init__(self, api_key):
         super().__init__(f"Invalid API Key: {api_key}")
         self.api_key = api_key
+
+
+class InvalidEmail(Exception):
+    def __init__(self, email):
+        super().__init__(f"Invalid email: {email}")
+        self.email = email
 
 
 def _create_api_key(email: str) -> str:
@@ -42,6 +52,10 @@ def register(event, context):
         raise ValueError("Missing email parameter")
 
     email = event["email"]
+
+    if not re.match(EMAIL_REGEX, email):
+        raise InvalidEmail(email)
+
     api_key = _get_or_create_api_key(email)
     body = {"api_key": api_key, "email": email}
 

--- a/api/awsauth/dynamo_client.py
+++ b/api/awsauth/dynamo_client.py
@@ -1,0 +1,53 @@
+from typing import Dict, List, Any, Optional
+
+import boto3
+from boto3.dynamodb.conditions import Key
+
+
+class DynamoDBClient:
+    def __init__(self, client=None):
+        self._client = client or boto3.resource("dynamodb")
+
+    def get_item(self, table: str, key: Dict[str, Any]) -> Optional[Dict[Any, Any]]:
+        """Get single item from table.
+
+        Args:
+            table: Table name
+            key: Key to query table with. Should be in form {'<attribute name>': <attribute value>}.
+
+        Returns: Row if exists, None if missing.
+        """
+        table = self._client.Table(table)
+        result = table.get_item(Key=key)
+
+        if "Item" not in result:
+            return None
+
+        return result["Item"]
+
+    def query_index(self, table: str, index: str, key: str, value: Any) -> List[dict]:
+        """Query index for items where `key` == `value`.
+
+        Args:
+            table: Table name.
+            index: Index name.
+            key: Key to query.
+            value: value.
+
+        Returns: List of rows matching query.
+        """
+        table = self._client.Table(table)
+
+        result = table.query(IndexName=index, KeyConditionExpression=Key(key).eq(value))
+        return result["Items"]
+
+    def put_item(self, table: str, item: Dict[str, Any]) -> None:
+        """Add item to table.
+
+        Args:
+            table: Table name.
+            item: Item to add in form {'<attribute_name>': <attribute_value>, ...}.
+
+        """
+        table = self._client.Table(table)
+        table.put_item(Item=item)

--- a/api/awsauth/serverless.yml
+++ b/api/awsauth/serverless.yml
@@ -93,5 +93,7 @@ resources:
          Projection:
            ProjectionType: ALL
          ProvisionedThroughput:
-           ReadCapacityUnits: '5'
-           WriteCapacityUnits: '5'
+           ReadCapacityUnits: '1'
+           WriteCapacityUnits: '1'
+
+  # TODO: Add API Gateway cloudformation

--- a/api/awsauth/serverless.yml
+++ b/api/awsauth/serverless.yml
@@ -1,0 +1,138 @@
+# Welcome to Serverless!
+#
+# This file is the main config file for your service.
+# It's very minimal at this point and uses default values.
+# You can always add more config options for more control.
+# We've included some commented out config examples here.
+# Just uncomment any of them to get that config option.
+#
+# For full config options, check the docs:
+#    docs.serverless.com
+#
+# Happy Coding!
+
+service: awsauth
+# app and org for use with dashboard.serverless.com
+#app: your-app-name
+#org: your-org-name
+
+# You can pin your service to only deploy with a specific Serverless version
+# Check out our docs for more details
+frameworkVersion: '2'
+
+
+custom:
+  tableName: 'can-api-keys-${self:provider.stage}'
+
+provider:
+  name: aws
+  runtime: python3.7
+
+# you can overwrite defaults here
+#  stage: dev
+#  region: us-east-1
+
+
+  iamRoleStatements:
+    - Effect: Allow
+      Action:
+        - dynamodb:Query
+        - dynamodb:Scan
+        - dynamodb:GetItem
+        - dynamodb:PutItem
+        - dynamodb:UpdateItem
+        - dynamodb:DeleteItem
+      Resource:
+        - { "Fn::GetAtt": ["APIKeysDynamoDBTable", "Arn" ] }
+    - Effect: Allow
+      Action:
+        - dynamodb:Query
+        - dynamodb:Scan
+      Resource: "arn:aws:dynamodb:${self:provider.region}:*:table/${self:provider.environment.API_KEYS_TABLE}/index/*"
+
+  environment:
+    API_KEYS_TABLE: ${self:custom.tableName}
+
+
+# you can add packaging information here
+#package:
+#  include:
+#    - include-me.py
+#    - include-me-dir/**
+#  exclude:
+#    - exclude-me.py
+#    - exclude-me-dir/**
+
+functions:
+  canAPIRegisterAPIKey:
+    handler: auth_app.register
+  canAPICheckApiKey:
+    handler: auth_app.check_api_key
+#    The following are a few example events you can configure
+#    NOTE: Please make sure to change your handler code to work with those events
+#    Check the event documentation for details
+#    events:
+#      - http:
+#          path: users/create
+#          method: get
+#      - websocket: $connect
+#      - s3: ${env:BUCKET}
+#      - schedule: rate(10 minutes)
+#      - sns: greeter-topic
+#      - stream: arn:aws:dynamodb:region:XXXXXX:table/foo/stream/1970-01-01T00:00:00.000
+#      - alexaSkill: amzn1.ask.skill.xx-xx-xx-xx
+#      - alexaSmartHome: amzn1.ask.skill.xx-xx-xx-xx
+#      - iot:
+#          sql: "SELECT * FROM 'some_topic'"
+#      - cloudwatchEvent:
+#          event:
+#            source:
+#              - "aws.ec2"
+#            detail-type:
+#              - "EC2 Instance State-change Notification"
+#            detail:
+#              state:
+#                - pending
+#      - cloudwatchLog: '/aws/lambda/hello'
+#      - cognitoUserPool:
+#          pool: MyUserPool
+#          trigger: PreSignUp
+#      - alb:
+#          listenerArn: arn:aws:elasticloadbalancing:us-east-1:XXXXXX:listener/app/my-load-balancer/50dc6c495c0c9188/
+#          priority: 1
+#          conditions:
+#            host: example.com
+#            path: /hello
+
+#    Define function environment variables here
+#    environment:
+#      variable2: value2
+
+# you can add CloudFormation resource templates here
+resources:
+ Resources:
+  APIKeysDynamoDBTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: ${self:custom.tableName}
+      AttributeDefinitions:
+        - AttributeName: email
+          AttributeType: S
+        - AttributeName: api_key
+          AttributeType: S
+      KeySchema:
+        - AttributeName: email
+          KeyType: HASH
+      ProvisionedThroughput:
+        ReadCapacityUnits: 1
+        WriteCapacityUnits: 1
+      GlobalSecondaryIndexes:
+       - IndexName: apiKeys
+         KeySchema:
+         - AttributeName: api_key
+           KeyType: HASH
+         Projection:
+           ProjectionType: ALL
+         ProvisionedThroughput:
+           ReadCapacityUnits: '5'
+           WriteCapacityUnits: '5'

--- a/api/awsauth/serverless.yml
+++ b/api/awsauth/serverless.yml
@@ -28,10 +28,7 @@ provider:
   name: aws
   runtime: python3.7
 
-# you can overwrite defaults here
-#  stage: dev
-#  region: us-east-1
-
+  stage: ${opt:stage, 'dev'}
 
   iamRoleStatements:
     - Effect: Allow
@@ -64,49 +61,11 @@ provider:
 #    - exclude-me-dir/**
 
 functions:
-  canAPIRegisterAPIKey:
+  apiRegisterAPIKey:
     handler: auth_app.register
-  canAPICheckApiKey:
+  apiCheckApiKey:
     handler: auth_app.check_api_key
-#    The following are a few example events you can configure
-#    NOTE: Please make sure to change your handler code to work with those events
-#    Check the event documentation for details
-#    events:
-#      - http:
-#          path: users/create
-#          method: get
-#      - websocket: $connect
-#      - s3: ${env:BUCKET}
-#      - schedule: rate(10 minutes)
-#      - sns: greeter-topic
-#      - stream: arn:aws:dynamodb:region:XXXXXX:table/foo/stream/1970-01-01T00:00:00.000
-#      - alexaSkill: amzn1.ask.skill.xx-xx-xx-xx
-#      - alexaSmartHome: amzn1.ask.skill.xx-xx-xx-xx
-#      - iot:
-#          sql: "SELECT * FROM 'some_topic'"
-#      - cloudwatchEvent:
-#          event:
-#            source:
-#              - "aws.ec2"
-#            detail-type:
-#              - "EC2 Instance State-change Notification"
-#            detail:
-#              state:
-#                - pending
-#      - cloudwatchLog: '/aws/lambda/hello'
-#      - cognitoUserPool:
-#          pool: MyUserPool
-#          trigger: PreSignUp
-#      - alb:
-#          listenerArn: arn:aws:elasticloadbalancing:us-east-1:XXXXXX:listener/app/my-load-balancer/50dc6c495c0c9188/
-#          priority: 1
-#          conditions:
-#            host: example.com
-#            path: /hello
 
-#    Define function environment variables here
-#    environment:
-#      variable2: value2
 
 # you can add CloudFormation resource templates here
 resources:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+boto3==1.15.6
 scipy==1.4.1
 astroid==2.4.1
 certifi==2019.11.28


### PR DESCRIPTION
This is preliminary code involved for handling API auth.

Components:
* Uses two lambda functions: one to register emails and provide a key, another to check that the API key included in the request is valid.
* Stores email/api key pairs in a DynamoDB table
* Uses the serverless framework to deploy lambda functions.  lets us easily create different "stages" or envrionments so we can develop locally and not modify the prod api until ready. 

This hooks up to our API Gateway which is pretty manually put together.  I'd love to add that setup to the cloudformation resources, but will take a bit too much time right now.  

Since this code is deployed independently, I don't think it quite makes sense to have it integrate with the rest of the setup (i.e. share requirements, maybe live in libs).  Right now there's no testing for this code.  Open to suggestions.  Would love to hook this up to more of an automated deploy (deploy code to dev state, run an integration test, then deploy to prod) but don't have that hooked up right now. 

I'd love a review on the code itself and definitely open to discussing the more operational components