### PR TITLE
Patch NJ Typical ICU as Quick Fix

### DIFF
--- a/libs/icu_headroom_metric.py
+++ b/libs/icu_headroom_metric.py
@@ -20,6 +20,12 @@ DEFAULT_ICU_DECOMP = 0.21
 NJ_CORRECTION = (
     0.176 - 0.57 + DEFAULT_ICU_DECOMP
 )  # https://trello.com/c/T15w5VLq/418-nj-icu-occupancy-rate-nonsensical
+# This is temporarily correcting for incorrect typical occupancy rate by
+# applying the shim in the decom override. It is negative, because we want
+# to say that the expect ICU occupancy is greater than the reported ICU occupancy
+# since CCM currently reports typical occupancy at 0.176 when they should be
+# reporting something closer to the historical 0.57 from the 2018 source data
+# they draw from.
 
 ICU_DECOMP_OVERRIDE = {
     "AL": 0.15,

--- a/libs/icu_headroom_metric.py
+++ b/libs/icu_headroom_metric.py
@@ -17,9 +17,8 @@ DEFAULT_ICU_UTILIZATION = 0.75
 
 DEFAULT_ICU_DECOMP = 0.21
 
-NJ_CORRECTION = (
-    0.176 - 0.57 + DEFAULT_ICU_DECOMP
-)  # https://trello.com/c/T15w5VLq/418-nj-icu-occupancy-rate-nonsensical
+NJ_CORRECTION = 0.176 - 0.57 + DEFAULT_ICU_DECOMP
+# https://trello.com/c/T15w5VLq/418-nj-icu-occupancy-rate-nonsensical
 # This is temporarily correcting for incorrect typical occupancy rate by
 # applying the shim in the decom override. It is negative, because we want
 # to say that the expect ICU occupancy is greater than the reported ICU occupancy

--- a/libs/icu_headroom_metric.py
+++ b/libs/icu_headroom_metric.py
@@ -17,6 +17,10 @@ DEFAULT_ICU_UTILIZATION = 0.75
 
 DEFAULT_ICU_DECOMP = 0.21
 
+NJ_CORRECTION = (
+    0.176 - 0.57 + DEFAULT_ICU_DECOMP
+)  # https://trello.com/c/T15w5VLq/418-nj-icu-occupancy-rate-nonsensical
+
 ICU_DECOMP_OVERRIDE = {
     "AL": 0.15,
     "AZ": 0.4,
@@ -29,6 +33,7 @@ ICU_DECOMP_OVERRIDE = {
     "MS": 0.37,
     "NV": 0.25,
     "RI": 0,
+    "NJ": NJ_CORRECTION,
 }
 
 


### PR DESCRIPTION

This PR addresses issue https://trello.com/c/T15w5VLq/418-nj-icu-occupancy-rate-nonsensical.

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/master/api/schemas) updated?
- [ ] Are the [api docs](https://github.com/covid-projections/covid-data-model/blob/master/api/README.V1.md) updated?
- [ ] Are tests passing?
