### PR TITLE
covid tracking from public repo

### DIFF
--- a/libs/datasets/sources/covid_tracking_source.py
+++ b/libs/datasets/sources/covid_tracking_source.py
@@ -1,124 +1,37 @@
-import logging
-import pandas as pd
-import numpy as np
-import sentry_sdk
+from covidactnow.datapublic import common_df
 
 from covidactnow.datapublic.common_fields import CommonFields
 from libs.datasets import data_source
 from libs.datasets import dataset_utils
-from libs.datasets.dataset_utils import AggregationLevel
-from libs.datasets.common_fields import CommonIndexFields
-
-_logger = logging.getLogger(__name__)
+from libs.datasets.timeseries import TimeseriesDataset
 
 
 class CovidTrackingDataSource(data_source.DataSource):
-    # This
-    DATA_PATH = "data/covid-tracking/covid_tracking_states.csv"
+    INPUT_PATH = dataset_utils.LOCAL_PUBLIC_DATA_PATH / "data" / "covid-tracking" / "timeseries.csv"
     SOURCE_NAME = "covid_tracking"
 
-    class Fields(object):
-        # ISO 8601 date of when these values were valid.
-        DATE_CHECKED = "dateChecked"
-        STATE = "state"
-        # Total cumulative positive test results.
-        POSITIVE_TESTS = "positive"
-        # Increase from the day before.
-        POSITIVE_INCREASE = "positiveIncrease"
-        # Total cumulative negative test results.
-        NEGATIVE_TESTS = "negative"
-        # Increase from the day before.
-        NEGATIVE_INCREASE = "negativeIncrease"
-        # Total cumulative number of people hospitalized.
-        TOTAL_HOSPITALIZED = "hospitalized"
-        # Total cumulative number of people hospitalized.
-        CURRENT_HOSPITALIZED = "hospitalizedCurrently"
-        # Increase from the day before.
-        HOSPITALIZED_INCREASE = "hospitalizedIncrease"
-        # Total cumulative number of people that have died.
-        DEATHS = "death"
-        # Increase from the day before.
-        DEATH_INCREASE = "deathIncrease"
-        # Tests that have been submitted to a lab but no results have been reported yet.
-        PENDING = "pending"
-        # Calculated value (positive + negative) of total test results.
-        TOTAL_TEST_RESULTS = "totalTestResults"
-        # Increase from the day before.
-        TOTAL_TEST_RESULTS_INCREASE = "totalTestResultsIncrease"
+    INDEX_FIELD_MAP = {f: f for f in TimeseriesDataset.INDEX_FIELDS}
 
-        IN_ICU_CURRENTLY = "inIcuCurrently"
-        IN_ICU_CUMULATIVE = "inIcuCumulative"
-
-        TOTAL_IN_ICU = "inIcuCumulative"
-
-        ON_VENTILATOR_CURRENTLY = "onVentilatorCurrently"
-        TOTAL_ON_VENTILATOR = "onVentilatorCumulative"
-
-        COUNTRY = "country"
-        COUNTY = "county"
-        DATE = "date"
-        AGGREGATE_LEVEL = "aggregate_level"
-        FIPS = "fips"
-
-    INDEX_FIELD_MAP = {
-        CommonIndexFields.DATE: Fields.DATE,
-        CommonIndexFields.COUNTRY: Fields.COUNTRY,
-        CommonIndexFields.STATE: Fields.STATE,
-        CommonIndexFields.FIPS: Fields.FIPS,
-        CommonIndexFields.AGGREGATE_LEVEL: Fields.AGGREGATE_LEVEL,
-    }
-
+    # Keep in sync with update_covid_tracking_data in the covid-data-public repo.
+    # DataSource objects must have a map from CommonFields to fields in the source file.
+    # For this source the conversion is done in the covid-data-public repo so the map
+    # here doesn't represent any field renaming.
     COMMON_FIELD_MAP = {
-        CommonFields.DEATHS: Fields.DEATHS,
-        CommonFields.CURRENT_HOSPITALIZED: Fields.CURRENT_HOSPITALIZED,
-        CommonFields.CURRENT_ICU: Fields.IN_ICU_CURRENTLY,
-        CommonFields.CURRENT_VENTILATED: Fields.ON_VENTILATOR_CURRENTLY,
-        CommonFields.CUMULATIVE_HOSPITALIZED: Fields.TOTAL_HOSPITALIZED,
-        CommonFields.CUMULATIVE_ICU: Fields.TOTAL_IN_ICU,
-        CommonFields.POSITIVE_TESTS: Fields.POSITIVE_TESTS,
-        CommonFields.NEGATIVE_TESTS: Fields.NEGATIVE_TESTS,
+        f: f
+        for f in {
+            CommonFields.DEATHS,
+            CommonFields.CURRENT_HOSPITALIZED,
+            CommonFields.CURRENT_ICU,
+            CommonFields.CURRENT_VENTILATED,
+            CommonFields.CUMULATIVE_HOSPITALIZED,
+            CommonFields.CUMULATIVE_ICU,
+            CommonFields.POSITIVE_TESTS,
+            CommonFields.NEGATIVE_TESTS,
+        }
     }
-
-    def __init__(self, input_path):
-        data = pd.read_csv(
-            input_path,
-            parse_dates=[self.Fields.DATE],
-            dtype={self.Fields.FIPS: str},
-            date_parser=lambda col: pd.to_datetime(col, format="%Y%m%d"),
-        )
-        data = self.standardize_data(data)
-        super().__init__(data)
 
     @classmethod
     def local(cls) -> "CovidTrackingDataSource":
-        data_root = dataset_utils.LOCAL_PUBLIC_DATA_PATH
-        return cls(data_root / cls.DATA_PATH)
-
-    @classmethod
-    def standardize_data(cls, data: pd.DataFrame) -> pd.DataFrame:
-        data[cls.Fields.COUNTY] = None
-        data[cls.Fields.COUNTRY] = "USA"
-        data[cls.Fields.AGGREGATE_LEVEL] = AggregationLevel.STATE.value
-
-        # Removing bad data from Delaware.
-        # Once that is resolved we can remove this while keeping the assert below.
-        icu_mask = data[cls.Fields.IN_ICU_CURRENTLY] > data[cls.Fields.CURRENT_HOSPITALIZED]
-        if icu_mask.any():
-            data[cls.Fields.IN_ICU_CURRENTLY].loc[icu_mask] = np.nan
-            message = (
-                f"{len(data[icu_mask])} lines were changed in the ICU Current data "
-                f"for {data[icu_mask]['state'].nunique()} state(s)"
-            )
-            _logger.warning(message)
-            sentry_sdk.capture_message(message)
-
-        # Current Sanity Check and Filter for In ICU.
-        # This should fail for Delaware right now unless we patch it.
-        # The 'not any' style is to deal with comparisons to np.nan.
-        assert not (
-            data[cls.Fields.IN_ICU_CURRENTLY] > data[cls.Fields.CURRENT_HOSPITALIZED]
-        ).any(), "IN_ICU_CURRENTLY field is greater than CURRENT_HOSPITALIZED"
-
-        # TODO implement assertion to check for shift, as sliced by geo
-        # df['totalTestResults'] - df['totalTestResultsIncrease']  ==  df['totalTestResults'].shift(-1)
-        return cls._rename_to_common_fields(data)
+        data = common_df.read_csv(cls.INPUT_PATH).reset_index()
+        # Column names are already CommonFields so don't need to rename
+        return cls(data, provenance=None)


### PR DESCRIPTION
## This PR

* Changes `CovidTrackingDataSource` to read timeseries.csv, which was parsed in the covid-data-public repo

## Tested

Checked that my local covid-data-public repo is at sha in `data/multiregion.json` + https://github.com/covid-projections/covid-data-public/pull/135 then ran `python ./run.py data update --summary-filename=''`  and checked that `multiregion.csv` was not modified.