### PR TITLE
Changing API Typing to be Required fields with nullable values

### DIFF
--- a/api/can_api_v2_definition.py
+++ b/api/can_api_v2_definition.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import List, Optional
 from libs.datasets.dataset_utils import AggregationLevel
 from api import can_api_definition
 from libs import base_model

--- a/api/can_api_v2_definition.py
+++ b/api/can_api_v2_definition.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 from libs.datasets.dataset_utils import AggregationLevel
 from api import can_api_definition
 from libs import base_model
@@ -7,43 +7,43 @@ import datetime
 
 
 class HospitalResourceUtilization(base_model.APIBaseModel):
-    capacity: int = pydantic.Field(None, description="Total capacity for resource.")
-    currentUsageTotal: int = pydantic.Field(
-        None, description="Currently used capacity for resource by all patients (COVID + Non-COVID)"
+    capacity: Optional[int] = pydantic.Field(..., description="Total capacity for resource.")
+    currentUsageTotal: Optional[int] = pydantic.Field(
+        ..., description="Currently used capacity for resource by all patients (COVID + Non-COVID)"
     )
-    currentUsageCovid: int = pydantic.Field(
-        None, description="Currently used capacity for resource by COVID "
+    currentUsageCovid: Optional[int] = pydantic.Field(
+        ..., description="Currently used capacity for resource by COVID "
     )
-    typicalUsageRate: float = pydantic.Field(
-        None, description="Typical used capacity rate for resource. This excludes any COVID usage."
+    typicalUsageRate: Optional[float] = pydantic.Field(
+        ..., description="Typical used capacity rate for resource. This excludes any COVID usage."
     )
 
 
 class Actuals(base_model.APIBaseModel):
     """Known actuals data."""
 
-    cases: int = pydantic.Field(
-        None, description="Cumulative number of confirmed or suspected cases"
+    cases: Optional[int] = pydantic.Field(
+        ..., description="Cumulative number of confirmed or suspected cases"
     )
-    deaths: int = pydantic.Field(
-        None,
+    deaths: Optional[int] = pydantic.Field(
+        ...,
         description=(
             "Cumulative number of deaths that are suspected or "
             "confirmed to have been caused by COVID-19"
         ),
     )
-    positiveTests: int = pydantic.Field(
-        None, description="Cumulative positive test results to date"
+    positiveTests: Optional[int] = pydantic.Field(
+        ..., description="Cumulative positive test results to date"
     )
-    negativeTests: int = pydantic.Field(
-        None, description="Cumulative negative test results to date"
+    negativeTests: Optional[int] = pydantic.Field(
+        ..., description="Cumulative negative test results to date"
     )
-    contactTracers: int = pydantic.Field(None, description="Number of Contact Tracers")
-    hospitalBeds: HospitalResourceUtilization = pydantic.Field(
-        None, description="Information about hospital bed utilization"
+    contactTracers: Optional[int] = pydantic.Field(..., description="Number of Contact Tracers")
+    hospitalBeds: Optional[HospitalResourceUtilization] = pydantic.Field(
+        ..., description="Information about hospital bed utilization"
     )
-    icuBeds: HospitalResourceUtilization = pydantic.Field(
-        None, description="Information about ICU bed utilization"
+    icuBeds: Optional[HospitalResourceUtilization] = pydantic.Field(
+        ..., description="Information about ICU bed utilization"
     )
 
 
@@ -56,34 +56,34 @@ class ActualsTimeseriesRow(Actuals):
 class Metrics(base_model.APIBaseModel):
     """Calculated metrics data based on known actuals."""
 
-    testPositivityRatio: float = pydantic.Field(
-        None,
+    testPositivityRatio: Optional[float] = pydantic.Field(
+        ...,
         description="Ratio of people who test positive calculated using a 7-day rolling average.",
     )
 
-    caseDensity: float = pydantic.Field(
-        None,
+    caseDensity: Optional[float] = pydantic.Field(
+        ...,
         description="The number of cases per 100k population calculated using a 7-day rolling average.",
     )
 
-    contactTracerCapacityRatio: float = pydantic.Field(
-        None,
+    contactTracerCapacityRatio: Optional[float] = pydantic.Field(
+        ...,
         description=(
             "Ratio of currently hired tracers to estimated "
             "tracers needed based on 7-day daily case average."
         ),
     )
 
-    infectionRate: float = pydantic.Field(
-        None, description="R_t, or the estimated number of infections arising from a typical case."
+    infectionRate: Optional[float] = pydantic.Field(
+        ..., description="R_t, or the estimated number of infections arising from a typical case."
     )
 
-    infectionRateCI90: float = pydantic.Field(
-        None,
+    infectionRateCI90: Optional[float] = pydantic.Field(
+        ...,
         description="90th percentile confidence interval upper endpoint of the infection rate.",
     )
-    icuHeadroomRatio: float = pydantic.Field(None)
-    icuHeadroomDetails: can_api_definition.ICUHeadroomMetricDetails = pydantic.Field(None)
+    icuHeadroomRatio: Optional[float] = pydantic.Field(...)
+    icuHeadroomDetails: Optional[can_api_definition.ICUHeadroomMetricDetails] = pydantic.Field(...)
 
 
 class MetricsTimeseriesRow(Metrics):
@@ -101,16 +101,20 @@ class RegionSummary(base_model.APIBaseModel):
     )
     country: str = pydantic.Field(..., description="2-letter ISO-3166 Country code.")
     state: str = pydantic.Field(..., description="2-letter ANSI state code.")
-    county: str = pydantic.Field(None, description="County name")
+    county: Optional[str] = pydantic.Field(..., description="County name")
 
     level: AggregationLevel = pydantic.Field(..., description="Level of region.")
-    lat: float = pydantic.Field(None, description="Latitude of point within the state or county")
-    long: float = pydantic.Field(None, description="Longitude of point within the state or county")
+    lat: Optional[float] = pydantic.Field(
+        ..., description="Latitude of point within the state or county"
+    )
+    long: Optional[float] = pydantic.Field(
+        ..., description="Longitude of point within the state or county"
+    )
     population: int = pydantic.Field(
         ..., description="Total Population in geographic region.", gt=0
     )
 
-    metrics: Metrics = pydantic.Field(None)
+    metrics: Optional[Metrics] = pydantic.Field(...)
     actuals: Actuals = pydantic.Field(...)
 
     lastUpdatedDate: datetime.date = pydantic.Field(..., description="Date of latest data")

--- a/api/can_api_v2_definition.py
+++ b/api/can_api_v2_definition.py
@@ -83,7 +83,7 @@ class Metrics(base_model.APIBaseModel):
         description="90th percentile confidence interval upper endpoint of the infection rate.",
     )
     icuHeadroomRatio: Optional[float] = pydantic.Field(...)
-    icuHeadroomDetails: Optional[can_api_definition.ICUHeadroomMetricDetails] = pydantic.Field(...)
+    icuHeadroomDetails: can_api_definition.ICUHeadroomMetricDetails = pydantic.Field(None)
 
 
 class MetricsTimeseriesRow(Metrics):

--- a/api/can_api_v2_definition.py
+++ b/api/can_api_v2_definition.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Union
 from libs.datasets.dataset_utils import AggregationLevel
 from api import can_api_definition
 from libs import base_model

--- a/api/docs/open_api_schema.json
+++ b/api/docs/open_api_schema.json
@@ -567,7 +567,14 @@
             ]
           },
           "icuHeadroomDetails": {
-            "$ref": "#/components/schemas/ICUHeadroomMetricDetails"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ICUHeadroomMetricDetails"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "description": "Calculated metrics data based on known actuals."
@@ -805,7 +812,14 @@
             "description": "Total Population in geographic region."
           },
           "metrics": {
-            "$ref": "#/components/schemas/Metrics"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Metrics"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "actuals": {
             "$ref": "#/components/schemas/Actuals"
@@ -913,7 +927,14 @@
             ]
           },
           "icuHeadroomDetails": {
-            "$ref": "#/components/schemas/ICUHeadroomMetricDetails"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ICUHeadroomMetricDetails"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "date": {
             "title": "Date",
@@ -1104,7 +1125,14 @@
             "description": "Total Population in geographic region."
           },
           "metrics": {
-            "$ref": "#/components/schemas/Metrics"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Metrics"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "actuals": {
             "$ref": "#/components/schemas/Actuals"

--- a/api/docs/open_api_schema.json
+++ b/api/docs/open_api_schema.json
@@ -484,6 +484,15 @@
       },
       "Metrics": {
         "title": "Metrics",
+        "required": [
+          "testPositivityRatio",
+          "caseDensity",
+          "contactTracerCapacityRatio",
+          "infectionRate",
+          "infectionRateCI90",
+          "icuHeadroomRatio",
+          "icuHeadroomDetails"
+        ],
         "type": "object",
         "properties": {
           "testPositivityRatio": {
@@ -523,6 +532,12 @@
       },
       "HospitalResourceUtilization": {
         "title": "HospitalResourceUtilization",
+        "required": [
+          "capacity",
+          "currentUsageTotal",
+          "currentUsageCovid",
+          "typicalUsageRate"
+        ],
         "type": "object",
         "properties": {
           "capacity": {
@@ -550,6 +565,15 @@
       },
       "Actuals": {
         "title": "Actuals",
+        "required": [
+          "cases",
+          "deaths",
+          "positiveTests",
+          "negativeTests",
+          "contactTracers",
+          "hospitalBeds",
+          "icuBeds"
+        ],
         "type": "object",
         "properties": {
           "cases": {
@@ -604,8 +628,12 @@
           "fips",
           "country",
           "state",
+          "county",
           "level",
+          "lat",
+          "long",
           "population",
+          "metrics",
           "actuals",
           "lastUpdatedDate"
         ],
@@ -676,6 +704,13 @@
       "MetricsTimeseriesRow": {
         "title": "MetricsTimeseriesRow",
         "required": [
+          "testPositivityRatio",
+          "caseDensity",
+          "contactTracerCapacityRatio",
+          "infectionRate",
+          "infectionRateCI90",
+          "icuHeadroomRatio",
+          "icuHeadroomDetails",
           "date"
         ],
         "type": "object",
@@ -724,6 +759,13 @@
       "ActualsTimeseriesRow": {
         "title": "ActualsTimeseriesRow",
         "required": [
+          "cases",
+          "deaths",
+          "positiveTests",
+          "negativeTests",
+          "contactTracers",
+          "hospitalBeds",
+          "icuBeds",
           "date"
         ],
         "type": "object",
@@ -786,8 +828,12 @@
           "fips",
           "country",
           "state",
+          "county",
           "level",
+          "lat",
+          "long",
           "population",
+          "metrics",
           "actuals",
           "lastUpdatedDate",
           "actualsTimeseries"

--- a/api/docs/open_api_schema.json
+++ b/api/docs/open_api_schema.json
@@ -490,8 +490,7 @@
           "contactTracerCapacityRatio",
           "infectionRate",
           "infectionRateCI90",
-          "icuHeadroomRatio",
-          "icuHeadroomDetails"
+          "icuHeadroomRatio"
         ],
         "type": "object",
         "properties": {
@@ -567,14 +566,7 @@
             ]
           },
           "icuHeadroomDetails": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ICUHeadroomMetricDetails"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "$ref": "#/components/schemas/ICUHeadroomMetricDetails"
           }
         },
         "description": "Calculated metrics data based on known actuals."
@@ -850,7 +842,6 @@
           "infectionRate",
           "infectionRateCI90",
           "icuHeadroomRatio",
-          "icuHeadroomDetails",
           "date"
         ],
         "type": "object",
@@ -927,14 +918,7 @@
             ]
           },
           "icuHeadroomDetails": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ICUHeadroomMetricDetails"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "$ref": "#/components/schemas/ICUHeadroomMetricDetails"
           },
           "date": {
             "title": "Date",

--- a/api/docs/open_api_schema.json
+++ b/api/docs/open_api_schema.json
@@ -496,62 +496,73 @@
         "type": "object",
         "properties": {
           "testPositivityRatio": {
+            "title": "Testpositivityratio",
             "anyOf": [
               {
-                "type": "null"
+                "type": "number"
               },
               {
-                "type": "number"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "Ratio of people who test positive calculated using a 7-day rolling average."
           },
           "caseDensity": {
+            "title": "Casedensity",
             "anyOf": [
               {
-                "type": "null"
+                "type": "number"
               },
               {
-                "type": "number"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "The number of cases per 100k population calculated using a 7-day rolling average."
           },
           "contactTracerCapacityRatio": {
+            "title": "Contacttracercapacityratio",
             "anyOf": [
               {
-                "type": "null"
+                "type": "number"
               },
               {
-                "type": "number"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average."
           },
           "infectionRate": {
+            "title": "Infectionrate",
             "anyOf": [
               {
-                "type": "null"
+                "type": "number"
               },
               {
-                "type": "number"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "R_t, or the estimated number of infections arising from a typical case."
           },
           "infectionRateCI90": {
+            "title": "Infectionrateci90",
             "anyOf": [
               {
-                "type": "null"
+                "type": "number"
               },
               {
-                "type": "number"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "90th percentile confidence interval upper endpoint of the infection rate."
           },
           "icuHeadroomRatio": {
+            "title": "Icuheadroomratio",
             "anyOf": [
               {
-                "type": "null"
+                "type": "number"
               },
               {
-                "type": "number"
+                "type": "null"
               }
             ]
           },
@@ -572,44 +583,52 @@
         "type": "object",
         "properties": {
           "capacity": {
+            "title": "Capacity",
             "anyOf": [
               {
-                "type": "null"
+                "type": "integer"
               },
               {
-                "type": "integer"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "Total capacity for resource."
           },
           "currentUsageTotal": {
+            "title": "Currentusagetotal",
             "anyOf": [
               {
-                "type": "null"
+                "type": "integer"
               },
               {
-                "type": "integer"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "Currently used capacity for resource by all patients (COVID + Non-COVID)"
           },
           "currentUsageCovid": {
+            "title": "Currentusagecovid",
             "anyOf": [
-              {
-                "type": "null"
-              },
               {
                 "type": "integer"
-              }
-            ]
-          },
-          "typicalUsageRate": {
-            "anyOf": [
-              {
-                "type": "null"
               },
               {
-                "type": "number"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "Currently used capacity for resource by COVID "
+          },
+          "typicalUsageRate": {
+            "title": "Typicalusagerate",
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Typical used capacity rate for resource. This excludes any COVID usage."
           }
         },
         "description": "Base model for API output."
@@ -628,54 +647,64 @@
         "type": "object",
         "properties": {
           "cases": {
+            "title": "Cases",
             "anyOf": [
               {
-                "type": "null"
+                "type": "integer"
               },
               {
-                "type": "integer"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "Cumulative number of confirmed or suspected cases"
           },
           "deaths": {
+            "title": "Deaths",
             "anyOf": [
               {
-                "type": "null"
+                "type": "integer"
               },
               {
-                "type": "integer"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "Cumulative number of deaths that are suspected or confirmed to have been caused by COVID-19"
           },
           "positiveTests": {
+            "title": "Positivetests",
             "anyOf": [
               {
-                "type": "null"
+                "type": "integer"
               },
               {
-                "type": "integer"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "Cumulative positive test results to date"
           },
           "negativeTests": {
+            "title": "Negativetests",
             "anyOf": [
               {
-                "type": "null"
+                "type": "integer"
               },
               {
-                "type": "integer"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "Cumulative negative test results to date"
           },
           "contactTracers": {
+            "title": "Contacttracers",
             "anyOf": [
               {
-                "type": "null"
+                "type": "integer"
               },
               {
-                "type": "integer"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "Number of Contact Tracers"
           },
           "hospitalBeds": {
             "title": "Hospitalbeds",
@@ -731,37 +760,43 @@
             "description": "2-letter ANSI state code."
           },
           "county": {
+            "title": "County",
             "anyOf": [
               {
-                "type": "null"
+                "type": "string"
               },
               {
-                "type": "string"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "County name"
           },
           "level": {
             "$ref": "#/components/schemas/AggregationLevel"
           },
           "lat": {
+            "title": "Lat",
             "anyOf": [
               {
-                "type": "null"
+                "type": "number"
               },
               {
-                "type": "number"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "Latitude of point within the state or county"
           },
           "long": {
+            "title": "Long",
             "anyOf": [
               {
-                "type": "null"
+                "type": "number"
               },
               {
-                "type": "number"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "Longitude of point within the state or county"
           },
           "population": {
             "title": "Population",
@@ -807,62 +842,73 @@
         "type": "object",
         "properties": {
           "testPositivityRatio": {
+            "title": "Testpositivityratio",
             "anyOf": [
               {
-                "type": "null"
+                "type": "number"
               },
               {
-                "type": "number"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "Ratio of people who test positive calculated using a 7-day rolling average."
           },
           "caseDensity": {
+            "title": "Casedensity",
             "anyOf": [
               {
-                "type": "null"
+                "type": "number"
               },
               {
-                "type": "number"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "The number of cases per 100k population calculated using a 7-day rolling average."
           },
           "contactTracerCapacityRatio": {
+            "title": "Contacttracercapacityratio",
             "anyOf": [
               {
-                "type": "null"
+                "type": "number"
               },
               {
-                "type": "number"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average."
           },
           "infectionRate": {
+            "title": "Infectionrate",
             "anyOf": [
               {
-                "type": "null"
+                "type": "number"
               },
               {
-                "type": "number"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "R_t, or the estimated number of infections arising from a typical case."
           },
           "infectionRateCI90": {
+            "title": "Infectionrateci90",
             "anyOf": [
               {
-                "type": "null"
+                "type": "number"
               },
               {
-                "type": "number"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "90th percentile confidence interval upper endpoint of the infection rate."
           },
           "icuHeadroomRatio": {
+            "title": "Icuheadroomratio",
             "anyOf": [
               {
-                "type": "null"
+                "type": "number"
               },
               {
-                "type": "number"
+                "type": "null"
               }
             ]
           },
@@ -893,54 +939,64 @@
         "type": "object",
         "properties": {
           "cases": {
+            "title": "Cases",
             "anyOf": [
               {
-                "type": "null"
+                "type": "integer"
               },
               {
-                "type": "integer"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "Cumulative number of confirmed or suspected cases"
           },
           "deaths": {
+            "title": "Deaths",
             "anyOf": [
               {
-                "type": "null"
+                "type": "integer"
               },
               {
-                "type": "integer"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "Cumulative number of deaths that are suspected or confirmed to have been caused by COVID-19"
           },
           "positiveTests": {
+            "title": "Positivetests",
             "anyOf": [
               {
-                "type": "null"
+                "type": "integer"
               },
               {
-                "type": "integer"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "Cumulative positive test results to date"
           },
           "negativeTests": {
+            "title": "Negativetests",
             "anyOf": [
               {
-                "type": "null"
+                "type": "integer"
               },
               {
-                "type": "integer"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "Cumulative negative test results to date"
           },
           "contactTracers": {
+            "title": "Contacttracers",
             "anyOf": [
               {
-                "type": "null"
+                "type": "integer"
               },
               {
-                "type": "integer"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "Number of Contact Tracers"
           },
           "hospitalBeds": {
             "title": "Hospitalbeds",
@@ -1003,37 +1059,43 @@
             "description": "2-letter ANSI state code."
           },
           "county": {
+            "title": "County",
             "anyOf": [
               {
-                "type": "null"
+                "type": "string"
               },
               {
-                "type": "string"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "County name"
           },
           "level": {
             "$ref": "#/components/schemas/AggregationLevel"
           },
           "lat": {
+            "title": "Lat",
             "anyOf": [
               {
-                "type": "null"
+                "type": "number"
               },
               {
-                "type": "number"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "Latitude of point within the state or county"
           },
           "long": {
+            "title": "Long",
             "anyOf": [
               {
-                "type": "null"
+                "type": "number"
               },
               {
-                "type": "number"
+                "type": "null"
               }
-            ]
+            ],
+            "description": "Longitude of point within the state or county"
           },
           "population": {
             "title": "Population",

--- a/api/docs/open_api_schema.json
+++ b/api/docs/open_api_schema.json
@@ -1172,7 +1172,7 @@
     "securitySchemes": {
       "API Key": {
         "type": "apiKey",
-        "description": "\nAn API key is required.\n\nRegister for an API key [here](/getting-started/access).\n    ",
+        "description": "\nAn API key is required.\n\nRegister for an API key [here](/access).\n    ",
         "name": "apiKey",
         "in": "query"
       }

--- a/api/docs/open_api_schema.json
+++ b/api/docs/open_api_schema.json
@@ -496,33 +496,64 @@
         "type": "object",
         "properties": {
           "testPositivityRatio": {
-            "title": "Testpositivityratio",
-            "type": "number",
-            "description": "Ratio of people who test positive calculated using a 7-day rolling average."
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "caseDensity": {
-            "title": "Casedensity",
-            "type": "number",
-            "description": "The number of cases per 100k population calculated using a 7-day rolling average."
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "contactTracerCapacityRatio": {
-            "title": "Contacttracercapacityratio",
-            "type": "number",
-            "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average."
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "infectionRate": {
-            "title": "Infectionrate",
-            "type": "number",
-            "description": "R_t, or the estimated number of infections arising from a typical case."
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "infectionRateCI90": {
-            "title": "Infectionrateci90",
-            "type": "number",
-            "description": "90th percentile confidence interval upper endpoint of the infection rate."
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "icuHeadroomRatio": {
-            "title": "Icuheadroomratio",
-            "type": "number"
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "icuHeadroomDetails": {
             "$ref": "#/components/schemas/ICUHeadroomMetricDetails"
@@ -541,24 +572,44 @@
         "type": "object",
         "properties": {
           "capacity": {
-            "title": "Capacity",
-            "type": "integer",
-            "description": "Total capacity for resource."
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "integer"
+              }
+            ]
           },
           "currentUsageTotal": {
-            "title": "Currentusagetotal",
-            "type": "integer",
-            "description": "Currently used capacity for resource by all patients (COVID + Non-COVID)"
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "integer"
+              }
+            ]
           },
           "currentUsageCovid": {
-            "title": "Currentusagecovid",
-            "type": "integer",
-            "description": "Currently used capacity for resource by COVID "
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "integer"
+              }
+            ]
           },
           "typicalUsageRate": {
-            "title": "Typicalusagerate",
-            "type": "number",
-            "description": "Typical used capacity rate for resource. This excludes any COVID usage."
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "number"
+              }
+            ]
           }
         },
         "description": "Base model for API output."
@@ -577,29 +628,54 @@
         "type": "object",
         "properties": {
           "cases": {
-            "title": "Cases",
-            "type": "integer",
-            "description": "Cumulative number of confirmed or suspected cases"
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "integer"
+              }
+            ]
           },
           "deaths": {
-            "title": "Deaths",
-            "type": "integer",
-            "description": "Cumulative number of deaths that are suspected or confirmed to have been caused by COVID-19"
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "integer"
+              }
+            ]
           },
           "positiveTests": {
-            "title": "Positivetests",
-            "type": "integer",
-            "description": "Cumulative positive test results to date"
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "integer"
+              }
+            ]
           },
           "negativeTests": {
-            "title": "Negativetests",
-            "type": "integer",
-            "description": "Cumulative negative test results to date"
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "integer"
+              }
+            ]
           },
           "contactTracers": {
-            "title": "Contacttracers",
-            "type": "integer",
-            "description": "Number of Contact Tracers"
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "integer"
+              }
+            ]
           },
           "hospitalBeds": {
             "title": "Hospitalbeds",
@@ -655,22 +731,37 @@
             "description": "2-letter ANSI state code."
           },
           "county": {
-            "title": "County",
-            "type": "string",
-            "description": "County name"
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "string"
+              }
+            ]
           },
           "level": {
             "$ref": "#/components/schemas/AggregationLevel"
           },
           "lat": {
-            "title": "Lat",
-            "type": "number",
-            "description": "Latitude of point within the state or county"
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "long": {
-            "title": "Long",
-            "type": "number",
-            "description": "Longitude of point within the state or county"
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "population": {
             "title": "Population",
@@ -716,33 +807,64 @@
         "type": "object",
         "properties": {
           "testPositivityRatio": {
-            "title": "Testpositivityratio",
-            "type": "number",
-            "description": "Ratio of people who test positive calculated using a 7-day rolling average."
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "caseDensity": {
-            "title": "Casedensity",
-            "type": "number",
-            "description": "The number of cases per 100k population calculated using a 7-day rolling average."
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "contactTracerCapacityRatio": {
-            "title": "Contacttracercapacityratio",
-            "type": "number",
-            "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average."
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "infectionRate": {
-            "title": "Infectionrate",
-            "type": "number",
-            "description": "R_t, or the estimated number of infections arising from a typical case."
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "infectionRateCI90": {
-            "title": "Infectionrateci90",
-            "type": "number",
-            "description": "90th percentile confidence interval upper endpoint of the infection rate."
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "icuHeadroomRatio": {
-            "title": "Icuheadroomratio",
-            "type": "number"
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "icuHeadroomDetails": {
             "$ref": "#/components/schemas/ICUHeadroomMetricDetails"
@@ -771,29 +893,54 @@
         "type": "object",
         "properties": {
           "cases": {
-            "title": "Cases",
-            "type": "integer",
-            "description": "Cumulative number of confirmed or suspected cases"
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "integer"
+              }
+            ]
           },
           "deaths": {
-            "title": "Deaths",
-            "type": "integer",
-            "description": "Cumulative number of deaths that are suspected or confirmed to have been caused by COVID-19"
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "integer"
+              }
+            ]
           },
           "positiveTests": {
-            "title": "Positivetests",
-            "type": "integer",
-            "description": "Cumulative positive test results to date"
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "integer"
+              }
+            ]
           },
           "negativeTests": {
-            "title": "Negativetests",
-            "type": "integer",
-            "description": "Cumulative negative test results to date"
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "integer"
+              }
+            ]
           },
           "contactTracers": {
-            "title": "Contacttracers",
-            "type": "integer",
-            "description": "Number of Contact Tracers"
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "integer"
+              }
+            ]
           },
           "hospitalBeds": {
             "title": "Hospitalbeds",
@@ -856,22 +1003,37 @@
             "description": "2-letter ANSI state code."
           },
           "county": {
-            "title": "County",
-            "type": "string",
-            "description": "County name"
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "string"
+              }
+            ]
           },
           "level": {
             "$ref": "#/components/schemas/AggregationLevel"
           },
           "lat": {
-            "title": "Lat",
-            "type": "number",
-            "description": "Latitude of point within the state or county"
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "long": {
-            "title": "Long",
-            "type": "number",
-            "description": "Longitude of point within the state or county"
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "population": {
             "title": "Population",

--- a/api/schemas_v2/Actuals.json
+++ b/api/schemas_v2/Actuals.json
@@ -3,26 +3,56 @@
   "description": "Known actuals data.",
   "type": "object",
   "properties": {
-    "cases": [
-      "null",
-      "integer"
-    ],
-    "deaths": [
-      "null",
-      "integer"
-    ],
-    "positiveTests": [
-      "null",
-      "integer"
-    ],
-    "negativeTests": [
-      "null",
-      "integer"
-    ],
-    "contactTracers": [
-      "null",
-      "integer"
-    ],
+    "cases": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "deaths": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "positiveTests": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "negativeTests": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "contactTracers": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
     "hospitalBeds": {
       "title": "Hospitalbeds",
       "description": "Information about hospital bed utilization",
@@ -57,22 +87,46 @@
       "description": "Base model for API output.",
       "type": "object",
       "properties": {
-        "capacity": [
-          "null",
-          "integer"
-        ],
-        "currentUsageTotal": [
-          "null",
-          "integer"
-        ],
-        "currentUsageCovid": [
-          "null",
-          "integer"
-        ],
-        "typicalUsageRate": [
-          "null",
-          "number"
-        ]
+        "capacity": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "currentUsageTotal": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "currentUsageCovid": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "typicalUsageRate": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        }
       },
       "required": [
         "capacity",

--- a/api/schemas_v2/Actuals.json
+++ b/api/schemas_v2/Actuals.json
@@ -4,52 +4,62 @@
   "type": "object",
   "properties": {
     "cases": {
+      "title": "Cases",
+      "description": "Cumulative number of confirmed or suspected cases",
       "anyOf": [
         {
-          "type": "null"
+          "type": "integer"
         },
         {
-          "type": "integer"
+          "type": "null"
         }
       ]
     },
     "deaths": {
+      "title": "Deaths",
+      "description": "Cumulative number of deaths that are suspected or confirmed to have been caused by COVID-19",
       "anyOf": [
         {
-          "type": "null"
+          "type": "integer"
         },
         {
-          "type": "integer"
+          "type": "null"
         }
       ]
     },
     "positiveTests": {
+      "title": "Positivetests",
+      "description": "Cumulative positive test results to date",
       "anyOf": [
         {
-          "type": "null"
+          "type": "integer"
         },
         {
-          "type": "integer"
+          "type": "null"
         }
       ]
     },
     "negativeTests": {
+      "title": "Negativetests",
+      "description": "Cumulative negative test results to date",
       "anyOf": [
         {
-          "type": "null"
+          "type": "integer"
         },
         {
-          "type": "integer"
+          "type": "null"
         }
       ]
     },
     "contactTracers": {
+      "title": "Contacttracers",
+      "description": "Number of Contact Tracers",
       "anyOf": [
         {
-          "type": "null"
+          "type": "integer"
         },
         {
-          "type": "integer"
+          "type": "null"
         }
       ]
     },
@@ -88,42 +98,50 @@
       "type": "object",
       "properties": {
         "capacity": {
+          "title": "Capacity",
+          "description": "Total capacity for resource.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "currentUsageTotal": {
+          "title": "Currentusagetotal",
+          "description": "Currently used capacity for resource by all patients (COVID + Non-COVID)",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "currentUsageCovid": {
+          "title": "Currentusagecovid",
+          "description": "Currently used capacity for resource by COVID ",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "typicalUsageRate": {
+          "title": "Typicalusagerate",
+          "description": "Typical used capacity rate for resource. This excludes any COVID usage.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         }

--- a/api/schemas_v2/Actuals.json
+++ b/api/schemas_v2/Actuals.json
@@ -3,31 +3,26 @@
   "description": "Known actuals data.",
   "type": "object",
   "properties": {
-    "cases": {
-      "title": "Cases",
-      "description": "Cumulative number of confirmed or suspected cases",
-      "type": "integer"
-    },
-    "deaths": {
-      "title": "Deaths",
-      "description": "Cumulative number of deaths that are suspected or confirmed to have been caused by COVID-19",
-      "type": "integer"
-    },
-    "positiveTests": {
-      "title": "Positivetests",
-      "description": "Cumulative positive test results to date",
-      "type": "integer"
-    },
-    "negativeTests": {
-      "title": "Negativetests",
-      "description": "Cumulative negative test results to date",
-      "type": "integer"
-    },
-    "contactTracers": {
-      "title": "Contacttracers",
-      "description": "Number of Contact Tracers",
-      "type": "integer"
-    },
+    "cases": [
+      "null",
+      "integer"
+    ],
+    "deaths": [
+      "null",
+      "integer"
+    ],
+    "positiveTests": [
+      "null",
+      "integer"
+    ],
+    "negativeTests": [
+      "null",
+      "integer"
+    ],
+    "contactTracers": [
+      "null",
+      "integer"
+    ],
     "hospitalBeds": {
       "title": "Hospitalbeds",
       "description": "Information about hospital bed utilization",
@@ -62,26 +57,22 @@
       "description": "Base model for API output.",
       "type": "object",
       "properties": {
-        "capacity": {
-          "title": "Capacity",
-          "description": "Total capacity for resource.",
-          "type": "integer"
-        },
-        "currentUsageTotal": {
-          "title": "Currentusagetotal",
-          "description": "Currently used capacity for resource by all patients (COVID + Non-COVID)",
-          "type": "integer"
-        },
-        "currentUsageCovid": {
-          "title": "Currentusagecovid",
-          "description": "Currently used capacity for resource by COVID ",
-          "type": "integer"
-        },
-        "typicalUsageRate": {
-          "title": "Typicalusagerate",
-          "description": "Typical used capacity rate for resource. This excludes any COVID usage.",
-          "type": "number"
-        }
+        "capacity": [
+          "null",
+          "integer"
+        ],
+        "currentUsageTotal": [
+          "null",
+          "integer"
+        ],
+        "currentUsageCovid": [
+          "null",
+          "integer"
+        ],
+        "typicalUsageRate": [
+          "null",
+          "number"
+        ]
       },
       "required": [
         "capacity",

--- a/api/schemas_v2/Actuals.json
+++ b/api/schemas_v2/Actuals.json
@@ -47,6 +47,15 @@
       ]
     }
   },
+  "required": [
+    "cases",
+    "deaths",
+    "positiveTests",
+    "negativeTests",
+    "contactTracers",
+    "hospitalBeds",
+    "icuBeds"
+  ],
   "definitions": {
     "HospitalResourceUtilization": {
       "title": "HospitalResourceUtilization",
@@ -73,7 +82,13 @@
           "description": "Typical used capacity rate for resource. This excludes any COVID usage.",
           "type": "number"
         }
-      }
+      },
+      "required": [
+        "capacity",
+        "currentUsageTotal",
+        "currentUsageCovid",
+        "typicalUsageRate"
+      ]
     }
   }
 }

--- a/api/schemas_v2/ActualsTimeseriesRow.json
+++ b/api/schemas_v2/ActualsTimeseriesRow.json
@@ -54,6 +54,13 @@
     }
   },
   "required": [
+    "cases",
+    "deaths",
+    "positiveTests",
+    "negativeTests",
+    "contactTracers",
+    "hospitalBeds",
+    "icuBeds",
     "date"
   ],
   "definitions": {
@@ -82,7 +89,13 @@
           "description": "Typical used capacity rate for resource. This excludes any COVID usage.",
           "type": "number"
         }
-      }
+      },
+      "required": [
+        "capacity",
+        "currentUsageTotal",
+        "currentUsageCovid",
+        "typicalUsageRate"
+      ]
     }
   }
 }

--- a/api/schemas_v2/ActualsTimeseriesRow.json
+++ b/api/schemas_v2/ActualsTimeseriesRow.json
@@ -3,31 +3,26 @@
   "description": "Actual data for a specific day.",
   "type": "object",
   "properties": {
-    "cases": {
-      "title": "Cases",
-      "description": "Cumulative number of confirmed or suspected cases",
-      "type": "integer"
-    },
-    "deaths": {
-      "title": "Deaths",
-      "description": "Cumulative number of deaths that are suspected or confirmed to have been caused by COVID-19",
-      "type": "integer"
-    },
-    "positiveTests": {
-      "title": "Positivetests",
-      "description": "Cumulative positive test results to date",
-      "type": "integer"
-    },
-    "negativeTests": {
-      "title": "Negativetests",
-      "description": "Cumulative negative test results to date",
-      "type": "integer"
-    },
-    "contactTracers": {
-      "title": "Contacttracers",
-      "description": "Number of Contact Tracers",
-      "type": "integer"
-    },
+    "cases": [
+      "null",
+      "integer"
+    ],
+    "deaths": [
+      "null",
+      "integer"
+    ],
+    "positiveTests": [
+      "null",
+      "integer"
+    ],
+    "negativeTests": [
+      "null",
+      "integer"
+    ],
+    "contactTracers": [
+      "null",
+      "integer"
+    ],
     "hospitalBeds": {
       "title": "Hospitalbeds",
       "description": "Information about hospital bed utilization",
@@ -69,26 +64,22 @@
       "description": "Base model for API output.",
       "type": "object",
       "properties": {
-        "capacity": {
-          "title": "Capacity",
-          "description": "Total capacity for resource.",
-          "type": "integer"
-        },
-        "currentUsageTotal": {
-          "title": "Currentusagetotal",
-          "description": "Currently used capacity for resource by all patients (COVID + Non-COVID)",
-          "type": "integer"
-        },
-        "currentUsageCovid": {
-          "title": "Currentusagecovid",
-          "description": "Currently used capacity for resource by COVID ",
-          "type": "integer"
-        },
-        "typicalUsageRate": {
-          "title": "Typicalusagerate",
-          "description": "Typical used capacity rate for resource. This excludes any COVID usage.",
-          "type": "number"
-        }
+        "capacity": [
+          "null",
+          "integer"
+        ],
+        "currentUsageTotal": [
+          "null",
+          "integer"
+        ],
+        "currentUsageCovid": [
+          "null",
+          "integer"
+        ],
+        "typicalUsageRate": [
+          "null",
+          "number"
+        ]
       },
       "required": [
         "capacity",

--- a/api/schemas_v2/ActualsTimeseriesRow.json
+++ b/api/schemas_v2/ActualsTimeseriesRow.json
@@ -4,52 +4,62 @@
   "type": "object",
   "properties": {
     "cases": {
+      "title": "Cases",
+      "description": "Cumulative number of confirmed or suspected cases",
       "anyOf": [
         {
-          "type": "null"
+          "type": "integer"
         },
         {
-          "type": "integer"
+          "type": "null"
         }
       ]
     },
     "deaths": {
+      "title": "Deaths",
+      "description": "Cumulative number of deaths that are suspected or confirmed to have been caused by COVID-19",
       "anyOf": [
         {
-          "type": "null"
+          "type": "integer"
         },
         {
-          "type": "integer"
+          "type": "null"
         }
       ]
     },
     "positiveTests": {
+      "title": "Positivetests",
+      "description": "Cumulative positive test results to date",
       "anyOf": [
         {
-          "type": "null"
+          "type": "integer"
         },
         {
-          "type": "integer"
+          "type": "null"
         }
       ]
     },
     "negativeTests": {
+      "title": "Negativetests",
+      "description": "Cumulative negative test results to date",
       "anyOf": [
         {
-          "type": "null"
+          "type": "integer"
         },
         {
-          "type": "integer"
+          "type": "null"
         }
       ]
     },
     "contactTracers": {
+      "title": "Contacttracers",
+      "description": "Number of Contact Tracers",
       "anyOf": [
         {
-          "type": "null"
+          "type": "integer"
         },
         {
-          "type": "integer"
+          "type": "null"
         }
       ]
     },
@@ -95,42 +105,50 @@
       "type": "object",
       "properties": {
         "capacity": {
+          "title": "Capacity",
+          "description": "Total capacity for resource.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "currentUsageTotal": {
+          "title": "Currentusagetotal",
+          "description": "Currently used capacity for resource by all patients (COVID + Non-COVID)",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "currentUsageCovid": {
+          "title": "Currentusagecovid",
+          "description": "Currently used capacity for resource by COVID ",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "typicalUsageRate": {
+          "title": "Typicalusagerate",
+          "description": "Typical used capacity rate for resource. This excludes any COVID usage.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         }

--- a/api/schemas_v2/ActualsTimeseriesRow.json
+++ b/api/schemas_v2/ActualsTimeseriesRow.json
@@ -3,26 +3,56 @@
   "description": "Actual data for a specific day.",
   "type": "object",
   "properties": {
-    "cases": [
-      "null",
-      "integer"
-    ],
-    "deaths": [
-      "null",
-      "integer"
-    ],
-    "positiveTests": [
-      "null",
-      "integer"
-    ],
-    "negativeTests": [
-      "null",
-      "integer"
-    ],
-    "contactTracers": [
-      "null",
-      "integer"
-    ],
+    "cases": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "deaths": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "positiveTests": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "negativeTests": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "contactTracers": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
     "hospitalBeds": {
       "title": "Hospitalbeds",
       "description": "Information about hospital bed utilization",
@@ -64,22 +94,46 @@
       "description": "Base model for API output.",
       "type": "object",
       "properties": {
-        "capacity": [
-          "null",
-          "integer"
-        ],
-        "currentUsageTotal": [
-          "null",
-          "integer"
-        ],
-        "currentUsageCovid": [
-          "null",
-          "integer"
-        ],
-        "typicalUsageRate": [
-          "null",
-          "number"
-        ]
+        "capacity": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "currentUsageTotal": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "currentUsageCovid": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "typicalUsageRate": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        }
       },
       "required": [
         "capacity",

--- a/api/schemas_v2/AggregateFlattenedTimeseries.json
+++ b/api/schemas_v2/AggregateFlattenedTimeseries.json
@@ -129,7 +129,14 @@
           ]
         },
         "icuHeadroomDetails": {
-          "$ref": "#/definitions/ICUHeadroomMetricDetails"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ICUHeadroomMetricDetails"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "date": {
           "title": "Date",

--- a/api/schemas_v2/AggregateFlattenedTimeseries.json
+++ b/api/schemas_v2/AggregateFlattenedTimeseries.json
@@ -57,35 +57,30 @@
       "description": "Prediction timeseries row with location information.",
       "type": "object",
       "properties": {
-        "testPositivityRatio": {
-          "title": "Testpositivityratio",
-          "description": "Ratio of people who test positive calculated using a 7-day rolling average.",
-          "type": "number"
-        },
-        "caseDensity": {
-          "title": "Casedensity",
-          "description": "The number of cases per 100k population calculated using a 7-day rolling average.",
-          "type": "number"
-        },
-        "contactTracerCapacityRatio": {
-          "title": "Contacttracercapacityratio",
-          "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average.",
-          "type": "number"
-        },
-        "infectionRate": {
-          "title": "Infectionrate",
-          "description": "R_t, or the estimated number of infections arising from a typical case.",
-          "type": "number"
-        },
-        "infectionRateCI90": {
-          "title": "Infectionrateci90",
-          "description": "90th percentile confidence interval upper endpoint of the infection rate.",
-          "type": "number"
-        },
-        "icuHeadroomRatio": {
-          "title": "Icuheadroomratio",
-          "type": "number"
-        },
+        "testPositivityRatio": [
+          "null",
+          "number"
+        ],
+        "caseDensity": [
+          "null",
+          "number"
+        ],
+        "contactTracerCapacityRatio": [
+          "null",
+          "number"
+        ],
+        "infectionRate": [
+          "null",
+          "number"
+        ],
+        "infectionRateCI90": [
+          "null",
+          "number"
+        ],
+        "icuHeadroomRatio": [
+          "null",
+          "number"
+        ],
         "icuHeadroomDetails": {
           "$ref": "#/definitions/ICUHeadroomMetricDetails"
         },

--- a/api/schemas_v2/AggregateFlattenedTimeseries.json
+++ b/api/schemas_v2/AggregateFlattenedTimeseries.json
@@ -6,6 +6,23 @@
     "$ref": "#/definitions/MetricsTimeseriesRowWithHeader"
   },
   "definitions": {
+    "CovidPatientsMethod": {
+      "title": "CovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients with covid.",
+      "enum": [
+        "actual",
+        "estimated"
+      ]
+    },
+    "NonCovidPatientsMethod": {
+      "title": "NonCovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients without covid.",
+      "enum": [
+        "actual",
+        "estimated_from_typical_utilization",
+        "estimated_from_total_icu_actual"
+      ]
+    },
     "ICUHeadroomMetricDetails": {
       "title": "ICUHeadroomMetricDetails",
       "description": "Details about how the ICU Headroom Metric was calculated.",
@@ -17,12 +34,7 @@
           "type": "integer"
         },
         "currentIcuCovidMethod": {
-          "title": "Currenticucovidmethod",
-          "description": "Method used to determine number of current ICU patients with covid.",
-          "enum": [
-            "actual",
-            "estimated"
-          ]
+          "$ref": "#/definitions/CovidPatientsMethod"
         },
         "currentIcuNonCovid": {
           "title": "Currenticunoncovid",
@@ -30,13 +42,7 @@
           "type": "integer"
         },
         "currentIcuNonCovidMethod": {
-          "title": "Currenticunoncovidmethod",
-          "description": "Method used to determine number of current ICU patients without covid.",
-          "enum": [
-            "actual",
-            "estimated_from_typical_utilization",
-            "estimated_from_total_icu_actual"
-          ]
+          "$ref": "#/definitions/NonCovidPatientsMethod"
         }
       },
       "required": [
@@ -127,6 +133,13 @@
         }
       },
       "required": [
+        "testPositivityRatio",
+        "caseDensity",
+        "contactTracerCapacityRatio",
+        "infectionRate",
+        "infectionRateCI90",
+        "icuHeadroomRatio",
+        "icuHeadroomDetails",
         "date",
         "state",
         "fips",

--- a/api/schemas_v2/AggregateFlattenedTimeseries.json
+++ b/api/schemas_v2/AggregateFlattenedTimeseries.json
@@ -129,14 +129,7 @@
           ]
         },
         "icuHeadroomDetails": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ICUHeadroomMetricDetails"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "$ref": "#/definitions/ICUHeadroomMetricDetails"
         },
         "date": {
           "title": "Date",
@@ -188,7 +181,6 @@
         "infectionRate",
         "infectionRateCI90",
         "icuHeadroomRatio",
-        "icuHeadroomDetails",
         "date",
         "state",
         "fips",

--- a/api/schemas_v2/AggregateFlattenedTimeseries.json
+++ b/api/schemas_v2/AggregateFlattenedTimeseries.json
@@ -57,30 +57,66 @@
       "description": "Prediction timeseries row with location information.",
       "type": "object",
       "properties": {
-        "testPositivityRatio": [
-          "null",
-          "number"
-        ],
-        "caseDensity": [
-          "null",
-          "number"
-        ],
-        "contactTracerCapacityRatio": [
-          "null",
-          "number"
-        ],
-        "infectionRate": [
-          "null",
-          "number"
-        ],
-        "infectionRateCI90": [
-          "null",
-          "number"
-        ],
-        "icuHeadroomRatio": [
-          "null",
-          "number"
-        ],
+        "testPositivityRatio": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "caseDensity": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "contactTracerCapacityRatio": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "infectionRate": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "infectionRateCI90": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "icuHeadroomRatio": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
         "icuHeadroomDetails": {
           "$ref": "#/definitions/ICUHeadroomMetricDetails"
         },

--- a/api/schemas_v2/AggregateFlattenedTimeseries.json
+++ b/api/schemas_v2/AggregateFlattenedTimeseries.json
@@ -58,62 +58,73 @@
       "type": "object",
       "properties": {
         "testPositivityRatio": {
+          "title": "Testpositivityratio",
+          "description": "Ratio of people who test positive calculated using a 7-day rolling average.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "caseDensity": {
+          "title": "Casedensity",
+          "description": "The number of cases per 100k population calculated using a 7-day rolling average.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "contactTracerCapacityRatio": {
+          "title": "Contacttracercapacityratio",
+          "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "infectionRate": {
+          "title": "Infectionrate",
+          "description": "R_t, or the estimated number of infections arising from a typical case.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "infectionRateCI90": {
+          "title": "Infectionrateci90",
+          "description": "90th percentile confidence interval upper endpoint of the infection rate.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "icuHeadroomRatio": {
+          "title": "Icuheadroomratio",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },

--- a/api/schemas_v2/AggregateRegionSummary.json
+++ b/api/schemas_v2/AggregateRegionSummary.json
@@ -66,30 +66,66 @@
       "description": "Calculated metrics data based on known actuals.",
       "type": "object",
       "properties": {
-        "testPositivityRatio": [
-          "null",
-          "number"
-        ],
-        "caseDensity": [
-          "null",
-          "number"
-        ],
-        "contactTracerCapacityRatio": [
-          "null",
-          "number"
-        ],
-        "infectionRate": [
-          "null",
-          "number"
-        ],
-        "infectionRateCI90": [
-          "null",
-          "number"
-        ],
-        "icuHeadroomRatio": [
-          "null",
-          "number"
-        ],
+        "testPositivityRatio": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "caseDensity": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "contactTracerCapacityRatio": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "infectionRate": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "infectionRateCI90": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "icuHeadroomRatio": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
         "icuHeadroomDetails": {
           "$ref": "#/definitions/ICUHeadroomMetricDetails"
         }
@@ -109,22 +145,46 @@
       "description": "Base model for API output.",
       "type": "object",
       "properties": {
-        "capacity": [
-          "null",
-          "integer"
-        ],
-        "currentUsageTotal": [
-          "null",
-          "integer"
-        ],
-        "currentUsageCovid": [
-          "null",
-          "integer"
-        ],
-        "typicalUsageRate": [
-          "null",
-          "number"
-        ]
+        "capacity": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "currentUsageTotal": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "currentUsageCovid": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "typicalUsageRate": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        }
       },
       "required": [
         "capacity",
@@ -138,26 +198,56 @@
       "description": "Known actuals data.",
       "type": "object",
       "properties": {
-        "cases": [
-          "null",
-          "integer"
-        ],
-        "deaths": [
-          "null",
-          "integer"
-        ],
-        "positiveTests": [
-          "null",
-          "integer"
-        ],
-        "negativeTests": [
-          "null",
-          "integer"
-        ],
-        "contactTracers": [
-          "null",
-          "integer"
-        ],
+        "cases": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "deaths": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "positiveTests": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "negativeTests": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "contactTracers": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
         "hospitalBeds": {
           "title": "Hospitalbeds",
           "description": "Information about hospital bed utilization",
@@ -207,21 +297,39 @@
           "description": "2-letter ANSI state code.",
           "type": "string"
         },
-        "county": [
-          "null",
-          "string"
-        ],
+        "county": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
         "level": {
           "$ref": "#/definitions/AggregationLevel"
         },
-        "lat": [
-          "null",
-          "number"
-        ],
-        "long": [
-          "null",
-          "number"
-        ],
+        "lat": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "long": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
         "population": {
           "title": "Population",
           "description": "Total Population in geographic region.",

--- a/api/schemas_v2/AggregateRegionSummary.json
+++ b/api/schemas_v2/AggregateRegionSummary.json
@@ -67,62 +67,73 @@
       "type": "object",
       "properties": {
         "testPositivityRatio": {
+          "title": "Testpositivityratio",
+          "description": "Ratio of people who test positive calculated using a 7-day rolling average.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "caseDensity": {
+          "title": "Casedensity",
+          "description": "The number of cases per 100k population calculated using a 7-day rolling average.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "contactTracerCapacityRatio": {
+          "title": "Contacttracercapacityratio",
+          "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "infectionRate": {
+          "title": "Infectionrate",
+          "description": "R_t, or the estimated number of infections arising from a typical case.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "infectionRateCI90": {
+          "title": "Infectionrateci90",
+          "description": "90th percentile confidence interval upper endpoint of the infection rate.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "icuHeadroomRatio": {
+          "title": "Icuheadroomratio",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
@@ -146,42 +157,50 @@
       "type": "object",
       "properties": {
         "capacity": {
+          "title": "Capacity",
+          "description": "Total capacity for resource.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "currentUsageTotal": {
+          "title": "Currentusagetotal",
+          "description": "Currently used capacity for resource by all patients (COVID + Non-COVID)",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "currentUsageCovid": {
+          "title": "Currentusagecovid",
+          "description": "Currently used capacity for resource by COVID ",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "typicalUsageRate": {
+          "title": "Typicalusagerate",
+          "description": "Typical used capacity rate for resource. This excludes any COVID usage.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         }
@@ -199,52 +218,62 @@
       "type": "object",
       "properties": {
         "cases": {
+          "title": "Cases",
+          "description": "Cumulative number of confirmed or suspected cases",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "deaths": {
+          "title": "Deaths",
+          "description": "Cumulative number of deaths that are suspected or confirmed to have been caused by COVID-19",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "positiveTests": {
+          "title": "Positivetests",
+          "description": "Cumulative positive test results to date",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "negativeTests": {
+          "title": "Negativetests",
+          "description": "Cumulative negative test results to date",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "contactTracers": {
+          "title": "Contacttracers",
+          "description": "Number of Contact Tracers",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
@@ -298,12 +327,14 @@
           "type": "string"
         },
         "county": {
+          "title": "County",
+          "description": "County name",
           "anyOf": [
             {
-              "type": "null"
+              "type": "string"
             },
             {
-              "type": "string"
+              "type": "null"
             }
           ]
         },
@@ -311,22 +342,26 @@
           "$ref": "#/definitions/AggregationLevel"
         },
         "lat": {
+          "title": "Lat",
+          "description": "Latitude of point within the state or county",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "long": {
+          "title": "Long",
+          "description": "Longitude of point within the state or county",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },

--- a/api/schemas_v2/AggregateRegionSummary.json
+++ b/api/schemas_v2/AggregateRegionSummary.json
@@ -138,7 +138,14 @@
           ]
         },
         "icuHeadroomDetails": {
-          "$ref": "#/definitions/ICUHeadroomMetricDetails"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ICUHeadroomMetricDetails"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -372,7 +379,14 @@
           "type": "integer"
         },
         "metrics": {
-          "$ref": "#/definitions/Metrics"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Metrics"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "actuals": {
           "$ref": "#/definitions/Actuals"

--- a/api/schemas_v2/AggregateRegionSummary.json
+++ b/api/schemas_v2/AggregateRegionSummary.json
@@ -6,6 +6,32 @@
     "$ref": "#/definitions/RegionSummary"
   },
   "definitions": {
+    "AggregationLevel": {
+      "title": "AggregationLevel",
+      "description": "An enumeration.",
+      "enum": [
+        "country",
+        "state",
+        "county"
+      ]
+    },
+    "CovidPatientsMethod": {
+      "title": "CovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients with covid.",
+      "enum": [
+        "actual",
+        "estimated"
+      ]
+    },
+    "NonCovidPatientsMethod": {
+      "title": "NonCovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients without covid.",
+      "enum": [
+        "actual",
+        "estimated_from_typical_utilization",
+        "estimated_from_total_icu_actual"
+      ]
+    },
     "ICUHeadroomMetricDetails": {
       "title": "ICUHeadroomMetricDetails",
       "description": "Details about how the ICU Headroom Metric was calculated.",
@@ -17,12 +43,7 @@
           "type": "integer"
         },
         "currentIcuCovidMethod": {
-          "title": "Currenticucovidmethod",
-          "description": "Method used to determine number of current ICU patients with covid.",
-          "enum": [
-            "actual",
-            "estimated"
-          ]
+          "$ref": "#/definitions/CovidPatientsMethod"
         },
         "currentIcuNonCovid": {
           "title": "Currenticunoncovid",
@@ -30,13 +51,7 @@
           "type": "integer"
         },
         "currentIcuNonCovidMethod": {
-          "title": "Currenticunoncovidmethod",
-          "description": "Method used to determine number of current ICU patients without covid.",
-          "enum": [
-            "actual",
-            "estimated_from_typical_utilization",
-            "estimated_from_total_icu_actual"
-          ]
+          "$ref": "#/definitions/NonCovidPatientsMethod"
         }
       },
       "required": [
@@ -83,7 +98,16 @@
         "icuHeadroomDetails": {
           "$ref": "#/definitions/ICUHeadroomMetricDetails"
         }
-      }
+      },
+      "required": [
+        "testPositivityRatio",
+        "caseDensity",
+        "contactTracerCapacityRatio",
+        "infectionRate",
+        "infectionRateCI90",
+        "icuHeadroomRatio",
+        "icuHeadroomDetails"
+      ]
     },
     "HospitalResourceUtilization": {
       "title": "HospitalResourceUtilization",
@@ -110,7 +134,13 @@
           "description": "Typical used capacity rate for resource. This excludes any COVID usage.",
           "type": "number"
         }
-      }
+      },
+      "required": [
+        "capacity",
+        "currentUsageTotal",
+        "currentUsageCovid",
+        "typicalUsageRate"
+      ]
     },
     "Actuals": {
       "title": "Actuals",
@@ -160,7 +190,16 @@
             }
           ]
         }
-      }
+      },
+      "required": [
+        "cases",
+        "deaths",
+        "positiveTests",
+        "negativeTests",
+        "contactTracers",
+        "hospitalBeds",
+        "icuBeds"
+      ]
     },
     "RegionSummary": {
       "title": "RegionSummary",
@@ -188,13 +227,7 @@
           "type": "string"
         },
         "level": {
-          "title": "Level",
-          "description": "Level of region.",
-          "enum": [
-            "country",
-            "state",
-            "county"
-          ]
+          "$ref": "#/definitions/AggregationLevel"
         },
         "lat": {
           "title": "Lat",
@@ -229,8 +262,12 @@
         "fips",
         "country",
         "state",
+        "county",
         "level",
+        "lat",
+        "long",
         "population",
+        "metrics",
         "actuals",
         "lastUpdatedDate"
       ]

--- a/api/schemas_v2/AggregateRegionSummary.json
+++ b/api/schemas_v2/AggregateRegionSummary.json
@@ -138,14 +138,7 @@
           ]
         },
         "icuHeadroomDetails": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ICUHeadroomMetricDetails"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "$ref": "#/definitions/ICUHeadroomMetricDetails"
         }
       },
       "required": [
@@ -154,8 +147,7 @@
         "contactTracerCapacityRatio",
         "infectionRate",
         "infectionRateCI90",
-        "icuHeadroomRatio",
-        "icuHeadroomDetails"
+        "icuHeadroomRatio"
       ]
     },
     "HospitalResourceUtilization": {

--- a/api/schemas_v2/AggregateRegionSummary.json
+++ b/api/schemas_v2/AggregateRegionSummary.json
@@ -66,35 +66,30 @@
       "description": "Calculated metrics data based on known actuals.",
       "type": "object",
       "properties": {
-        "testPositivityRatio": {
-          "title": "Testpositivityratio",
-          "description": "Ratio of people who test positive calculated using a 7-day rolling average.",
-          "type": "number"
-        },
-        "caseDensity": {
-          "title": "Casedensity",
-          "description": "The number of cases per 100k population calculated using a 7-day rolling average.",
-          "type": "number"
-        },
-        "contactTracerCapacityRatio": {
-          "title": "Contacttracercapacityratio",
-          "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average.",
-          "type": "number"
-        },
-        "infectionRate": {
-          "title": "Infectionrate",
-          "description": "R_t, or the estimated number of infections arising from a typical case.",
-          "type": "number"
-        },
-        "infectionRateCI90": {
-          "title": "Infectionrateci90",
-          "description": "90th percentile confidence interval upper endpoint of the infection rate.",
-          "type": "number"
-        },
-        "icuHeadroomRatio": {
-          "title": "Icuheadroomratio",
-          "type": "number"
-        },
+        "testPositivityRatio": [
+          "null",
+          "number"
+        ],
+        "caseDensity": [
+          "null",
+          "number"
+        ],
+        "contactTracerCapacityRatio": [
+          "null",
+          "number"
+        ],
+        "infectionRate": [
+          "null",
+          "number"
+        ],
+        "infectionRateCI90": [
+          "null",
+          "number"
+        ],
+        "icuHeadroomRatio": [
+          "null",
+          "number"
+        ],
         "icuHeadroomDetails": {
           "$ref": "#/definitions/ICUHeadroomMetricDetails"
         }
@@ -114,26 +109,22 @@
       "description": "Base model for API output.",
       "type": "object",
       "properties": {
-        "capacity": {
-          "title": "Capacity",
-          "description": "Total capacity for resource.",
-          "type": "integer"
-        },
-        "currentUsageTotal": {
-          "title": "Currentusagetotal",
-          "description": "Currently used capacity for resource by all patients (COVID + Non-COVID)",
-          "type": "integer"
-        },
-        "currentUsageCovid": {
-          "title": "Currentusagecovid",
-          "description": "Currently used capacity for resource by COVID ",
-          "type": "integer"
-        },
-        "typicalUsageRate": {
-          "title": "Typicalusagerate",
-          "description": "Typical used capacity rate for resource. This excludes any COVID usage.",
-          "type": "number"
-        }
+        "capacity": [
+          "null",
+          "integer"
+        ],
+        "currentUsageTotal": [
+          "null",
+          "integer"
+        ],
+        "currentUsageCovid": [
+          "null",
+          "integer"
+        ],
+        "typicalUsageRate": [
+          "null",
+          "number"
+        ]
       },
       "required": [
         "capacity",
@@ -147,31 +138,26 @@
       "description": "Known actuals data.",
       "type": "object",
       "properties": {
-        "cases": {
-          "title": "Cases",
-          "description": "Cumulative number of confirmed or suspected cases",
-          "type": "integer"
-        },
-        "deaths": {
-          "title": "Deaths",
-          "description": "Cumulative number of deaths that are suspected or confirmed to have been caused by COVID-19",
-          "type": "integer"
-        },
-        "positiveTests": {
-          "title": "Positivetests",
-          "description": "Cumulative positive test results to date",
-          "type": "integer"
-        },
-        "negativeTests": {
-          "title": "Negativetests",
-          "description": "Cumulative negative test results to date",
-          "type": "integer"
-        },
-        "contactTracers": {
-          "title": "Contacttracers",
-          "description": "Number of Contact Tracers",
-          "type": "integer"
-        },
+        "cases": [
+          "null",
+          "integer"
+        ],
+        "deaths": [
+          "null",
+          "integer"
+        ],
+        "positiveTests": [
+          "null",
+          "integer"
+        ],
+        "negativeTests": [
+          "null",
+          "integer"
+        ],
+        "contactTracers": [
+          "null",
+          "integer"
+        ],
         "hospitalBeds": {
           "title": "Hospitalbeds",
           "description": "Information about hospital bed utilization",
@@ -221,24 +207,21 @@
           "description": "2-letter ANSI state code.",
           "type": "string"
         },
-        "county": {
-          "title": "County",
-          "description": "County name",
-          "type": "string"
-        },
+        "county": [
+          "null",
+          "string"
+        ],
         "level": {
           "$ref": "#/definitions/AggregationLevel"
         },
-        "lat": {
-          "title": "Lat",
-          "description": "Latitude of point within the state or county",
-          "type": "number"
-        },
-        "long": {
-          "title": "Long",
-          "description": "Longitude of point within the state or county",
-          "type": "number"
-        },
+        "lat": [
+          "null",
+          "number"
+        ],
+        "long": [
+          "null",
+          "number"
+        ],
         "population": {
           "title": "Population",
           "description": "Total Population in geographic region.",

--- a/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
@@ -6,6 +6,32 @@
     "$ref": "#/definitions/RegionSummaryWithTimeseries"
   },
   "definitions": {
+    "AggregationLevel": {
+      "title": "AggregationLevel",
+      "description": "An enumeration.",
+      "enum": [
+        "country",
+        "state",
+        "county"
+      ]
+    },
+    "CovidPatientsMethod": {
+      "title": "CovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients with covid.",
+      "enum": [
+        "actual",
+        "estimated"
+      ]
+    },
+    "NonCovidPatientsMethod": {
+      "title": "NonCovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients without covid.",
+      "enum": [
+        "actual",
+        "estimated_from_typical_utilization",
+        "estimated_from_total_icu_actual"
+      ]
+    },
     "ICUHeadroomMetricDetails": {
       "title": "ICUHeadroomMetricDetails",
       "description": "Details about how the ICU Headroom Metric was calculated.",
@@ -17,12 +43,7 @@
           "type": "integer"
         },
         "currentIcuCovidMethod": {
-          "title": "Currenticucovidmethod",
-          "description": "Method used to determine number of current ICU patients with covid.",
-          "enum": [
-            "actual",
-            "estimated"
-          ]
+          "$ref": "#/definitions/CovidPatientsMethod"
         },
         "currentIcuNonCovid": {
           "title": "Currenticunoncovid",
@@ -30,13 +51,7 @@
           "type": "integer"
         },
         "currentIcuNonCovidMethod": {
-          "title": "Currenticunoncovidmethod",
-          "description": "Method used to determine number of current ICU patients without covid.",
-          "enum": [
-            "actual",
-            "estimated_from_typical_utilization",
-            "estimated_from_total_icu_actual"
-          ]
+          "$ref": "#/definitions/NonCovidPatientsMethod"
         }
       },
       "required": [
@@ -83,7 +98,16 @@
         "icuHeadroomDetails": {
           "$ref": "#/definitions/ICUHeadroomMetricDetails"
         }
-      }
+      },
+      "required": [
+        "testPositivityRatio",
+        "caseDensity",
+        "contactTracerCapacityRatio",
+        "infectionRate",
+        "infectionRateCI90",
+        "icuHeadroomRatio",
+        "icuHeadroomDetails"
+      ]
     },
     "HospitalResourceUtilization": {
       "title": "HospitalResourceUtilization",
@@ -110,7 +134,13 @@
           "description": "Typical used capacity rate for resource. This excludes any COVID usage.",
           "type": "number"
         }
-      }
+      },
+      "required": [
+        "capacity",
+        "currentUsageTotal",
+        "currentUsageCovid",
+        "typicalUsageRate"
+      ]
     },
     "Actuals": {
       "title": "Actuals",
@@ -160,7 +190,16 @@
             }
           ]
         }
-      }
+      },
+      "required": [
+        "cases",
+        "deaths",
+        "positiveTests",
+        "negativeTests",
+        "contactTracers",
+        "hospitalBeds",
+        "icuBeds"
+      ]
     },
     "MetricsTimeseriesRow": {
       "title": "MetricsTimeseriesRow",
@@ -207,6 +246,13 @@
         }
       },
       "required": [
+        "testPositivityRatio",
+        "caseDensity",
+        "contactTracerCapacityRatio",
+        "infectionRate",
+        "infectionRateCI90",
+        "icuHeadroomRatio",
+        "icuHeadroomDetails",
         "date"
       ]
     },
@@ -266,6 +312,13 @@
         }
       },
       "required": [
+        "cases",
+        "deaths",
+        "positiveTests",
+        "negativeTests",
+        "contactTracers",
+        "hospitalBeds",
+        "icuBeds",
         "date"
       ]
     },
@@ -295,13 +348,7 @@
           "type": "string"
         },
         "level": {
-          "title": "Level",
-          "description": "Level of region.",
-          "enum": [
-            "country",
-            "state",
-            "county"
-          ]
+          "$ref": "#/definitions/AggregationLevel"
         },
         "lat": {
           "title": "Lat",
@@ -350,8 +397,12 @@
         "fips",
         "country",
         "state",
+        "county",
         "level",
+        "lat",
+        "long",
         "population",
+        "metrics",
         "actuals",
         "lastUpdatedDate",
         "actualsTimeseries"

--- a/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
@@ -138,14 +138,7 @@
           ]
         },
         "icuHeadroomDetails": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ICUHeadroomMetricDetails"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "$ref": "#/definitions/ICUHeadroomMetricDetails"
         }
       },
       "required": [
@@ -154,8 +147,7 @@
         "contactTracerCapacityRatio",
         "infectionRate",
         "infectionRateCI90",
-        "icuHeadroomRatio",
-        "icuHeadroomDetails"
+        "icuHeadroomRatio"
       ]
     },
     "HospitalResourceUtilization": {
@@ -390,14 +382,7 @@
           ]
         },
         "icuHeadroomDetails": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ICUHeadroomMetricDetails"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "$ref": "#/definitions/ICUHeadroomMetricDetails"
         },
         "date": {
           "title": "Date",
@@ -413,7 +398,6 @@
         "infectionRate",
         "infectionRateCI90",
         "icuHeadroomRatio",
-        "icuHeadroomDetails",
         "date"
       ]
     },

--- a/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
@@ -138,7 +138,14 @@
           ]
         },
         "icuHeadroomDetails": {
-          "$ref": "#/definitions/ICUHeadroomMetricDetails"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ICUHeadroomMetricDetails"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -383,7 +390,14 @@
           ]
         },
         "icuHeadroomDetails": {
-          "$ref": "#/definitions/ICUHeadroomMetricDetails"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ICUHeadroomMetricDetails"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "date": {
           "title": "Date",
@@ -570,7 +584,14 @@
           "type": "integer"
         },
         "metrics": {
-          "$ref": "#/definitions/Metrics"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Metrics"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "actuals": {
           "$ref": "#/definitions/Actuals"

--- a/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
@@ -66,30 +66,66 @@
       "description": "Calculated metrics data based on known actuals.",
       "type": "object",
       "properties": {
-        "testPositivityRatio": [
-          "null",
-          "number"
-        ],
-        "caseDensity": [
-          "null",
-          "number"
-        ],
-        "contactTracerCapacityRatio": [
-          "null",
-          "number"
-        ],
-        "infectionRate": [
-          "null",
-          "number"
-        ],
-        "infectionRateCI90": [
-          "null",
-          "number"
-        ],
-        "icuHeadroomRatio": [
-          "null",
-          "number"
-        ],
+        "testPositivityRatio": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "caseDensity": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "contactTracerCapacityRatio": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "infectionRate": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "infectionRateCI90": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "icuHeadroomRatio": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
         "icuHeadroomDetails": {
           "$ref": "#/definitions/ICUHeadroomMetricDetails"
         }
@@ -109,22 +145,46 @@
       "description": "Base model for API output.",
       "type": "object",
       "properties": {
-        "capacity": [
-          "null",
-          "integer"
-        ],
-        "currentUsageTotal": [
-          "null",
-          "integer"
-        ],
-        "currentUsageCovid": [
-          "null",
-          "integer"
-        ],
-        "typicalUsageRate": [
-          "null",
-          "number"
-        ]
+        "capacity": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "currentUsageTotal": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "currentUsageCovid": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "typicalUsageRate": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        }
       },
       "required": [
         "capacity",
@@ -138,26 +198,56 @@
       "description": "Known actuals data.",
       "type": "object",
       "properties": {
-        "cases": [
-          "null",
-          "integer"
-        ],
-        "deaths": [
-          "null",
-          "integer"
-        ],
-        "positiveTests": [
-          "null",
-          "integer"
-        ],
-        "negativeTests": [
-          "null",
-          "integer"
-        ],
-        "contactTracers": [
-          "null",
-          "integer"
-        ],
+        "cases": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "deaths": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "positiveTests": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "negativeTests": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "contactTracers": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
         "hospitalBeds": {
           "title": "Hospitalbeds",
           "description": "Information about hospital bed utilization",
@@ -192,30 +282,66 @@
       "description": "Metrics data for a specific day.",
       "type": "object",
       "properties": {
-        "testPositivityRatio": [
-          "null",
-          "number"
-        ],
-        "caseDensity": [
-          "null",
-          "number"
-        ],
-        "contactTracerCapacityRatio": [
-          "null",
-          "number"
-        ],
-        "infectionRate": [
-          "null",
-          "number"
-        ],
-        "infectionRateCI90": [
-          "null",
-          "number"
-        ],
-        "icuHeadroomRatio": [
-          "null",
-          "number"
-        ],
+        "testPositivityRatio": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "caseDensity": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "contactTracerCapacityRatio": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "infectionRate": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "infectionRateCI90": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "icuHeadroomRatio": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
         "icuHeadroomDetails": {
           "$ref": "#/definitions/ICUHeadroomMetricDetails"
         },
@@ -242,26 +368,56 @@
       "description": "Actual data for a specific day.",
       "type": "object",
       "properties": {
-        "cases": [
-          "null",
-          "integer"
-        ],
-        "deaths": [
-          "null",
-          "integer"
-        ],
-        "positiveTests": [
-          "null",
-          "integer"
-        ],
-        "negativeTests": [
-          "null",
-          "integer"
-        ],
-        "contactTracers": [
-          "null",
-          "integer"
-        ],
+        "cases": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "deaths": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "positiveTests": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "negativeTests": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "contactTracers": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
         "hospitalBeds": {
           "title": "Hospitalbeds",
           "description": "Information about hospital bed utilization",
@@ -318,21 +474,39 @@
           "description": "2-letter ANSI state code.",
           "type": "string"
         },
-        "county": [
-          "null",
-          "string"
-        ],
+        "county": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
         "level": {
           "$ref": "#/definitions/AggregationLevel"
         },
-        "lat": [
-          "null",
-          "number"
-        ],
-        "long": [
-          "null",
-          "number"
-        ],
+        "lat": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "long": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
         "population": {
           "title": "Population",
           "description": "Total Population in geographic region.",

--- a/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
@@ -67,62 +67,73 @@
       "type": "object",
       "properties": {
         "testPositivityRatio": {
+          "title": "Testpositivityratio",
+          "description": "Ratio of people who test positive calculated using a 7-day rolling average.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "caseDensity": {
+          "title": "Casedensity",
+          "description": "The number of cases per 100k population calculated using a 7-day rolling average.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "contactTracerCapacityRatio": {
+          "title": "Contacttracercapacityratio",
+          "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "infectionRate": {
+          "title": "Infectionrate",
+          "description": "R_t, or the estimated number of infections arising from a typical case.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "infectionRateCI90": {
+          "title": "Infectionrateci90",
+          "description": "90th percentile confidence interval upper endpoint of the infection rate.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "icuHeadroomRatio": {
+          "title": "Icuheadroomratio",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
@@ -146,42 +157,50 @@
       "type": "object",
       "properties": {
         "capacity": {
+          "title": "Capacity",
+          "description": "Total capacity for resource.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "currentUsageTotal": {
+          "title": "Currentusagetotal",
+          "description": "Currently used capacity for resource by all patients (COVID + Non-COVID)",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "currentUsageCovid": {
+          "title": "Currentusagecovid",
+          "description": "Currently used capacity for resource by COVID ",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "typicalUsageRate": {
+          "title": "Typicalusagerate",
+          "description": "Typical used capacity rate for resource. This excludes any COVID usage.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         }
@@ -199,52 +218,62 @@
       "type": "object",
       "properties": {
         "cases": {
+          "title": "Cases",
+          "description": "Cumulative number of confirmed or suspected cases",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "deaths": {
+          "title": "Deaths",
+          "description": "Cumulative number of deaths that are suspected or confirmed to have been caused by COVID-19",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "positiveTests": {
+          "title": "Positivetests",
+          "description": "Cumulative positive test results to date",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "negativeTests": {
+          "title": "Negativetests",
+          "description": "Cumulative negative test results to date",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "contactTracers": {
+          "title": "Contacttracers",
+          "description": "Number of Contact Tracers",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
@@ -283,62 +312,73 @@
       "type": "object",
       "properties": {
         "testPositivityRatio": {
+          "title": "Testpositivityratio",
+          "description": "Ratio of people who test positive calculated using a 7-day rolling average.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "caseDensity": {
+          "title": "Casedensity",
+          "description": "The number of cases per 100k population calculated using a 7-day rolling average.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "contactTracerCapacityRatio": {
+          "title": "Contacttracercapacityratio",
+          "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "infectionRate": {
+          "title": "Infectionrate",
+          "description": "R_t, or the estimated number of infections arising from a typical case.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "infectionRateCI90": {
+          "title": "Infectionrateci90",
+          "description": "90th percentile confidence interval upper endpoint of the infection rate.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "icuHeadroomRatio": {
+          "title": "Icuheadroomratio",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
@@ -369,52 +409,62 @@
       "type": "object",
       "properties": {
         "cases": {
+          "title": "Cases",
+          "description": "Cumulative number of confirmed or suspected cases",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "deaths": {
+          "title": "Deaths",
+          "description": "Cumulative number of deaths that are suspected or confirmed to have been caused by COVID-19",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "positiveTests": {
+          "title": "Positivetests",
+          "description": "Cumulative positive test results to date",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "negativeTests": {
+          "title": "Negativetests",
+          "description": "Cumulative negative test results to date",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "contactTracers": {
+          "title": "Contacttracers",
+          "description": "Number of Contact Tracers",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
@@ -475,12 +525,14 @@
           "type": "string"
         },
         "county": {
+          "title": "County",
+          "description": "County name",
           "anyOf": [
             {
-              "type": "null"
+              "type": "string"
             },
             {
-              "type": "string"
+              "type": "null"
             }
           ]
         },
@@ -488,22 +540,26 @@
           "$ref": "#/definitions/AggregationLevel"
         },
         "lat": {
+          "title": "Lat",
+          "description": "Latitude of point within the state or county",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "long": {
+          "title": "Long",
+          "description": "Longitude of point within the state or county",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },

--- a/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
@@ -66,35 +66,30 @@
       "description": "Calculated metrics data based on known actuals.",
       "type": "object",
       "properties": {
-        "testPositivityRatio": {
-          "title": "Testpositivityratio",
-          "description": "Ratio of people who test positive calculated using a 7-day rolling average.",
-          "type": "number"
-        },
-        "caseDensity": {
-          "title": "Casedensity",
-          "description": "The number of cases per 100k population calculated using a 7-day rolling average.",
-          "type": "number"
-        },
-        "contactTracerCapacityRatio": {
-          "title": "Contacttracercapacityratio",
-          "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average.",
-          "type": "number"
-        },
-        "infectionRate": {
-          "title": "Infectionrate",
-          "description": "R_t, or the estimated number of infections arising from a typical case.",
-          "type": "number"
-        },
-        "infectionRateCI90": {
-          "title": "Infectionrateci90",
-          "description": "90th percentile confidence interval upper endpoint of the infection rate.",
-          "type": "number"
-        },
-        "icuHeadroomRatio": {
-          "title": "Icuheadroomratio",
-          "type": "number"
-        },
+        "testPositivityRatio": [
+          "null",
+          "number"
+        ],
+        "caseDensity": [
+          "null",
+          "number"
+        ],
+        "contactTracerCapacityRatio": [
+          "null",
+          "number"
+        ],
+        "infectionRate": [
+          "null",
+          "number"
+        ],
+        "infectionRateCI90": [
+          "null",
+          "number"
+        ],
+        "icuHeadroomRatio": [
+          "null",
+          "number"
+        ],
         "icuHeadroomDetails": {
           "$ref": "#/definitions/ICUHeadroomMetricDetails"
         }
@@ -114,26 +109,22 @@
       "description": "Base model for API output.",
       "type": "object",
       "properties": {
-        "capacity": {
-          "title": "Capacity",
-          "description": "Total capacity for resource.",
-          "type": "integer"
-        },
-        "currentUsageTotal": {
-          "title": "Currentusagetotal",
-          "description": "Currently used capacity for resource by all patients (COVID + Non-COVID)",
-          "type": "integer"
-        },
-        "currentUsageCovid": {
-          "title": "Currentusagecovid",
-          "description": "Currently used capacity for resource by COVID ",
-          "type": "integer"
-        },
-        "typicalUsageRate": {
-          "title": "Typicalusagerate",
-          "description": "Typical used capacity rate for resource. This excludes any COVID usage.",
-          "type": "number"
-        }
+        "capacity": [
+          "null",
+          "integer"
+        ],
+        "currentUsageTotal": [
+          "null",
+          "integer"
+        ],
+        "currentUsageCovid": [
+          "null",
+          "integer"
+        ],
+        "typicalUsageRate": [
+          "null",
+          "number"
+        ]
       },
       "required": [
         "capacity",
@@ -147,31 +138,26 @@
       "description": "Known actuals data.",
       "type": "object",
       "properties": {
-        "cases": {
-          "title": "Cases",
-          "description": "Cumulative number of confirmed or suspected cases",
-          "type": "integer"
-        },
-        "deaths": {
-          "title": "Deaths",
-          "description": "Cumulative number of deaths that are suspected or confirmed to have been caused by COVID-19",
-          "type": "integer"
-        },
-        "positiveTests": {
-          "title": "Positivetests",
-          "description": "Cumulative positive test results to date",
-          "type": "integer"
-        },
-        "negativeTests": {
-          "title": "Negativetests",
-          "description": "Cumulative negative test results to date",
-          "type": "integer"
-        },
-        "contactTracers": {
-          "title": "Contacttracers",
-          "description": "Number of Contact Tracers",
-          "type": "integer"
-        },
+        "cases": [
+          "null",
+          "integer"
+        ],
+        "deaths": [
+          "null",
+          "integer"
+        ],
+        "positiveTests": [
+          "null",
+          "integer"
+        ],
+        "negativeTests": [
+          "null",
+          "integer"
+        ],
+        "contactTracers": [
+          "null",
+          "integer"
+        ],
         "hospitalBeds": {
           "title": "Hospitalbeds",
           "description": "Information about hospital bed utilization",
@@ -206,35 +192,30 @@
       "description": "Metrics data for a specific day.",
       "type": "object",
       "properties": {
-        "testPositivityRatio": {
-          "title": "Testpositivityratio",
-          "description": "Ratio of people who test positive calculated using a 7-day rolling average.",
-          "type": "number"
-        },
-        "caseDensity": {
-          "title": "Casedensity",
-          "description": "The number of cases per 100k population calculated using a 7-day rolling average.",
-          "type": "number"
-        },
-        "contactTracerCapacityRatio": {
-          "title": "Contacttracercapacityratio",
-          "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average.",
-          "type": "number"
-        },
-        "infectionRate": {
-          "title": "Infectionrate",
-          "description": "R_t, or the estimated number of infections arising from a typical case.",
-          "type": "number"
-        },
-        "infectionRateCI90": {
-          "title": "Infectionrateci90",
-          "description": "90th percentile confidence interval upper endpoint of the infection rate.",
-          "type": "number"
-        },
-        "icuHeadroomRatio": {
-          "title": "Icuheadroomratio",
-          "type": "number"
-        },
+        "testPositivityRatio": [
+          "null",
+          "number"
+        ],
+        "caseDensity": [
+          "null",
+          "number"
+        ],
+        "contactTracerCapacityRatio": [
+          "null",
+          "number"
+        ],
+        "infectionRate": [
+          "null",
+          "number"
+        ],
+        "infectionRateCI90": [
+          "null",
+          "number"
+        ],
+        "icuHeadroomRatio": [
+          "null",
+          "number"
+        ],
         "icuHeadroomDetails": {
           "$ref": "#/definitions/ICUHeadroomMetricDetails"
         },
@@ -261,31 +242,26 @@
       "description": "Actual data for a specific day.",
       "type": "object",
       "properties": {
-        "cases": {
-          "title": "Cases",
-          "description": "Cumulative number of confirmed or suspected cases",
-          "type": "integer"
-        },
-        "deaths": {
-          "title": "Deaths",
-          "description": "Cumulative number of deaths that are suspected or confirmed to have been caused by COVID-19",
-          "type": "integer"
-        },
-        "positiveTests": {
-          "title": "Positivetests",
-          "description": "Cumulative positive test results to date",
-          "type": "integer"
-        },
-        "negativeTests": {
-          "title": "Negativetests",
-          "description": "Cumulative negative test results to date",
-          "type": "integer"
-        },
-        "contactTracers": {
-          "title": "Contacttracers",
-          "description": "Number of Contact Tracers",
-          "type": "integer"
-        },
+        "cases": [
+          "null",
+          "integer"
+        ],
+        "deaths": [
+          "null",
+          "integer"
+        ],
+        "positiveTests": [
+          "null",
+          "integer"
+        ],
+        "negativeTests": [
+          "null",
+          "integer"
+        ],
+        "contactTracers": [
+          "null",
+          "integer"
+        ],
         "hospitalBeds": {
           "title": "Hospitalbeds",
           "description": "Information about hospital bed utilization",
@@ -342,24 +318,21 @@
           "description": "2-letter ANSI state code.",
           "type": "string"
         },
-        "county": {
-          "title": "County",
-          "description": "County name",
-          "type": "string"
-        },
+        "county": [
+          "null",
+          "string"
+        ],
         "level": {
           "$ref": "#/definitions/AggregationLevel"
         },
-        "lat": {
-          "title": "Lat",
-          "description": "Latitude of point within the state or county",
-          "type": "number"
-        },
-        "long": {
-          "title": "Long",
-          "description": "Longitude of point within the state or county",
-          "type": "number"
-        },
+        "lat": [
+          "null",
+          "number"
+        ],
+        "long": [
+          "null",
+          "number"
+        ],
         "population": {
           "title": "Population",
           "description": "Total Population in geographic region.",

--- a/api/schemas_v2/HospitalResourceUtilization.json
+++ b/api/schemas_v2/HospitalResourceUtilization.json
@@ -23,5 +23,11 @@
       "description": "Typical used capacity rate for resource. This excludes any COVID usage.",
       "type": "number"
     }
-  }
+  },
+  "required": [
+    "capacity",
+    "currentUsageTotal",
+    "currentUsageCovid",
+    "typicalUsageRate"
+  ]
 }

--- a/api/schemas_v2/HospitalResourceUtilization.json
+++ b/api/schemas_v2/HospitalResourceUtilization.json
@@ -4,42 +4,50 @@
   "type": "object",
   "properties": {
     "capacity": {
+      "title": "Capacity",
+      "description": "Total capacity for resource.",
       "anyOf": [
         {
-          "type": "null"
+          "type": "integer"
         },
         {
-          "type": "integer"
+          "type": "null"
         }
       ]
     },
     "currentUsageTotal": {
+      "title": "Currentusagetotal",
+      "description": "Currently used capacity for resource by all patients (COVID + Non-COVID)",
       "anyOf": [
         {
-          "type": "null"
+          "type": "integer"
         },
         {
-          "type": "integer"
+          "type": "null"
         }
       ]
     },
     "currentUsageCovid": {
+      "title": "Currentusagecovid",
+      "description": "Currently used capacity for resource by COVID ",
       "anyOf": [
         {
-          "type": "null"
+          "type": "integer"
         },
         {
-          "type": "integer"
+          "type": "null"
         }
       ]
     },
     "typicalUsageRate": {
+      "title": "Typicalusagerate",
+      "description": "Typical used capacity rate for resource. This excludes any COVID usage.",
       "anyOf": [
         {
-          "type": "null"
+          "type": "number"
         },
         {
-          "type": "number"
+          "type": "null"
         }
       ]
     }

--- a/api/schemas_v2/HospitalResourceUtilization.json
+++ b/api/schemas_v2/HospitalResourceUtilization.json
@@ -3,22 +3,46 @@
   "description": "Base model for API output.",
   "type": "object",
   "properties": {
-    "capacity": [
-      "null",
-      "integer"
-    ],
-    "currentUsageTotal": [
-      "null",
-      "integer"
-    ],
-    "currentUsageCovid": [
-      "null",
-      "integer"
-    ],
-    "typicalUsageRate": [
-      "null",
-      "number"
-    ]
+    "capacity": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "currentUsageTotal": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "currentUsageCovid": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "typicalUsageRate": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    }
   },
   "required": [
     "capacity",

--- a/api/schemas_v2/HospitalResourceUtilization.json
+++ b/api/schemas_v2/HospitalResourceUtilization.json
@@ -3,26 +3,22 @@
   "description": "Base model for API output.",
   "type": "object",
   "properties": {
-    "capacity": {
-      "title": "Capacity",
-      "description": "Total capacity for resource.",
-      "type": "integer"
-    },
-    "currentUsageTotal": {
-      "title": "Currentusagetotal",
-      "description": "Currently used capacity for resource by all patients (COVID + Non-COVID)",
-      "type": "integer"
-    },
-    "currentUsageCovid": {
-      "title": "Currentusagecovid",
-      "description": "Currently used capacity for resource by COVID ",
-      "type": "integer"
-    },
-    "typicalUsageRate": {
-      "title": "Typicalusagerate",
-      "description": "Typical used capacity rate for resource. This excludes any COVID usage.",
-      "type": "number"
-    }
+    "capacity": [
+      "null",
+      "integer"
+    ],
+    "currentUsageTotal": [
+      "null",
+      "integer"
+    ],
+    "currentUsageCovid": [
+      "null",
+      "integer"
+    ],
+    "typicalUsageRate": [
+      "null",
+      "number"
+    ]
   },
   "required": [
     "capacity",

--- a/api/schemas_v2/Metrics.json
+++ b/api/schemas_v2/Metrics.json
@@ -4,62 +4,73 @@
   "type": "object",
   "properties": {
     "testPositivityRatio": {
+      "title": "Testpositivityratio",
+      "description": "Ratio of people who test positive calculated using a 7-day rolling average.",
       "anyOf": [
         {
-          "type": "null"
+          "type": "number"
         },
         {
-          "type": "number"
+          "type": "null"
         }
       ]
     },
     "caseDensity": {
+      "title": "Casedensity",
+      "description": "The number of cases per 100k population calculated using a 7-day rolling average.",
       "anyOf": [
         {
-          "type": "null"
+          "type": "number"
         },
         {
-          "type": "number"
+          "type": "null"
         }
       ]
     },
     "contactTracerCapacityRatio": {
+      "title": "Contacttracercapacityratio",
+      "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average.",
       "anyOf": [
         {
-          "type": "null"
+          "type": "number"
         },
         {
-          "type": "number"
+          "type": "null"
         }
       ]
     },
     "infectionRate": {
+      "title": "Infectionrate",
+      "description": "R_t, or the estimated number of infections arising from a typical case.",
       "anyOf": [
         {
-          "type": "null"
+          "type": "number"
         },
         {
-          "type": "number"
+          "type": "null"
         }
       ]
     },
     "infectionRateCI90": {
+      "title": "Infectionrateci90",
+      "description": "90th percentile confidence interval upper endpoint of the infection rate.",
       "anyOf": [
         {
-          "type": "null"
+          "type": "number"
         },
         {
-          "type": "number"
+          "type": "null"
         }
       ]
     },
     "icuHeadroomRatio": {
+      "title": "Icuheadroomratio",
       "anyOf": [
         {
-          "type": "null"
+          "type": "number"
         },
         {
-          "type": "number"
+          "type": "null"
         }
       ]
     },

--- a/api/schemas_v2/Metrics.json
+++ b/api/schemas_v2/Metrics.json
@@ -75,14 +75,7 @@
       ]
     },
     "icuHeadroomDetails": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ICUHeadroomMetricDetails"
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "$ref": "#/definitions/ICUHeadroomMetricDetails"
     }
   },
   "required": [
@@ -91,8 +84,7 @@
     "contactTracerCapacityRatio",
     "infectionRate",
     "infectionRateCI90",
-    "icuHeadroomRatio",
-    "icuHeadroomDetails"
+    "icuHeadroomRatio"
   ],
   "definitions": {
     "CovidPatientsMethod": {

--- a/api/schemas_v2/Metrics.json
+++ b/api/schemas_v2/Metrics.json
@@ -36,7 +36,33 @@
       "$ref": "#/definitions/ICUHeadroomMetricDetails"
     }
   },
+  "required": [
+    "testPositivityRatio",
+    "caseDensity",
+    "contactTracerCapacityRatio",
+    "infectionRate",
+    "infectionRateCI90",
+    "icuHeadroomRatio",
+    "icuHeadroomDetails"
+  ],
   "definitions": {
+    "CovidPatientsMethod": {
+      "title": "CovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients with covid.",
+      "enum": [
+        "actual",
+        "estimated"
+      ]
+    },
+    "NonCovidPatientsMethod": {
+      "title": "NonCovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients without covid.",
+      "enum": [
+        "actual",
+        "estimated_from_typical_utilization",
+        "estimated_from_total_icu_actual"
+      ]
+    },
     "ICUHeadroomMetricDetails": {
       "title": "ICUHeadroomMetricDetails",
       "description": "Details about how the ICU Headroom Metric was calculated.",
@@ -48,12 +74,7 @@
           "type": "integer"
         },
         "currentIcuCovidMethod": {
-          "title": "Currenticucovidmethod",
-          "description": "Method used to determine number of current ICU patients with covid.",
-          "enum": [
-            "actual",
-            "estimated"
-          ]
+          "$ref": "#/definitions/CovidPatientsMethod"
         },
         "currentIcuNonCovid": {
           "title": "Currenticunoncovid",
@@ -61,13 +82,7 @@
           "type": "integer"
         },
         "currentIcuNonCovidMethod": {
-          "title": "Currenticunoncovidmethod",
-          "description": "Method used to determine number of current ICU patients without covid.",
-          "enum": [
-            "actual",
-            "estimated_from_typical_utilization",
-            "estimated_from_total_icu_actual"
-          ]
+          "$ref": "#/definitions/NonCovidPatientsMethod"
         }
       },
       "required": [

--- a/api/schemas_v2/Metrics.json
+++ b/api/schemas_v2/Metrics.json
@@ -3,30 +3,66 @@
   "description": "Calculated metrics data based on known actuals.",
   "type": "object",
   "properties": {
-    "testPositivityRatio": [
-      "null",
-      "number"
-    ],
-    "caseDensity": [
-      "null",
-      "number"
-    ],
-    "contactTracerCapacityRatio": [
-      "null",
-      "number"
-    ],
-    "infectionRate": [
-      "null",
-      "number"
-    ],
-    "infectionRateCI90": [
-      "null",
-      "number"
-    ],
-    "icuHeadroomRatio": [
-      "null",
-      "number"
-    ],
+    "testPositivityRatio": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "caseDensity": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "contactTracerCapacityRatio": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "infectionRate": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "infectionRateCI90": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "icuHeadroomRatio": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
     "icuHeadroomDetails": {
       "$ref": "#/definitions/ICUHeadroomMetricDetails"
     }

--- a/api/schemas_v2/Metrics.json
+++ b/api/schemas_v2/Metrics.json
@@ -3,35 +3,30 @@
   "description": "Calculated metrics data based on known actuals.",
   "type": "object",
   "properties": {
-    "testPositivityRatio": {
-      "title": "Testpositivityratio",
-      "description": "Ratio of people who test positive calculated using a 7-day rolling average.",
-      "type": "number"
-    },
-    "caseDensity": {
-      "title": "Casedensity",
-      "description": "The number of cases per 100k population calculated using a 7-day rolling average.",
-      "type": "number"
-    },
-    "contactTracerCapacityRatio": {
-      "title": "Contacttracercapacityratio",
-      "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average.",
-      "type": "number"
-    },
-    "infectionRate": {
-      "title": "Infectionrate",
-      "description": "R_t, or the estimated number of infections arising from a typical case.",
-      "type": "number"
-    },
-    "infectionRateCI90": {
-      "title": "Infectionrateci90",
-      "description": "90th percentile confidence interval upper endpoint of the infection rate.",
-      "type": "number"
-    },
-    "icuHeadroomRatio": {
-      "title": "Icuheadroomratio",
-      "type": "number"
-    },
+    "testPositivityRatio": [
+      "null",
+      "number"
+    ],
+    "caseDensity": [
+      "null",
+      "number"
+    ],
+    "contactTracerCapacityRatio": [
+      "null",
+      "number"
+    ],
+    "infectionRate": [
+      "null",
+      "number"
+    ],
+    "infectionRateCI90": [
+      "null",
+      "number"
+    ],
+    "icuHeadroomRatio": [
+      "null",
+      "number"
+    ],
     "icuHeadroomDetails": {
       "$ref": "#/definitions/ICUHeadroomMetricDetails"
     }

--- a/api/schemas_v2/Metrics.json
+++ b/api/schemas_v2/Metrics.json
@@ -75,7 +75,14 @@
       ]
     },
     "icuHeadroomDetails": {
-      "$ref": "#/definitions/ICUHeadroomMetricDetails"
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ICUHeadroomMetricDetails"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "required": [

--- a/api/schemas_v2/MetricsTimeseriesRow.json
+++ b/api/schemas_v2/MetricsTimeseriesRow.json
@@ -4,62 +4,73 @@
   "type": "object",
   "properties": {
     "testPositivityRatio": {
+      "title": "Testpositivityratio",
+      "description": "Ratio of people who test positive calculated using a 7-day rolling average.",
       "anyOf": [
         {
-          "type": "null"
+          "type": "number"
         },
         {
-          "type": "number"
+          "type": "null"
         }
       ]
     },
     "caseDensity": {
+      "title": "Casedensity",
+      "description": "The number of cases per 100k population calculated using a 7-day rolling average.",
       "anyOf": [
         {
-          "type": "null"
+          "type": "number"
         },
         {
-          "type": "number"
+          "type": "null"
         }
       ]
     },
     "contactTracerCapacityRatio": {
+      "title": "Contacttracercapacityratio",
+      "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average.",
       "anyOf": [
         {
-          "type": "null"
+          "type": "number"
         },
         {
-          "type": "number"
+          "type": "null"
         }
       ]
     },
     "infectionRate": {
+      "title": "Infectionrate",
+      "description": "R_t, or the estimated number of infections arising from a typical case.",
       "anyOf": [
         {
-          "type": "null"
+          "type": "number"
         },
         {
-          "type": "number"
+          "type": "null"
         }
       ]
     },
     "infectionRateCI90": {
+      "title": "Infectionrateci90",
+      "description": "90th percentile confidence interval upper endpoint of the infection rate.",
       "anyOf": [
         {
-          "type": "null"
+          "type": "number"
         },
         {
-          "type": "number"
+          "type": "null"
         }
       ]
     },
     "icuHeadroomRatio": {
+      "title": "Icuheadroomratio",
       "anyOf": [
         {
-          "type": "null"
+          "type": "number"
         },
         {
-          "type": "number"
+          "type": "null"
         }
       ]
     },

--- a/api/schemas_v2/MetricsTimeseriesRow.json
+++ b/api/schemas_v2/MetricsTimeseriesRow.json
@@ -3,35 +3,30 @@
   "description": "Metrics data for a specific day.",
   "type": "object",
   "properties": {
-    "testPositivityRatio": {
-      "title": "Testpositivityratio",
-      "description": "Ratio of people who test positive calculated using a 7-day rolling average.",
-      "type": "number"
-    },
-    "caseDensity": {
-      "title": "Casedensity",
-      "description": "The number of cases per 100k population calculated using a 7-day rolling average.",
-      "type": "number"
-    },
-    "contactTracerCapacityRatio": {
-      "title": "Contacttracercapacityratio",
-      "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average.",
-      "type": "number"
-    },
-    "infectionRate": {
-      "title": "Infectionrate",
-      "description": "R_t, or the estimated number of infections arising from a typical case.",
-      "type": "number"
-    },
-    "infectionRateCI90": {
-      "title": "Infectionrateci90",
-      "description": "90th percentile confidence interval upper endpoint of the infection rate.",
-      "type": "number"
-    },
-    "icuHeadroomRatio": {
-      "title": "Icuheadroomratio",
-      "type": "number"
-    },
+    "testPositivityRatio": [
+      "null",
+      "number"
+    ],
+    "caseDensity": [
+      "null",
+      "number"
+    ],
+    "contactTracerCapacityRatio": [
+      "null",
+      "number"
+    ],
+    "infectionRate": [
+      "null",
+      "number"
+    ],
+    "infectionRateCI90": [
+      "null",
+      "number"
+    ],
+    "icuHeadroomRatio": [
+      "null",
+      "number"
+    ],
     "icuHeadroomDetails": {
       "$ref": "#/definitions/ICUHeadroomMetricDetails"
     },

--- a/api/schemas_v2/MetricsTimeseriesRow.json
+++ b/api/schemas_v2/MetricsTimeseriesRow.json
@@ -3,30 +3,66 @@
   "description": "Metrics data for a specific day.",
   "type": "object",
   "properties": {
-    "testPositivityRatio": [
-      "null",
-      "number"
-    ],
-    "caseDensity": [
-      "null",
-      "number"
-    ],
-    "contactTracerCapacityRatio": [
-      "null",
-      "number"
-    ],
-    "infectionRate": [
-      "null",
-      "number"
-    ],
-    "infectionRateCI90": [
-      "null",
-      "number"
-    ],
-    "icuHeadroomRatio": [
-      "null",
-      "number"
-    ],
+    "testPositivityRatio": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "caseDensity": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "contactTracerCapacityRatio": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "infectionRate": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "infectionRateCI90": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "icuHeadroomRatio": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
     "icuHeadroomDetails": {
       "$ref": "#/definitions/ICUHeadroomMetricDetails"
     },

--- a/api/schemas_v2/MetricsTimeseriesRow.json
+++ b/api/schemas_v2/MetricsTimeseriesRow.json
@@ -75,7 +75,14 @@
       ]
     },
     "icuHeadroomDetails": {
-      "$ref": "#/definitions/ICUHeadroomMetricDetails"
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ICUHeadroomMetricDetails"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "date": {
       "title": "Date",

--- a/api/schemas_v2/MetricsTimeseriesRow.json
+++ b/api/schemas_v2/MetricsTimeseriesRow.json
@@ -43,9 +43,33 @@
     }
   },
   "required": [
+    "testPositivityRatio",
+    "caseDensity",
+    "contactTracerCapacityRatio",
+    "infectionRate",
+    "infectionRateCI90",
+    "icuHeadroomRatio",
+    "icuHeadroomDetails",
     "date"
   ],
   "definitions": {
+    "CovidPatientsMethod": {
+      "title": "CovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients with covid.",
+      "enum": [
+        "actual",
+        "estimated"
+      ]
+    },
+    "NonCovidPatientsMethod": {
+      "title": "NonCovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients without covid.",
+      "enum": [
+        "actual",
+        "estimated_from_typical_utilization",
+        "estimated_from_total_icu_actual"
+      ]
+    },
     "ICUHeadroomMetricDetails": {
       "title": "ICUHeadroomMetricDetails",
       "description": "Details about how the ICU Headroom Metric was calculated.",
@@ -57,12 +81,7 @@
           "type": "integer"
         },
         "currentIcuCovidMethod": {
-          "title": "Currenticucovidmethod",
-          "description": "Method used to determine number of current ICU patients with covid.",
-          "enum": [
-            "actual",
-            "estimated"
-          ]
+          "$ref": "#/definitions/CovidPatientsMethod"
         },
         "currentIcuNonCovid": {
           "title": "Currenticunoncovid",
@@ -70,13 +89,7 @@
           "type": "integer"
         },
         "currentIcuNonCovidMethod": {
-          "title": "Currenticunoncovidmethod",
-          "description": "Method used to determine number of current ICU patients without covid.",
-          "enum": [
-            "actual",
-            "estimated_from_typical_utilization",
-            "estimated_from_total_icu_actual"
-          ]
+          "$ref": "#/definitions/NonCovidPatientsMethod"
         }
       },
       "required": [

--- a/api/schemas_v2/MetricsTimeseriesRow.json
+++ b/api/schemas_v2/MetricsTimeseriesRow.json
@@ -75,14 +75,7 @@
       ]
     },
     "icuHeadroomDetails": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ICUHeadroomMetricDetails"
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "$ref": "#/definitions/ICUHeadroomMetricDetails"
     },
     "date": {
       "title": "Date",
@@ -98,7 +91,6 @@
     "infectionRate",
     "infectionRateCI90",
     "icuHeadroomRatio",
-    "icuHeadroomDetails",
     "date"
   ],
   "definitions": {

--- a/api/schemas_v2/MetricsTimeseriesRowWithHeader.json
+++ b/api/schemas_v2/MetricsTimeseriesRowWithHeader.json
@@ -4,62 +4,73 @@
   "type": "object",
   "properties": {
     "testPositivityRatio": {
+      "title": "Testpositivityratio",
+      "description": "Ratio of people who test positive calculated using a 7-day rolling average.",
       "anyOf": [
         {
-          "type": "null"
+          "type": "number"
         },
         {
-          "type": "number"
+          "type": "null"
         }
       ]
     },
     "caseDensity": {
+      "title": "Casedensity",
+      "description": "The number of cases per 100k population calculated using a 7-day rolling average.",
       "anyOf": [
         {
-          "type": "null"
+          "type": "number"
         },
         {
-          "type": "number"
+          "type": "null"
         }
       ]
     },
     "contactTracerCapacityRatio": {
+      "title": "Contacttracercapacityratio",
+      "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average.",
       "anyOf": [
         {
-          "type": "null"
+          "type": "number"
         },
         {
-          "type": "number"
+          "type": "null"
         }
       ]
     },
     "infectionRate": {
+      "title": "Infectionrate",
+      "description": "R_t, or the estimated number of infections arising from a typical case.",
       "anyOf": [
         {
-          "type": "null"
+          "type": "number"
         },
         {
-          "type": "number"
+          "type": "null"
         }
       ]
     },
     "infectionRateCI90": {
+      "title": "Infectionrateci90",
+      "description": "90th percentile confidence interval upper endpoint of the infection rate.",
       "anyOf": [
         {
-          "type": "null"
+          "type": "number"
         },
         {
-          "type": "number"
+          "type": "null"
         }
       ]
     },
     "icuHeadroomRatio": {
+      "title": "Icuheadroomratio",
       "anyOf": [
         {
-          "type": "null"
+          "type": "number"
         },
         {
-          "type": "number"
+          "type": "null"
         }
       ]
     },

--- a/api/schemas_v2/MetricsTimeseriesRowWithHeader.json
+++ b/api/schemas_v2/MetricsTimeseriesRowWithHeader.json
@@ -3,30 +3,66 @@
   "description": "Prediction timeseries row with location information.",
   "type": "object",
   "properties": {
-    "testPositivityRatio": [
-      "null",
-      "number"
-    ],
-    "caseDensity": [
-      "null",
-      "number"
-    ],
-    "contactTracerCapacityRatio": [
-      "null",
-      "number"
-    ],
-    "infectionRate": [
-      "null",
-      "number"
-    ],
-    "infectionRateCI90": [
-      "null",
-      "number"
-    ],
-    "icuHeadroomRatio": [
-      "null",
-      "number"
-    ],
+    "testPositivityRatio": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "caseDensity": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "contactTracerCapacityRatio": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "infectionRate": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "infectionRateCI90": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "icuHeadroomRatio": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
     "icuHeadroomDetails": {
       "$ref": "#/definitions/ICUHeadroomMetricDetails"
     },

--- a/api/schemas_v2/MetricsTimeseriesRowWithHeader.json
+++ b/api/schemas_v2/MetricsTimeseriesRowWithHeader.json
@@ -75,7 +75,14 @@
       ]
     },
     "icuHeadroomDetails": {
-      "$ref": "#/definitions/ICUHeadroomMetricDetails"
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ICUHeadroomMetricDetails"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "date": {
       "title": "Date",

--- a/api/schemas_v2/MetricsTimeseriesRowWithHeader.json
+++ b/api/schemas_v2/MetricsTimeseriesRowWithHeader.json
@@ -79,12 +79,36 @@
     }
   },
   "required": [
+    "testPositivityRatio",
+    "caseDensity",
+    "contactTracerCapacityRatio",
+    "infectionRate",
+    "infectionRateCI90",
+    "icuHeadroomRatio",
+    "icuHeadroomDetails",
     "date",
     "state",
     "fips",
     "lastUpdatedDate"
   ],
   "definitions": {
+    "CovidPatientsMethod": {
+      "title": "CovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients with covid.",
+      "enum": [
+        "actual",
+        "estimated"
+      ]
+    },
+    "NonCovidPatientsMethod": {
+      "title": "NonCovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients without covid.",
+      "enum": [
+        "actual",
+        "estimated_from_typical_utilization",
+        "estimated_from_total_icu_actual"
+      ]
+    },
     "ICUHeadroomMetricDetails": {
       "title": "ICUHeadroomMetricDetails",
       "description": "Details about how the ICU Headroom Metric was calculated.",
@@ -96,12 +120,7 @@
           "type": "integer"
         },
         "currentIcuCovidMethod": {
-          "title": "Currenticucovidmethod",
-          "description": "Method used to determine number of current ICU patients with covid.",
-          "enum": [
-            "actual",
-            "estimated"
-          ]
+          "$ref": "#/definitions/CovidPatientsMethod"
         },
         "currentIcuNonCovid": {
           "title": "Currenticunoncovid",
@@ -109,13 +128,7 @@
           "type": "integer"
         },
         "currentIcuNonCovidMethod": {
-          "title": "Currenticunoncovidmethod",
-          "description": "Method used to determine number of current ICU patients without covid.",
-          "enum": [
-            "actual",
-            "estimated_from_typical_utilization",
-            "estimated_from_total_icu_actual"
-          ]
+          "$ref": "#/definitions/NonCovidPatientsMethod"
         }
       },
       "required": [

--- a/api/schemas_v2/MetricsTimeseriesRowWithHeader.json
+++ b/api/schemas_v2/MetricsTimeseriesRowWithHeader.json
@@ -75,14 +75,7 @@
       ]
     },
     "icuHeadroomDetails": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ICUHeadroomMetricDetails"
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "$ref": "#/definitions/ICUHeadroomMetricDetails"
     },
     "date": {
       "title": "Date",
@@ -134,7 +127,6 @@
     "infectionRate",
     "infectionRateCI90",
     "icuHeadroomRatio",
-    "icuHeadroomDetails",
     "date",
     "state",
     "fips",

--- a/api/schemas_v2/MetricsTimeseriesRowWithHeader.json
+++ b/api/schemas_v2/MetricsTimeseriesRowWithHeader.json
@@ -3,35 +3,30 @@
   "description": "Prediction timeseries row with location information.",
   "type": "object",
   "properties": {
-    "testPositivityRatio": {
-      "title": "Testpositivityratio",
-      "description": "Ratio of people who test positive calculated using a 7-day rolling average.",
-      "type": "number"
-    },
-    "caseDensity": {
-      "title": "Casedensity",
-      "description": "The number of cases per 100k population calculated using a 7-day rolling average.",
-      "type": "number"
-    },
-    "contactTracerCapacityRatio": {
-      "title": "Contacttracercapacityratio",
-      "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average.",
-      "type": "number"
-    },
-    "infectionRate": {
-      "title": "Infectionrate",
-      "description": "R_t, or the estimated number of infections arising from a typical case.",
-      "type": "number"
-    },
-    "infectionRateCI90": {
-      "title": "Infectionrateci90",
-      "description": "90th percentile confidence interval upper endpoint of the infection rate.",
-      "type": "number"
-    },
-    "icuHeadroomRatio": {
-      "title": "Icuheadroomratio",
-      "type": "number"
-    },
+    "testPositivityRatio": [
+      "null",
+      "number"
+    ],
+    "caseDensity": [
+      "null",
+      "number"
+    ],
+    "contactTracerCapacityRatio": [
+      "null",
+      "number"
+    ],
+    "infectionRate": [
+      "null",
+      "number"
+    ],
+    "infectionRateCI90": [
+      "null",
+      "number"
+    ],
+    "icuHeadroomRatio": [
+      "null",
+      "number"
+    ],
     "icuHeadroomDetails": {
       "$ref": "#/definitions/ICUHeadroomMetricDetails"
     },

--- a/api/schemas_v2/RegionSummary.json
+++ b/api/schemas_v2/RegionSummary.json
@@ -19,12 +19,14 @@
       "type": "string"
     },
     "county": {
+      "title": "County",
+      "description": "County name",
       "anyOf": [
         {
-          "type": "null"
+          "type": "string"
         },
         {
-          "type": "string"
+          "type": "null"
         }
       ]
     },
@@ -32,22 +34,26 @@
       "$ref": "#/definitions/AggregationLevel"
     },
     "lat": {
+      "title": "Lat",
+      "description": "Latitude of point within the state or county",
       "anyOf": [
         {
-          "type": "null"
+          "type": "number"
         },
         {
-          "type": "number"
+          "type": "null"
         }
       ]
     },
     "long": {
+      "title": "Long",
+      "description": "Longitude of point within the state or county",
       "anyOf": [
         {
-          "type": "null"
+          "type": "number"
         },
         {
-          "type": "number"
+          "type": "null"
         }
       ]
     },
@@ -145,62 +151,73 @@
       "type": "object",
       "properties": {
         "testPositivityRatio": {
+          "title": "Testpositivityratio",
+          "description": "Ratio of people who test positive calculated using a 7-day rolling average.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "caseDensity": {
+          "title": "Casedensity",
+          "description": "The number of cases per 100k population calculated using a 7-day rolling average.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "contactTracerCapacityRatio": {
+          "title": "Contacttracercapacityratio",
+          "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "infectionRate": {
+          "title": "Infectionrate",
+          "description": "R_t, or the estimated number of infections arising from a typical case.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "infectionRateCI90": {
+          "title": "Infectionrateci90",
+          "description": "90th percentile confidence interval upper endpoint of the infection rate.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "icuHeadroomRatio": {
+          "title": "Icuheadroomratio",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
@@ -224,42 +241,50 @@
       "type": "object",
       "properties": {
         "capacity": {
+          "title": "Capacity",
+          "description": "Total capacity for resource.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "currentUsageTotal": {
+          "title": "Currentusagetotal",
+          "description": "Currently used capacity for resource by all patients (COVID + Non-COVID)",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "currentUsageCovid": {
+          "title": "Currentusagecovid",
+          "description": "Currently used capacity for resource by COVID ",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "typicalUsageRate": {
+          "title": "Typicalusagerate",
+          "description": "Typical used capacity rate for resource. This excludes any COVID usage.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         }
@@ -277,52 +302,62 @@
       "type": "object",
       "properties": {
         "cases": {
+          "title": "Cases",
+          "description": "Cumulative number of confirmed or suspected cases",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "deaths": {
+          "title": "Deaths",
+          "description": "Cumulative number of deaths that are suspected or confirmed to have been caused by COVID-19",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "positiveTests": {
+          "title": "Positivetests",
+          "description": "Cumulative positive test results to date",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "negativeTests": {
+          "title": "Negativetests",
+          "description": "Cumulative negative test results to date",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "contactTracers": {
+          "title": "Contacttracers",
+          "description": "Number of Contact Tracers",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },

--- a/api/schemas_v2/RegionSummary.json
+++ b/api/schemas_v2/RegionSummary.json
@@ -229,14 +229,7 @@
           ]
         },
         "icuHeadroomDetails": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ICUHeadroomMetricDetails"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "$ref": "#/definitions/ICUHeadroomMetricDetails"
         }
       },
       "required": [
@@ -245,8 +238,7 @@
         "contactTracerCapacityRatio",
         "infectionRate",
         "infectionRateCI90",
-        "icuHeadroomRatio",
-        "icuHeadroomDetails"
+        "icuHeadroomRatio"
       ]
     },
     "HospitalResourceUtilization": {

--- a/api/schemas_v2/RegionSummary.json
+++ b/api/schemas_v2/RegionSummary.json
@@ -24,13 +24,7 @@
       "type": "string"
     },
     "level": {
-      "title": "Level",
-      "description": "Level of region.",
-      "enum": [
-        "country",
-        "state",
-        "county"
-      ]
+      "$ref": "#/definitions/AggregationLevel"
     },
     "lat": {
       "title": "Lat",
@@ -65,12 +59,42 @@
     "fips",
     "country",
     "state",
+    "county",
     "level",
+    "lat",
+    "long",
     "population",
+    "metrics",
     "actuals",
     "lastUpdatedDate"
   ],
   "definitions": {
+    "AggregationLevel": {
+      "title": "AggregationLevel",
+      "description": "An enumeration.",
+      "enum": [
+        "country",
+        "state",
+        "county"
+      ]
+    },
+    "CovidPatientsMethod": {
+      "title": "CovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients with covid.",
+      "enum": [
+        "actual",
+        "estimated"
+      ]
+    },
+    "NonCovidPatientsMethod": {
+      "title": "NonCovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients without covid.",
+      "enum": [
+        "actual",
+        "estimated_from_typical_utilization",
+        "estimated_from_total_icu_actual"
+      ]
+    },
     "ICUHeadroomMetricDetails": {
       "title": "ICUHeadroomMetricDetails",
       "description": "Details about how the ICU Headroom Metric was calculated.",
@@ -82,12 +106,7 @@
           "type": "integer"
         },
         "currentIcuCovidMethod": {
-          "title": "Currenticucovidmethod",
-          "description": "Method used to determine number of current ICU patients with covid.",
-          "enum": [
-            "actual",
-            "estimated"
-          ]
+          "$ref": "#/definitions/CovidPatientsMethod"
         },
         "currentIcuNonCovid": {
           "title": "Currenticunoncovid",
@@ -95,13 +114,7 @@
           "type": "integer"
         },
         "currentIcuNonCovidMethod": {
-          "title": "Currenticunoncovidmethod",
-          "description": "Method used to determine number of current ICU patients without covid.",
-          "enum": [
-            "actual",
-            "estimated_from_typical_utilization",
-            "estimated_from_total_icu_actual"
-          ]
+          "$ref": "#/definitions/NonCovidPatientsMethod"
         }
       },
       "required": [
@@ -148,7 +161,16 @@
         "icuHeadroomDetails": {
           "$ref": "#/definitions/ICUHeadroomMetricDetails"
         }
-      }
+      },
+      "required": [
+        "testPositivityRatio",
+        "caseDensity",
+        "contactTracerCapacityRatio",
+        "infectionRate",
+        "infectionRateCI90",
+        "icuHeadroomRatio",
+        "icuHeadroomDetails"
+      ]
     },
     "HospitalResourceUtilization": {
       "title": "HospitalResourceUtilization",
@@ -175,7 +197,13 @@
           "description": "Typical used capacity rate for resource. This excludes any COVID usage.",
           "type": "number"
         }
-      }
+      },
+      "required": [
+        "capacity",
+        "currentUsageTotal",
+        "currentUsageCovid",
+        "typicalUsageRate"
+      ]
     },
     "Actuals": {
       "title": "Actuals",
@@ -225,7 +253,16 @@
             }
           ]
         }
-      }
+      },
+      "required": [
+        "cases",
+        "deaths",
+        "positiveTests",
+        "negativeTests",
+        "contactTracers",
+        "hospitalBeds",
+        "icuBeds"
+      ]
     }
   }
 }

--- a/api/schemas_v2/RegionSummary.json
+++ b/api/schemas_v2/RegionSummary.json
@@ -18,21 +18,39 @@
       "description": "2-letter ANSI state code.",
       "type": "string"
     },
-    "county": [
-      "null",
-      "string"
-    ],
+    "county": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
     "level": {
       "$ref": "#/definitions/AggregationLevel"
     },
-    "lat": [
-      "null",
-      "number"
-    ],
-    "long": [
-      "null",
-      "number"
-    ],
+    "lat": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "long": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
     "population": {
       "title": "Population",
       "description": "Total Population in geographic region.",
@@ -126,30 +144,66 @@
       "description": "Calculated metrics data based on known actuals.",
       "type": "object",
       "properties": {
-        "testPositivityRatio": [
-          "null",
-          "number"
-        ],
-        "caseDensity": [
-          "null",
-          "number"
-        ],
-        "contactTracerCapacityRatio": [
-          "null",
-          "number"
-        ],
-        "infectionRate": [
-          "null",
-          "number"
-        ],
-        "infectionRateCI90": [
-          "null",
-          "number"
-        ],
-        "icuHeadroomRatio": [
-          "null",
-          "number"
-        ],
+        "testPositivityRatio": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "caseDensity": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "contactTracerCapacityRatio": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "infectionRate": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "infectionRateCI90": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "icuHeadroomRatio": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
         "icuHeadroomDetails": {
           "$ref": "#/definitions/ICUHeadroomMetricDetails"
         }
@@ -169,22 +223,46 @@
       "description": "Base model for API output.",
       "type": "object",
       "properties": {
-        "capacity": [
-          "null",
-          "integer"
-        ],
-        "currentUsageTotal": [
-          "null",
-          "integer"
-        ],
-        "currentUsageCovid": [
-          "null",
-          "integer"
-        ],
-        "typicalUsageRate": [
-          "null",
-          "number"
-        ]
+        "capacity": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "currentUsageTotal": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "currentUsageCovid": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "typicalUsageRate": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        }
       },
       "required": [
         "capacity",
@@ -198,26 +276,56 @@
       "description": "Known actuals data.",
       "type": "object",
       "properties": {
-        "cases": [
-          "null",
-          "integer"
-        ],
-        "deaths": [
-          "null",
-          "integer"
-        ],
-        "positiveTests": [
-          "null",
-          "integer"
-        ],
-        "negativeTests": [
-          "null",
-          "integer"
-        ],
-        "contactTracers": [
-          "null",
-          "integer"
-        ],
+        "cases": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "deaths": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "positiveTests": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "negativeTests": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "contactTracers": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
         "hospitalBeds": {
           "title": "Hospitalbeds",
           "description": "Information about hospital bed utilization",

--- a/api/schemas_v2/RegionSummary.json
+++ b/api/schemas_v2/RegionSummary.json
@@ -64,7 +64,14 @@
       "type": "integer"
     },
     "metrics": {
-      "$ref": "#/definitions/Metrics"
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Metrics"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "actuals": {
       "$ref": "#/definitions/Actuals"
@@ -222,7 +229,14 @@
           ]
         },
         "icuHeadroomDetails": {
-          "$ref": "#/definitions/ICUHeadroomMetricDetails"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ICUHeadroomMetricDetails"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [

--- a/api/schemas_v2/RegionSummary.json
+++ b/api/schemas_v2/RegionSummary.json
@@ -18,24 +18,21 @@
       "description": "2-letter ANSI state code.",
       "type": "string"
     },
-    "county": {
-      "title": "County",
-      "description": "County name",
-      "type": "string"
-    },
+    "county": [
+      "null",
+      "string"
+    ],
     "level": {
       "$ref": "#/definitions/AggregationLevel"
     },
-    "lat": {
-      "title": "Lat",
-      "description": "Latitude of point within the state or county",
-      "type": "number"
-    },
-    "long": {
-      "title": "Long",
-      "description": "Longitude of point within the state or county",
-      "type": "number"
-    },
+    "lat": [
+      "null",
+      "number"
+    ],
+    "long": [
+      "null",
+      "number"
+    ],
     "population": {
       "title": "Population",
       "description": "Total Population in geographic region.",
@@ -129,35 +126,30 @@
       "description": "Calculated metrics data based on known actuals.",
       "type": "object",
       "properties": {
-        "testPositivityRatio": {
-          "title": "Testpositivityratio",
-          "description": "Ratio of people who test positive calculated using a 7-day rolling average.",
-          "type": "number"
-        },
-        "caseDensity": {
-          "title": "Casedensity",
-          "description": "The number of cases per 100k population calculated using a 7-day rolling average.",
-          "type": "number"
-        },
-        "contactTracerCapacityRatio": {
-          "title": "Contacttracercapacityratio",
-          "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average.",
-          "type": "number"
-        },
-        "infectionRate": {
-          "title": "Infectionrate",
-          "description": "R_t, or the estimated number of infections arising from a typical case.",
-          "type": "number"
-        },
-        "infectionRateCI90": {
-          "title": "Infectionrateci90",
-          "description": "90th percentile confidence interval upper endpoint of the infection rate.",
-          "type": "number"
-        },
-        "icuHeadroomRatio": {
-          "title": "Icuheadroomratio",
-          "type": "number"
-        },
+        "testPositivityRatio": [
+          "null",
+          "number"
+        ],
+        "caseDensity": [
+          "null",
+          "number"
+        ],
+        "contactTracerCapacityRatio": [
+          "null",
+          "number"
+        ],
+        "infectionRate": [
+          "null",
+          "number"
+        ],
+        "infectionRateCI90": [
+          "null",
+          "number"
+        ],
+        "icuHeadroomRatio": [
+          "null",
+          "number"
+        ],
         "icuHeadroomDetails": {
           "$ref": "#/definitions/ICUHeadroomMetricDetails"
         }
@@ -177,26 +169,22 @@
       "description": "Base model for API output.",
       "type": "object",
       "properties": {
-        "capacity": {
-          "title": "Capacity",
-          "description": "Total capacity for resource.",
-          "type": "integer"
-        },
-        "currentUsageTotal": {
-          "title": "Currentusagetotal",
-          "description": "Currently used capacity for resource by all patients (COVID + Non-COVID)",
-          "type": "integer"
-        },
-        "currentUsageCovid": {
-          "title": "Currentusagecovid",
-          "description": "Currently used capacity for resource by COVID ",
-          "type": "integer"
-        },
-        "typicalUsageRate": {
-          "title": "Typicalusagerate",
-          "description": "Typical used capacity rate for resource. This excludes any COVID usage.",
-          "type": "number"
-        }
+        "capacity": [
+          "null",
+          "integer"
+        ],
+        "currentUsageTotal": [
+          "null",
+          "integer"
+        ],
+        "currentUsageCovid": [
+          "null",
+          "integer"
+        ],
+        "typicalUsageRate": [
+          "null",
+          "number"
+        ]
       },
       "required": [
         "capacity",
@@ -210,31 +198,26 @@
       "description": "Known actuals data.",
       "type": "object",
       "properties": {
-        "cases": {
-          "title": "Cases",
-          "description": "Cumulative number of confirmed or suspected cases",
-          "type": "integer"
-        },
-        "deaths": {
-          "title": "Deaths",
-          "description": "Cumulative number of deaths that are suspected or confirmed to have been caused by COVID-19",
-          "type": "integer"
-        },
-        "positiveTests": {
-          "title": "Positivetests",
-          "description": "Cumulative positive test results to date",
-          "type": "integer"
-        },
-        "negativeTests": {
-          "title": "Negativetests",
-          "description": "Cumulative negative test results to date",
-          "type": "integer"
-        },
-        "contactTracers": {
-          "title": "Contacttracers",
-          "description": "Number of Contact Tracers",
-          "type": "integer"
-        },
+        "cases": [
+          "null",
+          "integer"
+        ],
+        "deaths": [
+          "null",
+          "integer"
+        ],
+        "positiveTests": [
+          "null",
+          "integer"
+        ],
+        "negativeTests": [
+          "null",
+          "integer"
+        ],
+        "contactTracers": [
+          "null",
+          "integer"
+        ],
         "hospitalBeds": {
           "title": "Hospitalbeds",
           "description": "Information about hospital bed utilization",

--- a/api/schemas_v2/RegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/RegionSummaryWithTimeseries.json
@@ -18,21 +18,39 @@
       "description": "2-letter ANSI state code.",
       "type": "string"
     },
-    "county": [
-      "null",
-      "string"
-    ],
+    "county": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
     "level": {
       "$ref": "#/definitions/AggregationLevel"
     },
-    "lat": [
-      "null",
-      "number"
-    ],
-    "long": [
-      "null",
-      "number"
-    ],
+    "lat": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "long": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
     "population": {
       "title": "Population",
       "description": "Total Population in geographic region.",
@@ -141,30 +159,66 @@
       "description": "Calculated metrics data based on known actuals.",
       "type": "object",
       "properties": {
-        "testPositivityRatio": [
-          "null",
-          "number"
-        ],
-        "caseDensity": [
-          "null",
-          "number"
-        ],
-        "contactTracerCapacityRatio": [
-          "null",
-          "number"
-        ],
-        "infectionRate": [
-          "null",
-          "number"
-        ],
-        "infectionRateCI90": [
-          "null",
-          "number"
-        ],
-        "icuHeadroomRatio": [
-          "null",
-          "number"
-        ],
+        "testPositivityRatio": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "caseDensity": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "contactTracerCapacityRatio": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "infectionRate": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "infectionRateCI90": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "icuHeadroomRatio": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
         "icuHeadroomDetails": {
           "$ref": "#/definitions/ICUHeadroomMetricDetails"
         }
@@ -184,22 +238,46 @@
       "description": "Base model for API output.",
       "type": "object",
       "properties": {
-        "capacity": [
-          "null",
-          "integer"
-        ],
-        "currentUsageTotal": [
-          "null",
-          "integer"
-        ],
-        "currentUsageCovid": [
-          "null",
-          "integer"
-        ],
-        "typicalUsageRate": [
-          "null",
-          "number"
-        ]
+        "capacity": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "currentUsageTotal": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "currentUsageCovid": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "typicalUsageRate": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        }
       },
       "required": [
         "capacity",
@@ -213,26 +291,56 @@
       "description": "Known actuals data.",
       "type": "object",
       "properties": {
-        "cases": [
-          "null",
-          "integer"
-        ],
-        "deaths": [
-          "null",
-          "integer"
-        ],
-        "positiveTests": [
-          "null",
-          "integer"
-        ],
-        "negativeTests": [
-          "null",
-          "integer"
-        ],
-        "contactTracers": [
-          "null",
-          "integer"
-        ],
+        "cases": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "deaths": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "positiveTests": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "negativeTests": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "contactTracers": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
         "hospitalBeds": {
           "title": "Hospitalbeds",
           "description": "Information about hospital bed utilization",
@@ -267,30 +375,66 @@
       "description": "Metrics data for a specific day.",
       "type": "object",
       "properties": {
-        "testPositivityRatio": [
-          "null",
-          "number"
-        ],
-        "caseDensity": [
-          "null",
-          "number"
-        ],
-        "contactTracerCapacityRatio": [
-          "null",
-          "number"
-        ],
-        "infectionRate": [
-          "null",
-          "number"
-        ],
-        "infectionRateCI90": [
-          "null",
-          "number"
-        ],
-        "icuHeadroomRatio": [
-          "null",
-          "number"
-        ],
+        "testPositivityRatio": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "caseDensity": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "contactTracerCapacityRatio": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "infectionRate": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "infectionRateCI90": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "icuHeadroomRatio": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
         "icuHeadroomDetails": {
           "$ref": "#/definitions/ICUHeadroomMetricDetails"
         },
@@ -317,26 +461,56 @@
       "description": "Actual data for a specific day.",
       "type": "object",
       "properties": {
-        "cases": [
-          "null",
-          "integer"
-        ],
-        "deaths": [
-          "null",
-          "integer"
-        ],
-        "positiveTests": [
-          "null",
-          "integer"
-        ],
-        "negativeTests": [
-          "null",
-          "integer"
-        ],
-        "contactTracers": [
-          "null",
-          "integer"
-        ],
+        "cases": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "deaths": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "positiveTests": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "negativeTests": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "contactTracers": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
         "hospitalBeds": {
           "title": "Hospitalbeds",
           "description": "Information about hospital bed utilization",

--- a/api/schemas_v2/RegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/RegionSummaryWithTimeseries.json
@@ -18,24 +18,21 @@
       "description": "2-letter ANSI state code.",
       "type": "string"
     },
-    "county": {
-      "title": "County",
-      "description": "County name",
-      "type": "string"
-    },
+    "county": [
+      "null",
+      "string"
+    ],
     "level": {
       "$ref": "#/definitions/AggregationLevel"
     },
-    "lat": {
-      "title": "Lat",
-      "description": "Latitude of point within the state or county",
-      "type": "number"
-    },
-    "long": {
-      "title": "Long",
-      "description": "Longitude of point within the state or county",
-      "type": "number"
-    },
+    "lat": [
+      "null",
+      "number"
+    ],
+    "long": [
+      "null",
+      "number"
+    ],
     "population": {
       "title": "Population",
       "description": "Total Population in geographic region.",
@@ -144,35 +141,30 @@
       "description": "Calculated metrics data based on known actuals.",
       "type": "object",
       "properties": {
-        "testPositivityRatio": {
-          "title": "Testpositivityratio",
-          "description": "Ratio of people who test positive calculated using a 7-day rolling average.",
-          "type": "number"
-        },
-        "caseDensity": {
-          "title": "Casedensity",
-          "description": "The number of cases per 100k population calculated using a 7-day rolling average.",
-          "type": "number"
-        },
-        "contactTracerCapacityRatio": {
-          "title": "Contacttracercapacityratio",
-          "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average.",
-          "type": "number"
-        },
-        "infectionRate": {
-          "title": "Infectionrate",
-          "description": "R_t, or the estimated number of infections arising from a typical case.",
-          "type": "number"
-        },
-        "infectionRateCI90": {
-          "title": "Infectionrateci90",
-          "description": "90th percentile confidence interval upper endpoint of the infection rate.",
-          "type": "number"
-        },
-        "icuHeadroomRatio": {
-          "title": "Icuheadroomratio",
-          "type": "number"
-        },
+        "testPositivityRatio": [
+          "null",
+          "number"
+        ],
+        "caseDensity": [
+          "null",
+          "number"
+        ],
+        "contactTracerCapacityRatio": [
+          "null",
+          "number"
+        ],
+        "infectionRate": [
+          "null",
+          "number"
+        ],
+        "infectionRateCI90": [
+          "null",
+          "number"
+        ],
+        "icuHeadroomRatio": [
+          "null",
+          "number"
+        ],
         "icuHeadroomDetails": {
           "$ref": "#/definitions/ICUHeadroomMetricDetails"
         }
@@ -192,26 +184,22 @@
       "description": "Base model for API output.",
       "type": "object",
       "properties": {
-        "capacity": {
-          "title": "Capacity",
-          "description": "Total capacity for resource.",
-          "type": "integer"
-        },
-        "currentUsageTotal": {
-          "title": "Currentusagetotal",
-          "description": "Currently used capacity for resource by all patients (COVID + Non-COVID)",
-          "type": "integer"
-        },
-        "currentUsageCovid": {
-          "title": "Currentusagecovid",
-          "description": "Currently used capacity for resource by COVID ",
-          "type": "integer"
-        },
-        "typicalUsageRate": {
-          "title": "Typicalusagerate",
-          "description": "Typical used capacity rate for resource. This excludes any COVID usage.",
-          "type": "number"
-        }
+        "capacity": [
+          "null",
+          "integer"
+        ],
+        "currentUsageTotal": [
+          "null",
+          "integer"
+        ],
+        "currentUsageCovid": [
+          "null",
+          "integer"
+        ],
+        "typicalUsageRate": [
+          "null",
+          "number"
+        ]
       },
       "required": [
         "capacity",
@@ -225,31 +213,26 @@
       "description": "Known actuals data.",
       "type": "object",
       "properties": {
-        "cases": {
-          "title": "Cases",
-          "description": "Cumulative number of confirmed or suspected cases",
-          "type": "integer"
-        },
-        "deaths": {
-          "title": "Deaths",
-          "description": "Cumulative number of deaths that are suspected or confirmed to have been caused by COVID-19",
-          "type": "integer"
-        },
-        "positiveTests": {
-          "title": "Positivetests",
-          "description": "Cumulative positive test results to date",
-          "type": "integer"
-        },
-        "negativeTests": {
-          "title": "Negativetests",
-          "description": "Cumulative negative test results to date",
-          "type": "integer"
-        },
-        "contactTracers": {
-          "title": "Contacttracers",
-          "description": "Number of Contact Tracers",
-          "type": "integer"
-        },
+        "cases": [
+          "null",
+          "integer"
+        ],
+        "deaths": [
+          "null",
+          "integer"
+        ],
+        "positiveTests": [
+          "null",
+          "integer"
+        ],
+        "negativeTests": [
+          "null",
+          "integer"
+        ],
+        "contactTracers": [
+          "null",
+          "integer"
+        ],
         "hospitalBeds": {
           "title": "Hospitalbeds",
           "description": "Information about hospital bed utilization",
@@ -284,35 +267,30 @@
       "description": "Metrics data for a specific day.",
       "type": "object",
       "properties": {
-        "testPositivityRatio": {
-          "title": "Testpositivityratio",
-          "description": "Ratio of people who test positive calculated using a 7-day rolling average.",
-          "type": "number"
-        },
-        "caseDensity": {
-          "title": "Casedensity",
-          "description": "The number of cases per 100k population calculated using a 7-day rolling average.",
-          "type": "number"
-        },
-        "contactTracerCapacityRatio": {
-          "title": "Contacttracercapacityratio",
-          "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average.",
-          "type": "number"
-        },
-        "infectionRate": {
-          "title": "Infectionrate",
-          "description": "R_t, or the estimated number of infections arising from a typical case.",
-          "type": "number"
-        },
-        "infectionRateCI90": {
-          "title": "Infectionrateci90",
-          "description": "90th percentile confidence interval upper endpoint of the infection rate.",
-          "type": "number"
-        },
-        "icuHeadroomRatio": {
-          "title": "Icuheadroomratio",
-          "type": "number"
-        },
+        "testPositivityRatio": [
+          "null",
+          "number"
+        ],
+        "caseDensity": [
+          "null",
+          "number"
+        ],
+        "contactTracerCapacityRatio": [
+          "null",
+          "number"
+        ],
+        "infectionRate": [
+          "null",
+          "number"
+        ],
+        "infectionRateCI90": [
+          "null",
+          "number"
+        ],
+        "icuHeadroomRatio": [
+          "null",
+          "number"
+        ],
         "icuHeadroomDetails": {
           "$ref": "#/definitions/ICUHeadroomMetricDetails"
         },
@@ -339,31 +317,26 @@
       "description": "Actual data for a specific day.",
       "type": "object",
       "properties": {
-        "cases": {
-          "title": "Cases",
-          "description": "Cumulative number of confirmed or suspected cases",
-          "type": "integer"
-        },
-        "deaths": {
-          "title": "Deaths",
-          "description": "Cumulative number of deaths that are suspected or confirmed to have been caused by COVID-19",
-          "type": "integer"
-        },
-        "positiveTests": {
-          "title": "Positivetests",
-          "description": "Cumulative positive test results to date",
-          "type": "integer"
-        },
-        "negativeTests": {
-          "title": "Negativetests",
-          "description": "Cumulative negative test results to date",
-          "type": "integer"
-        },
-        "contactTracers": {
-          "title": "Contacttracers",
-          "description": "Number of Contact Tracers",
-          "type": "integer"
-        },
+        "cases": [
+          "null",
+          "integer"
+        ],
+        "deaths": [
+          "null",
+          "integer"
+        ],
+        "positiveTests": [
+          "null",
+          "integer"
+        ],
+        "negativeTests": [
+          "null",
+          "integer"
+        ],
+        "contactTracers": [
+          "null",
+          "integer"
+        ],
         "hospitalBeds": {
           "title": "Hospitalbeds",
           "description": "Information about hospital bed utilization",

--- a/api/schemas_v2/RegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/RegionSummaryWithTimeseries.json
@@ -19,12 +19,14 @@
       "type": "string"
     },
     "county": {
+      "title": "County",
+      "description": "County name",
       "anyOf": [
         {
-          "type": "null"
+          "type": "string"
         },
         {
-          "type": "string"
+          "type": "null"
         }
       ]
     },
@@ -32,22 +34,26 @@
       "$ref": "#/definitions/AggregationLevel"
     },
     "lat": {
+      "title": "Lat",
+      "description": "Latitude of point within the state or county",
       "anyOf": [
         {
-          "type": "null"
+          "type": "number"
         },
         {
-          "type": "number"
+          "type": "null"
         }
       ]
     },
     "long": {
+      "title": "Long",
+      "description": "Longitude of point within the state or county",
       "anyOf": [
         {
-          "type": "null"
+          "type": "number"
         },
         {
-          "type": "number"
+          "type": "null"
         }
       ]
     },
@@ -160,62 +166,73 @@
       "type": "object",
       "properties": {
         "testPositivityRatio": {
+          "title": "Testpositivityratio",
+          "description": "Ratio of people who test positive calculated using a 7-day rolling average.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "caseDensity": {
+          "title": "Casedensity",
+          "description": "The number of cases per 100k population calculated using a 7-day rolling average.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "contactTracerCapacityRatio": {
+          "title": "Contacttracercapacityratio",
+          "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "infectionRate": {
+          "title": "Infectionrate",
+          "description": "R_t, or the estimated number of infections arising from a typical case.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "infectionRateCI90": {
+          "title": "Infectionrateci90",
+          "description": "90th percentile confidence interval upper endpoint of the infection rate.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "icuHeadroomRatio": {
+          "title": "Icuheadroomratio",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
@@ -239,42 +256,50 @@
       "type": "object",
       "properties": {
         "capacity": {
+          "title": "Capacity",
+          "description": "Total capacity for resource.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "currentUsageTotal": {
+          "title": "Currentusagetotal",
+          "description": "Currently used capacity for resource by all patients (COVID + Non-COVID)",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "currentUsageCovid": {
+          "title": "Currentusagecovid",
+          "description": "Currently used capacity for resource by COVID ",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "typicalUsageRate": {
+          "title": "Typicalusagerate",
+          "description": "Typical used capacity rate for resource. This excludes any COVID usage.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         }
@@ -292,52 +317,62 @@
       "type": "object",
       "properties": {
         "cases": {
+          "title": "Cases",
+          "description": "Cumulative number of confirmed or suspected cases",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "deaths": {
+          "title": "Deaths",
+          "description": "Cumulative number of deaths that are suspected or confirmed to have been caused by COVID-19",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "positiveTests": {
+          "title": "Positivetests",
+          "description": "Cumulative positive test results to date",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "negativeTests": {
+          "title": "Negativetests",
+          "description": "Cumulative negative test results to date",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "contactTracers": {
+          "title": "Contacttracers",
+          "description": "Number of Contact Tracers",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
@@ -376,62 +411,73 @@
       "type": "object",
       "properties": {
         "testPositivityRatio": {
+          "title": "Testpositivityratio",
+          "description": "Ratio of people who test positive calculated using a 7-day rolling average.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "caseDensity": {
+          "title": "Casedensity",
+          "description": "The number of cases per 100k population calculated using a 7-day rolling average.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "contactTracerCapacityRatio": {
+          "title": "Contacttracercapacityratio",
+          "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "infectionRate": {
+          "title": "Infectionrate",
+          "description": "R_t, or the estimated number of infections arising from a typical case.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "infectionRateCI90": {
+          "title": "Infectionrateci90",
+          "description": "90th percentile confidence interval upper endpoint of the infection rate.",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
         "icuHeadroomRatio": {
+          "title": "Icuheadroomratio",
           "anyOf": [
             {
-              "type": "null"
+              "type": "number"
             },
             {
-              "type": "number"
+              "type": "null"
             }
           ]
         },
@@ -462,52 +508,62 @@
       "type": "object",
       "properties": {
         "cases": {
+          "title": "Cases",
+          "description": "Cumulative number of confirmed or suspected cases",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "deaths": {
+          "title": "Deaths",
+          "description": "Cumulative number of deaths that are suspected or confirmed to have been caused by COVID-19",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "positiveTests": {
+          "title": "Positivetests",
+          "description": "Cumulative positive test results to date",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "negativeTests": {
+          "title": "Negativetests",
+          "description": "Cumulative negative test results to date",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },
         "contactTracers": {
+          "title": "Contacttracers",
+          "description": "Number of Contact Tracers",
           "anyOf": [
             {
-              "type": "null"
+              "type": "integer"
             },
             {
-              "type": "integer"
+              "type": "null"
             }
           ]
         },

--- a/api/schemas_v2/RegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/RegionSummaryWithTimeseries.json
@@ -244,14 +244,7 @@
           ]
         },
         "icuHeadroomDetails": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ICUHeadroomMetricDetails"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "$ref": "#/definitions/ICUHeadroomMetricDetails"
         }
       },
       "required": [
@@ -260,8 +253,7 @@
         "contactTracerCapacityRatio",
         "infectionRate",
         "infectionRateCI90",
-        "icuHeadroomRatio",
-        "icuHeadroomDetails"
+        "icuHeadroomRatio"
       ]
     },
     "HospitalResourceUtilization": {
@@ -496,14 +488,7 @@
           ]
         },
         "icuHeadroomDetails": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ICUHeadroomMetricDetails"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "$ref": "#/definitions/ICUHeadroomMetricDetails"
         },
         "date": {
           "title": "Date",
@@ -519,7 +504,6 @@
         "infectionRate",
         "infectionRateCI90",
         "icuHeadroomRatio",
-        "icuHeadroomDetails",
         "date"
       ]
     },

--- a/api/schemas_v2/RegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/RegionSummaryWithTimeseries.json
@@ -24,13 +24,7 @@
       "type": "string"
     },
     "level": {
-      "title": "Level",
-      "description": "Level of region.",
-      "enum": [
-        "country",
-        "state",
-        "county"
-      ]
+      "$ref": "#/definitions/AggregationLevel"
     },
     "lat": {
       "title": "Lat",
@@ -79,13 +73,43 @@
     "fips",
     "country",
     "state",
+    "county",
     "level",
+    "lat",
+    "long",
     "population",
+    "metrics",
     "actuals",
     "lastUpdatedDate",
     "actualsTimeseries"
   ],
   "definitions": {
+    "AggregationLevel": {
+      "title": "AggregationLevel",
+      "description": "An enumeration.",
+      "enum": [
+        "country",
+        "state",
+        "county"
+      ]
+    },
+    "CovidPatientsMethod": {
+      "title": "CovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients with covid.",
+      "enum": [
+        "actual",
+        "estimated"
+      ]
+    },
+    "NonCovidPatientsMethod": {
+      "title": "NonCovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients without covid.",
+      "enum": [
+        "actual",
+        "estimated_from_typical_utilization",
+        "estimated_from_total_icu_actual"
+      ]
+    },
     "ICUHeadroomMetricDetails": {
       "title": "ICUHeadroomMetricDetails",
       "description": "Details about how the ICU Headroom Metric was calculated.",
@@ -97,12 +121,7 @@
           "type": "integer"
         },
         "currentIcuCovidMethod": {
-          "title": "Currenticucovidmethod",
-          "description": "Method used to determine number of current ICU patients with covid.",
-          "enum": [
-            "actual",
-            "estimated"
-          ]
+          "$ref": "#/definitions/CovidPatientsMethod"
         },
         "currentIcuNonCovid": {
           "title": "Currenticunoncovid",
@@ -110,13 +129,7 @@
           "type": "integer"
         },
         "currentIcuNonCovidMethod": {
-          "title": "Currenticunoncovidmethod",
-          "description": "Method used to determine number of current ICU patients without covid.",
-          "enum": [
-            "actual",
-            "estimated_from_typical_utilization",
-            "estimated_from_total_icu_actual"
-          ]
+          "$ref": "#/definitions/NonCovidPatientsMethod"
         }
       },
       "required": [
@@ -163,7 +176,16 @@
         "icuHeadroomDetails": {
           "$ref": "#/definitions/ICUHeadroomMetricDetails"
         }
-      }
+      },
+      "required": [
+        "testPositivityRatio",
+        "caseDensity",
+        "contactTracerCapacityRatio",
+        "infectionRate",
+        "infectionRateCI90",
+        "icuHeadroomRatio",
+        "icuHeadroomDetails"
+      ]
     },
     "HospitalResourceUtilization": {
       "title": "HospitalResourceUtilization",
@@ -190,7 +212,13 @@
           "description": "Typical used capacity rate for resource. This excludes any COVID usage.",
           "type": "number"
         }
-      }
+      },
+      "required": [
+        "capacity",
+        "currentUsageTotal",
+        "currentUsageCovid",
+        "typicalUsageRate"
+      ]
     },
     "Actuals": {
       "title": "Actuals",
@@ -240,7 +268,16 @@
             }
           ]
         }
-      }
+      },
+      "required": [
+        "cases",
+        "deaths",
+        "positiveTests",
+        "negativeTests",
+        "contactTracers",
+        "hospitalBeds",
+        "icuBeds"
+      ]
     },
     "MetricsTimeseriesRow": {
       "title": "MetricsTimeseriesRow",
@@ -287,6 +324,13 @@
         }
       },
       "required": [
+        "testPositivityRatio",
+        "caseDensity",
+        "contactTracerCapacityRatio",
+        "infectionRate",
+        "infectionRateCI90",
+        "icuHeadroomRatio",
+        "icuHeadroomDetails",
         "date"
       ]
     },
@@ -346,6 +390,13 @@
         }
       },
       "required": [
+        "cases",
+        "deaths",
+        "positiveTests",
+        "negativeTests",
+        "contactTracers",
+        "hospitalBeds",
+        "icuBeds",
         "date"
       ]
     }

--- a/api/schemas_v2/RegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/RegionSummaryWithTimeseries.json
@@ -64,7 +64,14 @@
       "type": "integer"
     },
     "metrics": {
-      "$ref": "#/definitions/Metrics"
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Metrics"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "actuals": {
       "$ref": "#/definitions/Actuals"
@@ -237,7 +244,14 @@
           ]
         },
         "icuHeadroomDetails": {
-          "$ref": "#/definitions/ICUHeadroomMetricDetails"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ICUHeadroomMetricDetails"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -482,7 +496,14 @@
           ]
         },
         "icuHeadroomDetails": {
-          "$ref": "#/definitions/ICUHeadroomMetricDetails"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ICUHeadroomMetricDetails"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "date": {
           "title": "Date",

--- a/api/update_open_api_spec.py
+++ b/api/update_open_api_spec.py
@@ -184,7 +184,7 @@ The Covid Act Now API provides historical covid projections updated daily.
     api_key_description = """
 An API key is required.
 
-Register for an API key [here](/getting-started/access).
+Register for an API key [here](/access).
     """
     spec = OpenAPI.parse_obj(
         {

--- a/cli/api.py
+++ b/cli/api.py
@@ -81,9 +81,9 @@ def update_schemas(output_dir, update_readme):
 )
 def update_v2_schemas(api_output_path, schemas_output_dir):
     """Updates all public facing API schemas."""
-    spec = update_open_api_spec.construct_open_api_spec()
-    schema_out = spec.json(by_alias=True, exclude_none=True, indent=2)
-    api_output_path.write_text(schema_out)
+    # spec = update_open_api_spec.construct_open_api_spec()
+    # schema_out = spec.json(by_alias=True, exclude_none=True, indent=2)
+    # api_output_path.write_text(schema_out)
 
     schemas = api.find_public_model_classes(api_v2=True)
     for schema in schemas:

--- a/cli/api.py
+++ b/cli/api.py
@@ -81,9 +81,9 @@ def update_schemas(output_dir, update_readme):
 )
 def update_v2_schemas(api_output_path, schemas_output_dir):
     """Updates all public facing API schemas."""
-    # spec = update_open_api_spec.construct_open_api_spec()
-    # schema_out = spec.json(by_alias=True, exclude_none=True, indent=2)
-    # api_output_path.write_text(schema_out)
+    spec = update_open_api_spec.construct_open_api_spec()
+    schema_out = spec.json(by_alias=True, exclude_none=True, indent=2)
+    api_output_path.write_text(schema_out)
 
     schemas = api.find_public_model_classes(api_v2=True)
     for schema in schemas:

--- a/libs/base_model.py
+++ b/libs/base_model.py
@@ -12,6 +12,7 @@ class APIBaseModel(pydantic.BaseModel):
     class Config:
         json_dumps = _nan_safe_json_dumps
 
+        @staticmethod
         def schema_extra(schema, model):
             # Updating json schema output to respect optional typed fields.
             # Without this code, the schema output doesn't signify that a value

--- a/libs/base_model.py
+++ b/libs/base_model.py
@@ -25,17 +25,9 @@ class APIBaseModel(pydantic.BaseModel):
                             {"type": existing_type},
                             {"type": "null"},
                         ]
-                        print(schema["properties"][field_name])
-
-                        # schema['properties']['nullable'] = True
-                    # print(field_name, field)
-                    # print(field.field_info)
-                    # print(field.outer_type_)
-                    # print(field.type_)
-                    # print(field.allow_none)
-                # print(vars(field))
-                # print(field.type_)
-                # print(dir(field.type_))
-            # for field in model.fields:
-            #     print(field)
-            # print(model)
+                    if "$ref" in existing_field:
+                        existing_type = existing_field.pop("$ref")
+                        existing_field["anyOf"] = [
+                            {"$ref": existing_type},
+                            {"type": "null"},
+                        ]

--- a/libs/base_model.py
+++ b/libs/base_model.py
@@ -18,9 +18,15 @@ class APIBaseModel(pydantic.BaseModel):
                 if field.allow_none and field.required:
                     print("*****")
                     print(field_name)
-                    if "type" in schema["properties"][field_name]:
-                        existing_schema_type = schema["properties"][field_name]["type"]
-                        schema["properties"][field_name] = ["null", existing_schema_type]
+                    existing_field = schema["properties"][field_name]
+                    if "type" in existing_field:
+                        existing_type = existing_field.pop("type")
+                        existing_field["anyOf"] = [
+                            {"type": existing_type},
+                            {"type": "null"},
+                        ]
+                        print(schema["properties"][field_name])
+
                         # schema['properties']['nullable'] = True
                     # print(field_name, field)
                     # print(field.field_info)

--- a/libs/base_model.py
+++ b/libs/base_model.py
@@ -13,19 +13,30 @@ class APIBaseModel(pydantic.BaseModel):
         json_dumps = _nan_safe_json_dumps
 
         def schema_extra(schema, model):
-            print(schema)
+            # Updating json schema output to respect optional typed fields.
+            # Without this code, the schema output doesn't signify that a value
+            # is nullable.
+            # This behavior will not be changed until
+            # Pydantic v2.0 it seems https://github.com/samuelcolvin/pydantic/issues/1270.
             for field_name, field in model.__fields__.items():
+
+                # Checking for fields that allow none (essentially indicating that the
+                # type is Optional[<type>]) and required.
+                # This is possibly more stringent than necessary (field.required may not be
+                # necessary), but since this code is fairly manual, this applies the
+                # minimum changes necessary for our code.
                 if field.allow_none and field.required:
-                    print("*****")
-                    print(field_name)
                     existing_field = schema["properties"][field_name]
                     if "type" in existing_field:
+                        # Removing existing type field and adding a "anyOf" indicates that
+                        # the field may contain any of the following subschemas
+                        # https://json-schema.org/understanding-json-schema/reference/combining.html
                         existing_type = existing_field.pop("type")
                         existing_field["anyOf"] = [
                             {"type": existing_type},
                             {"type": "null"},
                         ]
-                    if "$ref" in existing_field:
+                    elif "$ref" in existing_field:
                         existing_type = existing_field.pop("$ref")
                         existing_field["anyOf"] = [
                             {"$ref": existing_type},

--- a/libs/base_model.py
+++ b/libs/base_model.py
@@ -11,3 +11,25 @@ class APIBaseModel(pydantic.BaseModel):
 
     class Config:
         json_dumps = _nan_safe_json_dumps
+
+        def schema_extra(schema, model):
+            print(schema)
+            for field_name, field in model.__fields__.items():
+                if field.allow_none and field.required:
+                    print("*****")
+                    print(field_name)
+                    if "type" in schema["properties"][field_name]:
+                        existing_schema_type = schema["properties"][field_name]["type"]
+                        schema["properties"][field_name] = ["null", existing_schema_type]
+                        # schema['properties']['nullable'] = True
+                    # print(field_name, field)
+                    # print(field.field_info)
+                    # print(field.outer_type_)
+                    # print(field.type_)
+                    # print(field.allow_none)
+                # print(vars(field))
+                # print(field.type_)
+                # print(dir(field.type_))
+            # for field in model.fields:
+            #     print(field)
+            # print(model)

--- a/test/libs/base_model_test.py
+++ b/test/libs/base_model_test.py
@@ -27,7 +27,7 @@ def test_optional_field_modifies_schema_properly():
         bee: Optional[Bar] = pydantic.Field(...)
 
     results = Foo.schema()
-    print(results)
+
     expected = {
         "title": "Foo",
         "description": "Base model for API output.",


### PR DESCRIPTION
@mikelehen brought up a good point that it is strange that we have the fields as being possibly not included, since all fields are currently included right now.

I ended up going down a bit of a rabbit hole, but long story short is that pydantic doesn't actually support outputting a field that is typed: `Optional[int]` as being null or int.  This PR implements some manual tweaking to identify when there is a required field that can be either null or a value and modifying the resulting schema.

It will make the typing more clear on the website