### PR TITLE
Get latest data from multiregion.csv

### DIFF
--- a/test/libs/datasets/combined_dataset_utils_test.py
+++ b/test/libs/datasets/combined_dataset_utils_test.py
@@ -1,13 +1,16 @@
 import pathlib
+import pandas as pd
 
 from covidactnow.datapublic.common_fields import CommonFields
 
 from libs.datasets import combined_dataset_utils
 from libs.datasets import combined_datasets
+from libs.datasets.latest_values_dataset import LatestValuesDataset
 from libs.datasets.timeseries import MultiRegionTimeseriesDataset
 from libs.datasets.timeseries import TimeseriesDataset
 from libs.pipeline import Region
 from libs.qa.common_df_diff import DatasetDiff
+from test.libs.datasets.timeseries_test import assert_combined_like
 
 
 def test_persist_and_load_dataset(tmp_path, nyc_fips):
@@ -33,15 +36,16 @@ def test_update_and_load(tmp_path: pathlib.Path, nyc_fips, nyc_region):
     multiregion_timeseries_nyc = MultiRegionTimeseriesDataset.from_combined_dataframe(
         nyc_combined_df
     )
-    timeseries_nyc = multiregion_timeseries_nyc.to_timeseries()
-    latest_nyc = timeseries_nyc.latest_values_object()
+    latest_nyc = LatestValuesDataset(multiregion_timeseries_nyc.latest_data_with_fips.reset_index())
+    latest_nyc_record = latest_nyc.get_record_for_fips(nyc_fips)
+    assert latest_nyc_record[CommonFields.POPULATION] > 1_000_000
+    assert latest_nyc_record[CommonFields.LOCATION_ID]
 
     combined_dataset_utils.update_data_public_head(
         tmp_path, latest_dataset=latest_nyc, timeseries_dataset=multiregion_timeseries_nyc,
     )
 
-    timeseries = combined_datasets.load_us_timeseries_dataset(pointer_directory=tmp_path)
-
-    latest = combined_datasets.load_us_latest_dataset(pointer_directory=tmp_path)
-
-    assert latest.get_record_for_fips(nyc_fips) == latest_nyc.get_record_for_fips(nyc_fips)
+    timeseries_loaded = combined_datasets.load_us_timeseries_dataset(pointer_directory=tmp_path)
+    latest_loaded = combined_datasets.load_us_latest_dataset(pointer_directory=tmp_path)
+    assert latest_loaded.get_record_for_fips(nyc_fips) == latest_nyc_record
+    assert_combined_like(timeseries_loaded, multiregion_timeseries_nyc)

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -230,7 +230,7 @@ def _combined_sorted_by_location_date(ts: timeseries.MultiRegionTimeseriesDatase
     )
 
 
-def _assert_combined_like(
+def assert_combined_like(
     ts1: timeseries.MultiRegionTimeseriesDataset, ts2: timeseries.MultiRegionTimeseriesDataset
 ):
     """Asserts that two datasets contain similar date, ignoring order."""
@@ -263,7 +263,7 @@ def test_merge():
     # Check that merge is symmetric
     ts_merged_1 = ts_fips.merge(ts_cbsa)
     ts_merged_2 = ts_cbsa.merge(ts_fips)
-    _assert_combined_like(ts_merged_1, ts_merged_2)
+    assert_combined_like(ts_merged_1, ts_merged_2)
 
     ts_expected = timeseries.MultiRegionTimeseriesDataset.from_csv(
         io.StringIO(
@@ -280,4 +280,4 @@ def test_merge():
             "iso1:us#fips:97222,,Foo County,county,,11\n"
         )
     )
-    _assert_combined_like(ts_merged_1, ts_expected)
+    assert_combined_like(ts_merged_1, ts_expected)


### PR DESCRIPTION
## This PR

* strengthens `test_persist_and_load_dataset` so both latest and timeseries are compared after being loaded


### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [ ] Are tests passing?
