### PR TITLE
drop dates without real values in the timeseries

### DIFF
--- a/cli/data.py
+++ b/cli/data.py
@@ -86,7 +86,7 @@ def update(summary_filename, wide_dates_filename, aggregate_to_msas: bool):
     )
     multiregion_dataset = MultiRegionTimeseriesDataset.from_timeseries_and_latest(
         timeseries_dataset, latest_dataset
-    )
+    ).drop_na_dates()
     if aggregate_to_msas:
         aggregator = statistical_areas.CountyToCBSAAggregator.from_local_public_data()
         multiregion_dataset = multiregion_dataset.merge(aggregator.aggregate(multiregion_dataset))
@@ -113,6 +113,16 @@ def update(summary_filename, wide_dates_filename, aggregate_to_msas: bool):
 
     if summary_filename:
         _save_field_summary(multiregion_dataset, path_prefix / summary_filename)
+
+
+@main.command()
+@click.argument("filename_in", type=click.Path(exists=True))
+@click.argument("filename_out", type=click.Path(exists=False))
+def filter_drop_na_dates(filename_in: pathlib.Path, filename_out: pathlib.Path):
+    """Apply the drop_na_dates filter to FILENAME_IN and write FILENAME_OUT."""
+    multiregion_in = MultiRegionTimeseriesDataset.from_csv(filename_in)
+    multiregion_out = multiregion_in.drop_na_dates()
+    multiregion_out.to_csv(filename_out)
 
 
 @main.command()

--- a/libs/datasets/dataset_utils.py
+++ b/libs/datasets/dataset_utils.py
@@ -16,6 +16,7 @@ GEO_DATA_COLUMNS = [
     CommonFields.AGGREGATE_LEVEL,
     CommonFields.COUNTRY,
     CommonFields.COUNTY,
+    CommonFields.LOCATION_ID,
 ]
 
 

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -281,3 +281,29 @@ def test_merge():
         )
     )
     assert_combined_like(ts_merged_1, ts_expected)
+
+
+def test_drop_na_dates():
+    ts_in = timeseries.MultiRegionTimeseriesDataset.from_csv(
+        io.StringIO(
+            "location_id,date,county,aggregate_level,m1,m2\n"
+            "iso1:us#fips:97111,2020-04-02,Bar County,county,2,\n"
+            "iso1:us#fips:97111,2020-04-03,Bar County,county,,\n"
+            "iso1:us#fips:97111,,Bar County,county,,\n"
+            "iso1:us#cbsa:10100,2020-04-02,,,,\n"
+            "iso1:us#cbsa:10100,2020-04-03,,,3,33\n"
+            "iso1:us#cbsa:10100,,,,3,33\n"
+        )
+    )
+    ts_result = ts_in.drop_na_dates()
+
+    ts_expected = timeseries.MultiRegionTimeseriesDataset.from_csv(
+        io.StringIO(
+            "location_id,date,fips,county,aggregate_level,m1,m2\n"
+            "iso1:us#fips:97111,2020-04-02,97111,Bar County,county,2,\n"
+            "iso1:us#cbsa:10100,2020-04-03,,,,3,33\n"
+            "iso1:us#fips:97111,,97111,Bar County,county,,\n"
+            "iso1:us#cbsa:10100,,,,,3,33\n"
+        )
+    )
+    assert_combined_like(ts_result, ts_expected)

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -281,3 +281,29 @@ def test_merge():
         )
     )
     _assert_combined_like(ts_merged_1, ts_expected)
+
+
+def test_drop_na_dates():
+    ts_in = timeseries.MultiRegionTimeseriesDataset.from_csv(
+        io.StringIO(
+            "location_id,date,county,aggregate_level,m1,m2\n"
+            "iso1:us#fips:97111,2020-04-02,Bar County,county,2,\n"
+            "iso1:us#fips:97111,2020-04-03,Bar County,county,,\n"
+            "iso1:us#fips:97111,,Bar County,county,,\n"
+            "iso1:us#cbsa:10100,2020-04-02,,,,\n"
+            "iso1:us#cbsa:10100,2020-04-03,,,3,33\n"
+            "iso1:us#cbsa:10100,,,,3,33\n"
+        )
+    )
+    ts_result = ts_in.drop_na_dates()
+
+    ts_expected = timeseries.MultiRegionTimeseriesDataset.from_csv(
+        io.StringIO(
+            "location_id,date,fips,county,aggregate_level,m1,m2\n"
+            "iso1:us#fips:97111,2020-04-02,97111,Bar County,county,2,\n"
+            "iso1:us#cbsa:10100,2020-04-03,,,,3,33\n"
+            "iso1:us#fips:97111,,97111,Bar County,county,,\n"
+            "iso1:us#cbsa:10100,,,,,3,33\n"
+        )
+    )
+    _assert_combined_like(ts_result, ts_expected)


### PR DESCRIPTION
Tested by running `python ./run.py data filter-drop-na-dates data/multiregion.csv data/multiregion-drop-na-dates.csv` and looking at `vimdiff data/multiregion.csv data/multiregion-drop-na-dates.csv`. File size dropped from 84MB to 74MB; I was hoping for a bigger drop but code is written now.