### PR TITLE
Adding pool back to processing

### DIFF
--- a/libs/pipelines/api_v2_pipeline.py
+++ b/libs/pipelines/api_v2_pipeline.py
@@ -71,7 +71,7 @@ def run_on_regions(
     # Setting maxtasksperchild to one ensures that we minimize memory usage over time by creating
     # a new child for every task. Addresses OOMs we saw on highly parallel build machine.
     pool = pool or multiprocessing.Pool(maxtasksperchild=1)
-    results = map(build_timeseries_for_region, regional_inputs)
+    results = pool.map(build_timeseries_for_region, regional_inputs)
     all_timeseries = [result for result in results if result]
 
     if sort_func:


### PR DESCRIPTION
This shaves a good 15 min off the deploy.  API v2 generation now takes 7 min instead of 23 min. 