### PR TITLE
Updating to pydantic 1.6.1 and fixing enum handling

### DIFF
--- a/api/README.V1.md
+++ b/api/README.V1.md
@@ -245,15 +245,25 @@ Utilization of hospital resources.
 | currentUsageTotal | integer | Currently used capacity for resource by all patients (COVID + Non-COVID)                                                                                                                                                                |
 | typicalUsageRate  | number  | Typical used capacity rate for resource. This excludes any COVID usage.                                                                                                                                                                 |
 
+### CovidPatientsMethod
+Method used to determine number of current ICU patients with covid.
+
+
+
+### NonCovidPatientsMethod
+Method used to determine number of current ICU patients without covid.
+
+
+
 ### ICUHeadroomMetricDetails
 Details about how the ICU Headroom Metric was calculated.
 
-| name                     | type    | description                                                            |
-|--------------------------|---------|------------------------------------------------------------------------|
-| currentIcuCovid          | integer | Current number of covid patients in icu.                               |
-| currentIcuCovidMethod    |         | Method used to determine number of current ICU patients with covid.    |
-| currentIcuNonCovid       | integer | Current number of covid patients in icu.                               |
-| currentIcuNonCovidMethod |         | Method used to determine number of current ICU patients without covid. |
+| name                     | type                                              | description                                                            |
+|--------------------------|---------------------------------------------------|------------------------------------------------------------------------|
+| currentIcuCovid          | integer                                           | Current number of covid patients in icu.                               |
+| currentIcuCovidMethod    | [CovidPatientsMethod](#CovidPatientsMethod)       | Method used to determine number of current ICU patients with covid.    |
+| currentIcuNonCovid       | integer                                           | Current number of covid patients in icu.                               |
+| currentIcuNonCovidMethod | [NonCovidPatientsMethod](#NonCovidPatientsMethod) | Method used to determine number of current ICU patients without covid. |
 
 ### Metrics
 Calculated metrics data based on known actuals.
@@ -293,8 +303,8 @@ Known actuals data.
 | cumulativePositiveTests  | integer                                     | Number of positive test results to date                                         |
 | cumulativeNegativeTests  | integer                                     | Number of negative test results to date                                         |
 | cumulativeDeaths         | integer                                     | Number of deaths so far                                                         |
-| hospitalBeds             | [ResourceUtilization](#ResourceUtilization) | Utilization of hospital resources.                                              |
-| ICUBeds                  | [ResourceUtilization](#ResourceUtilization) | Utilization of hospital resources.                                              |
+| hospitalBeds             | [ResourceUtilization](#ResourceUtilization) |                                                                                 |
+| ICUBeds                  | [ResourceUtilization](#ResourceUtilization) |                                                                                 |
 | contactTracers           | integer                                     | # of Contact Tracers                                                            |
 
 ### ActualsTimeseriesRow
@@ -308,8 +318,8 @@ Actual data for a specific day.
 | cumulativePositiveTests  | integer                                     | Number of positive test results to date                                         |
 | cumulativeNegativeTests  | integer                                     | Number of negative test results to date                                         |
 | cumulativeDeaths         | integer                                     | Number of deaths so far                                                         |
-| hospitalBeds             | [ResourceUtilization](#ResourceUtilization) | Utilization of hospital resources.                                              |
-| ICUBeds                  | [ResourceUtilization](#ResourceUtilization) | Utilization of hospital resources.                                              |
+| hospitalBeds             | [ResourceUtilization](#ResourceUtilization) |                                                                                 |
+| ICUBeds                  | [ResourceUtilization](#ResourceUtilization) |                                                                                 |
 | contactTracers           | integer                                     | # of Contact Tracers                                                            |
 | date                     | string                                      |                                                                                 |
 
@@ -325,8 +335,8 @@ Summary of actual and prediction data for a single region.
 | stateName       | string                      | The state name                                                                       |
 | countyName      | string                      | The county name                                                                      |
 | lastUpdatedDate | string                      | Date of latest data                                                                  |
-| projections     | [Projections](#Projections) | Summary of projection data.                                                          |
-| actuals         | [Actuals](#Actuals)         | Known actuals data.                                                                  |
+| projections     | [Projections](#Projections) |                                                                                      |
+| actuals         | [Actuals](#Actuals)         |                                                                                      |
 | metrics         | [Metrics](#Metrics)         | Region level metrics                                                                 |
 | population      | integer                     | Total Population in geographic region.                                               |
 
@@ -362,8 +372,8 @@ Summary data for a region with prediction timeseries data and actual timeseries 
 | stateName         | string                      | The state name                                                                       |
 | countyName        | string                      | The county name                                                                      |
 | lastUpdatedDate   | string                      | Date of latest data                                                                  |
-| projections       | [Projections](#Projections) | Summary of projection data.                                                          |
-| actuals           | [Actuals](#Actuals)         | Known actuals data.                                                                  |
+| projections       | [Projections](#Projections) |                                                                                      |
+| actuals           | [Actuals](#Actuals)         |                                                                                      |
 | metrics           | [Metrics](#Metrics)         | Region level metrics                                                                 |
 | population        | integer                     | Total Population in geographic region.                                               |
 | timeseries        | array                       |                                                                                      |

--- a/api/schemas/Actuals.json
+++ b/api/schemas/Actuals.json
@@ -7,7 +7,14 @@
       "title": "Population",
       "description": "Total population in geographic region [*deprecated*: refer to summary for this]",
       "exclusiveMinimum": 0,
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "intervention": {
       "title": "Intervention",
@@ -17,28 +24,70 @@
     "cumulativeConfirmedCases": {
       "title": "Cumulativeconfirmedcases",
       "description": "Number of confirmed cases so far",
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "cumulativePositiveTests": {
       "title": "Cumulativepositivetests",
       "description": "Number of positive test results to date",
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "cumulativeNegativeTests": {
       "title": "Cumulativenegativetests",
       "description": "Number of negative test results to date",
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "cumulativeDeaths": {
       "title": "Cumulativedeaths",
       "description": "Number of deaths so far",
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "hospitalBeds": {
-      "$ref": "#/definitions/ResourceUtilization"
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ResourceUtilization"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "ICUBeds": {
-      "$ref": "#/definitions/ResourceUtilization"
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ResourceUtilization"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "contactTracers": {
       "title": "Contacttracers",
@@ -65,27 +114,62 @@
         "capacity": {
           "title": "Capacity",
           "description": "*deprecated*: Capacity for resource. In the case of ICUs, this refers to total capacity. For hospitalization this refers to free capacity for COVID patients. This value is calculated by (1 - typicalUsageRate) * totalCapacity * 2.07",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "totalCapacity": {
           "title": "Totalcapacity",
           "description": "Total capacity for resource.",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "currentUsageCovid": {
           "title": "Currentusagecovid",
           "description": "Currently used capacity for resource by COVID ",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "currentUsageTotal": {
           "title": "Currentusagetotal",
           "description": "Currently used capacity for resource by all patients (COVID + Non-COVID)",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "typicalUsageRate": {
           "title": "Typicalusagerate",
           "description": "Typical used capacity rate for resource. This excludes any COVID usage.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [

--- a/api/schemas/ActualsTimeseriesRow.json
+++ b/api/schemas/ActualsTimeseriesRow.json
@@ -7,7 +7,14 @@
       "title": "Population",
       "description": "Total population in geographic region [*deprecated*: refer to summary for this]",
       "exclusiveMinimum": 0,
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "intervention": {
       "title": "Intervention",
@@ -17,28 +24,70 @@
     "cumulativeConfirmedCases": {
       "title": "Cumulativeconfirmedcases",
       "description": "Number of confirmed cases so far",
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "cumulativePositiveTests": {
       "title": "Cumulativepositivetests",
       "description": "Number of positive test results to date",
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "cumulativeNegativeTests": {
       "title": "Cumulativenegativetests",
       "description": "Number of negative test results to date",
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "cumulativeDeaths": {
       "title": "Cumulativedeaths",
       "description": "Number of deaths so far",
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "hospitalBeds": {
-      "$ref": "#/definitions/ResourceUtilization"
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ResourceUtilization"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "ICUBeds": {
-      "$ref": "#/definitions/ResourceUtilization"
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ResourceUtilization"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "contactTracers": {
       "title": "Contacttracers",
@@ -72,27 +121,62 @@
         "capacity": {
           "title": "Capacity",
           "description": "*deprecated*: Capacity for resource. In the case of ICUs, this refers to total capacity. For hospitalization this refers to free capacity for COVID patients. This value is calculated by (1 - typicalUsageRate) * totalCapacity * 2.07",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "totalCapacity": {
           "title": "Totalcapacity",
           "description": "Total capacity for resource.",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "currentUsageCovid": {
           "title": "Currentusagecovid",
           "description": "Currently used capacity for resource by COVID ",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "currentUsageTotal": {
           "title": "Currentusagetotal",
           "description": "Currently used capacity for resource by all patients (COVID + Non-COVID)",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "typicalUsageRate": {
           "title": "Typicalusagerate",
           "description": "Typical used capacity rate for resource. This excludes any COVID usage.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [

--- a/api/schemas/AggregateFlattenedTimeseries.json
+++ b/api/schemas/AggregateFlattenedTimeseries.json
@@ -30,7 +30,14 @@
         "ICUBedsInUse": {
           "title": "Icubedsinuse",
           "description": "Number of ICU beds projected to be in-use or that were actually in use (if in the past)",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "ICUBedCapacity": {
           "title": "Icubedcapacity",
@@ -50,12 +57,26 @@
         "RtIndicator": {
           "title": "Rtindicator",
           "description": "Historical or Inferred Rt",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "RtIndicatorCI90": {
           "title": "Rtindicatorci90",
           "description": "Rt standard deviation",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "cumulativeDeaths": {
           "title": "Cumulativedeaths",
@@ -65,22 +86,50 @@
         "cumulativeInfected": {
           "title": "Cumulativeinfected",
           "description": "Number of cumulative infections",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "currentInfected": {
           "title": "Currentinfected",
           "description": "Number of current infections",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "currentSusceptible": {
           "title": "Currentsusceptible",
           "description": "Number of people currently susceptible ",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "currentExposed": {
           "title": "Currentexposed",
           "description": "Number of people currently exposed",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "countryName": {
           "title": "Countryname",
@@ -95,7 +144,14 @@
         "countyName": {
           "title": "Countyname",
           "description": "The county name",
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "intervention": {
           "title": "Intervention",
@@ -110,12 +166,26 @@
         "lat": {
           "title": "Lat",
           "description": "Latitude of point within the state or county",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "long": {
           "title": "Long",
           "description": "Longitude of point within the state or county",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "lastUpdatedDate": {
           "title": "Lastupdateddate",

--- a/api/schemas/AggregateRegionSummary.json
+++ b/api/schemas/AggregateRegionSummary.json
@@ -19,14 +19,28 @@
         "peakDate": {
           "title": "Peakdate",
           "description": "Date of peak resource utilization",
-          "type": "string",
-          "format": "date"
+          "format": "date",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "shortageStartDate": {
           "title": "Shortagestartdate",
           "description": "Date when resource shortage begins",
-          "type": "string",
-          "format": "date"
+          "format": "date",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -61,12 +75,26 @@
         "Rt": {
           "title": "Rt",
           "description": "Inferred Rt",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "RtCI90": {
           "title": "Rtci90",
           "description": "Rt 90th percentile confidence interval upper endpoint.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -84,27 +112,62 @@
         "capacity": {
           "title": "Capacity",
           "description": "*deprecated*: Capacity for resource. In the case of ICUs, this refers to total capacity. For hospitalization this refers to free capacity for COVID patients. This value is calculated by (1 - typicalUsageRate) * totalCapacity * 2.07",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "totalCapacity": {
           "title": "Totalcapacity",
           "description": "Total capacity for resource.",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "currentUsageCovid": {
           "title": "Currentusagecovid",
           "description": "Currently used capacity for resource by COVID ",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "currentUsageTotal": {
           "title": "Currentusagetotal",
           "description": "Currently used capacity for resource by all patients (COVID + Non-COVID)",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "typicalUsageRate": {
           "title": "Typicalusagerate",
           "description": "Typical used capacity rate for resource. This excludes any COVID usage.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -124,7 +187,14 @@
           "title": "Population",
           "description": "Total population in geographic region [*deprecated*: refer to summary for this]",
           "exclusiveMinimum": 0,
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "intervention": {
           "title": "Intervention",
@@ -134,28 +204,70 @@
         "cumulativeConfirmedCases": {
           "title": "Cumulativeconfirmedcases",
           "description": "Number of confirmed cases so far",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "cumulativePositiveTests": {
           "title": "Cumulativepositivetests",
           "description": "Number of positive test results to date",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "cumulativeNegativeTests": {
           "title": "Cumulativenegativetests",
           "description": "Number of negative test results to date",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "cumulativeDeaths": {
           "title": "Cumulativedeaths",
           "description": "Number of deaths so far",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "hospitalBeds": {
-          "$ref": "#/definitions/ResourceUtilization"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ResourceUtilization"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "ICUBeds": {
-          "$ref": "#/definitions/ResourceUtilization"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ResourceUtilization"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "contactTracers": {
           "title": "Contacttracers",
@@ -174,6 +286,23 @@
         "ICUBeds"
       ]
     },
+    "CovidPatientsMethod": {
+      "title": "CovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients with covid.",
+      "enum": [
+        "actual",
+        "estimated"
+      ]
+    },
+    "NonCovidPatientsMethod": {
+      "title": "NonCovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients without covid.",
+      "enum": [
+        "actual",
+        "estimated_from_typical_utilization",
+        "estimated_from_total_icu_actual"
+      ]
+    },
     "ICUHeadroomMetricDetails": {
       "title": "ICUHeadroomMetricDetails",
       "description": "Details about how the ICU Headroom Metric was calculated.",
@@ -185,12 +314,7 @@
           "type": "integer"
         },
         "currentIcuCovidMethod": {
-          "title": "Currenticucovidmethod",
-          "description": "Method used to determine number of current ICU patients with covid.",
-          "enum": [
-            "actual",
-            "estimated"
-          ]
+          "$ref": "#/definitions/CovidPatientsMethod"
         },
         "currentIcuNonCovid": {
           "title": "Currenticunoncovid",
@@ -198,13 +322,7 @@
           "type": "integer"
         },
         "currentIcuNonCovidMethod": {
-          "title": "Currenticunoncovidmethod",
-          "description": "Method used to determine number of current ICU patients without covid.",
-          "enum": [
-            "actual",
-            "estimated_from_typical_utilization",
-            "estimated_from_total_icu_actual"
-          ]
+          "$ref": "#/definitions/NonCovidPatientsMethod"
         }
       },
       "required": [
@@ -222,31 +340,73 @@
         "testPositivityRatio": {
           "title": "Testpositivityratio",
           "description": "Ratio of people who test positive calculated using a 7-day rolling average.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "caseDensity": {
           "title": "Casedensity",
           "description": "The number of cases per 100k population calculated using a 7-day rolling average.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "contactTracerCapacityRatio": {
           "title": "Contacttracercapacityratio",
           "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "infectionRate": {
           "title": "Infectionrate",
           "description": "R_t, or the estimated number of infections arising from a typical case.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "infectionRateCI90": {
           "title": "Infectionrateci90",
           "description": "90th percentile confidence interval upper endpoint of the infection rate.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "icuHeadroomRatio": {
           "title": "Icuheadroomratio",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "icuHeadroomDetails": {
           "$ref": "#/definitions/ICUHeadroomMetricDetails"
@@ -279,12 +439,26 @@
         "lat": {
           "title": "Lat",
           "description": "Latitude of point within the state or county",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "long": {
           "title": "Long",
           "description": "Longitude of point within the state or county",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "stateName": {
           "title": "Statename",
@@ -303,10 +477,24 @@
           "format": "date"
         },
         "projections": {
-          "$ref": "#/definitions/Projections"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Projections"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "actuals": {
-          "$ref": "#/definitions/Actuals"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Actuals"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "metrics": {
           "title": "Metrics",

--- a/api/schemas/AggregateRegionSummaryWithTimeseries.json
+++ b/api/schemas/AggregateRegionSummaryWithTimeseries.json
@@ -19,14 +19,28 @@
         "peakDate": {
           "title": "Peakdate",
           "description": "Date of peak resource utilization",
-          "type": "string",
-          "format": "date"
+          "format": "date",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "shortageStartDate": {
           "title": "Shortagestartdate",
           "description": "Date when resource shortage begins",
-          "type": "string",
-          "format": "date"
+          "format": "date",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -61,12 +75,26 @@
         "Rt": {
           "title": "Rt",
           "description": "Inferred Rt",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "RtCI90": {
           "title": "Rtci90",
           "description": "Rt 90th percentile confidence interval upper endpoint.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -84,27 +112,62 @@
         "capacity": {
           "title": "Capacity",
           "description": "*deprecated*: Capacity for resource. In the case of ICUs, this refers to total capacity. For hospitalization this refers to free capacity for COVID patients. This value is calculated by (1 - typicalUsageRate) * totalCapacity * 2.07",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "totalCapacity": {
           "title": "Totalcapacity",
           "description": "Total capacity for resource.",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "currentUsageCovid": {
           "title": "Currentusagecovid",
           "description": "Currently used capacity for resource by COVID ",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "currentUsageTotal": {
           "title": "Currentusagetotal",
           "description": "Currently used capacity for resource by all patients (COVID + Non-COVID)",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "typicalUsageRate": {
           "title": "Typicalusagerate",
           "description": "Typical used capacity rate for resource. This excludes any COVID usage.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -124,7 +187,14 @@
           "title": "Population",
           "description": "Total population in geographic region [*deprecated*: refer to summary for this]",
           "exclusiveMinimum": 0,
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "intervention": {
           "title": "Intervention",
@@ -134,28 +204,70 @@
         "cumulativeConfirmedCases": {
           "title": "Cumulativeconfirmedcases",
           "description": "Number of confirmed cases so far",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "cumulativePositiveTests": {
           "title": "Cumulativepositivetests",
           "description": "Number of positive test results to date",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "cumulativeNegativeTests": {
           "title": "Cumulativenegativetests",
           "description": "Number of negative test results to date",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "cumulativeDeaths": {
           "title": "Cumulativedeaths",
           "description": "Number of deaths so far",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "hospitalBeds": {
-          "$ref": "#/definitions/ResourceUtilization"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ResourceUtilization"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "ICUBeds": {
-          "$ref": "#/definitions/ResourceUtilization"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ResourceUtilization"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "contactTracers": {
           "title": "Contacttracers",
@@ -174,6 +286,23 @@
         "ICUBeds"
       ]
     },
+    "CovidPatientsMethod": {
+      "title": "CovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients with covid.",
+      "enum": [
+        "actual",
+        "estimated"
+      ]
+    },
+    "NonCovidPatientsMethod": {
+      "title": "NonCovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients without covid.",
+      "enum": [
+        "actual",
+        "estimated_from_typical_utilization",
+        "estimated_from_total_icu_actual"
+      ]
+    },
     "ICUHeadroomMetricDetails": {
       "title": "ICUHeadroomMetricDetails",
       "description": "Details about how the ICU Headroom Metric was calculated.",
@@ -185,12 +314,7 @@
           "type": "integer"
         },
         "currentIcuCovidMethod": {
-          "title": "Currenticucovidmethod",
-          "description": "Method used to determine number of current ICU patients with covid.",
-          "enum": [
-            "actual",
-            "estimated"
-          ]
+          "$ref": "#/definitions/CovidPatientsMethod"
         },
         "currentIcuNonCovid": {
           "title": "Currenticunoncovid",
@@ -198,13 +322,7 @@
           "type": "integer"
         },
         "currentIcuNonCovidMethod": {
-          "title": "Currenticunoncovidmethod",
-          "description": "Method used to determine number of current ICU patients without covid.",
-          "enum": [
-            "actual",
-            "estimated_from_typical_utilization",
-            "estimated_from_total_icu_actual"
-          ]
+          "$ref": "#/definitions/NonCovidPatientsMethod"
         }
       },
       "required": [
@@ -222,31 +340,73 @@
         "testPositivityRatio": {
           "title": "Testpositivityratio",
           "description": "Ratio of people who test positive calculated using a 7-day rolling average.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "caseDensity": {
           "title": "Casedensity",
           "description": "The number of cases per 100k population calculated using a 7-day rolling average.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "contactTracerCapacityRatio": {
           "title": "Contacttracercapacityratio",
           "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "infectionRate": {
           "title": "Infectionrate",
           "description": "R_t, or the estimated number of infections arising from a typical case.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "infectionRateCI90": {
           "title": "Infectionrateci90",
           "description": "90th percentile confidence interval upper endpoint of the infection rate.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "icuHeadroomRatio": {
           "title": "Icuheadroomratio",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "icuHeadroomDetails": {
           "$ref": "#/definitions/ICUHeadroomMetricDetails"
@@ -285,7 +445,14 @@
         "ICUBedsInUse": {
           "title": "Icubedsinuse",
           "description": "Number of ICU beds projected to be in-use or that were actually in use (if in the past)",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "ICUBedCapacity": {
           "title": "Icubedcapacity",
@@ -305,12 +472,26 @@
         "RtIndicator": {
           "title": "Rtindicator",
           "description": "Historical or Inferred Rt",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "RtIndicatorCI90": {
           "title": "Rtindicatorci90",
           "description": "Rt standard deviation",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "cumulativeDeaths": {
           "title": "Cumulativedeaths",
@@ -320,22 +501,50 @@
         "cumulativeInfected": {
           "title": "Cumulativeinfected",
           "description": "Number of cumulative infections",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "currentInfected": {
           "title": "Currentinfected",
           "description": "Number of current infections",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "currentSusceptible": {
           "title": "Currentsusceptible",
           "description": "Number of people currently susceptible ",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "currentExposed": {
           "title": "Currentexposed",
           "description": "Number of people currently exposed",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -364,7 +573,14 @@
           "title": "Population",
           "description": "Total population in geographic region [*deprecated*: refer to summary for this]",
           "exclusiveMinimum": 0,
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "intervention": {
           "title": "Intervention",
@@ -374,28 +590,70 @@
         "cumulativeConfirmedCases": {
           "title": "Cumulativeconfirmedcases",
           "description": "Number of confirmed cases so far",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "cumulativePositiveTests": {
           "title": "Cumulativepositivetests",
           "description": "Number of positive test results to date",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "cumulativeNegativeTests": {
           "title": "Cumulativenegativetests",
           "description": "Number of negative test results to date",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "cumulativeDeaths": {
           "title": "Cumulativedeaths",
           "description": "Number of deaths so far",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "hospitalBeds": {
-          "$ref": "#/definitions/ResourceUtilization"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ResourceUtilization"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "ICUBeds": {
-          "$ref": "#/definitions/ResourceUtilization"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ResourceUtilization"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "contactTracers": {
           "title": "Contacttracers",
@@ -429,31 +687,73 @@
         "testPositivityRatio": {
           "title": "Testpositivityratio",
           "description": "Ratio of people who test positive calculated using a 7-day rolling average.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "caseDensity": {
           "title": "Casedensity",
           "description": "The number of cases per 100k population calculated using a 7-day rolling average.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "contactTracerCapacityRatio": {
           "title": "Contacttracercapacityratio",
           "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "infectionRate": {
           "title": "Infectionrate",
           "description": "R_t, or the estimated number of infections arising from a typical case.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "infectionRateCI90": {
           "title": "Infectionrateci90",
           "description": "90th percentile confidence interval upper endpoint of the infection rate.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "icuHeadroomRatio": {
           "title": "Icuheadroomratio",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "icuHeadroomDetails": {
           "$ref": "#/definitions/ICUHeadroomMetricDetails"
@@ -493,12 +793,26 @@
         "lat": {
           "title": "Lat",
           "description": "Latitude of point within the state or county",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "long": {
           "title": "Long",
           "description": "Longitude of point within the state or county",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "stateName": {
           "title": "Statename",
@@ -517,10 +831,24 @@
           "format": "date"
         },
         "projections": {
-          "$ref": "#/definitions/Projections"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Projections"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "actuals": {
-          "$ref": "#/definitions/Actuals"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Actuals"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "metrics": {
           "title": "Metrics",
@@ -539,10 +867,17 @@
         },
         "timeseries": {
           "title": "Timeseries",
-          "type": "array",
           "items": {
             "$ref": "#/definitions/PredictionTimeseriesRow"
-          }
+          },
+          "anyOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "actualsTimeseries": {
           "title": "Actualstimeseries",
@@ -553,10 +888,17 @@
         },
         "metricsTimeseries": {
           "title": "Metricstimeseries",
-          "type": "array",
           "items": {
             "$ref": "#/definitions/MetricsTimeseriesRow"
-          }
+          },
+          "anyOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [

--- a/api/schemas/ICUHeadroomMetricDetails.json
+++ b/api/schemas/ICUHeadroomMetricDetails.json
@@ -9,12 +9,7 @@
       "type": "integer"
     },
     "currentIcuCovidMethod": {
-      "title": "Currenticucovidmethod",
-      "description": "Method used to determine number of current ICU patients with covid.",
-      "enum": [
-        "actual",
-        "estimated"
-      ]
+      "$ref": "#/definitions/CovidPatientsMethod"
     },
     "currentIcuNonCovid": {
       "title": "Currenticunoncovid",
@@ -22,13 +17,7 @@
       "type": "integer"
     },
     "currentIcuNonCovidMethod": {
-      "title": "Currenticunoncovidmethod",
-      "description": "Method used to determine number of current ICU patients without covid.",
-      "enum": [
-        "actual",
-        "estimated_from_typical_utilization",
-        "estimated_from_total_icu_actual"
-      ]
+      "$ref": "#/definitions/NonCovidPatientsMethod"
     }
   },
   "required": [
@@ -36,5 +25,24 @@
     "currentIcuCovidMethod",
     "currentIcuNonCovid",
     "currentIcuNonCovidMethod"
-  ]
+  ],
+  "definitions": {
+    "CovidPatientsMethod": {
+      "title": "CovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients with covid.",
+      "enum": [
+        "actual",
+        "estimated"
+      ]
+    },
+    "NonCovidPatientsMethod": {
+      "title": "NonCovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients without covid.",
+      "enum": [
+        "actual",
+        "estimated_from_typical_utilization",
+        "estimated_from_total_icu_actual"
+      ]
+    }
+  }
 }

--- a/api/schemas/Metrics.json
+++ b/api/schemas/Metrics.json
@@ -6,31 +6,73 @@
     "testPositivityRatio": {
       "title": "Testpositivityratio",
       "description": "Ratio of people who test positive calculated using a 7-day rolling average.",
-      "type": "number"
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "caseDensity": {
       "title": "Casedensity",
       "description": "The number of cases per 100k population calculated using a 7-day rolling average.",
-      "type": "number"
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "contactTracerCapacityRatio": {
       "title": "Contacttracercapacityratio",
       "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average.",
-      "type": "number"
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "infectionRate": {
       "title": "Infectionrate",
       "description": "R_t, or the estimated number of infections arising from a typical case.",
-      "type": "number"
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "infectionRateCI90": {
       "title": "Infectionrateci90",
       "description": "90th percentile confidence interval upper endpoint of the infection rate.",
-      "type": "number"
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "icuHeadroomRatio": {
       "title": "Icuheadroomratio",
-      "type": "number"
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "icuHeadroomDetails": {
       "$ref": "#/definitions/ICUHeadroomMetricDetails"
@@ -45,6 +87,23 @@
     "icuHeadroomRatio"
   ],
   "definitions": {
+    "CovidPatientsMethod": {
+      "title": "CovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients with covid.",
+      "enum": [
+        "actual",
+        "estimated"
+      ]
+    },
+    "NonCovidPatientsMethod": {
+      "title": "NonCovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients without covid.",
+      "enum": [
+        "actual",
+        "estimated_from_typical_utilization",
+        "estimated_from_total_icu_actual"
+      ]
+    },
     "ICUHeadroomMetricDetails": {
       "title": "ICUHeadroomMetricDetails",
       "description": "Details about how the ICU Headroom Metric was calculated.",
@@ -56,12 +115,7 @@
           "type": "integer"
         },
         "currentIcuCovidMethod": {
-          "title": "Currenticucovidmethod",
-          "description": "Method used to determine number of current ICU patients with covid.",
-          "enum": [
-            "actual",
-            "estimated"
-          ]
+          "$ref": "#/definitions/CovidPatientsMethod"
         },
         "currentIcuNonCovid": {
           "title": "Currenticunoncovid",
@@ -69,13 +123,7 @@
           "type": "integer"
         },
         "currentIcuNonCovidMethod": {
-          "title": "Currenticunoncovidmethod",
-          "description": "Method used to determine number of current ICU patients without covid.",
-          "enum": [
-            "actual",
-            "estimated_from_typical_utilization",
-            "estimated_from_total_icu_actual"
-          ]
+          "$ref": "#/definitions/NonCovidPatientsMethod"
         }
       },
       "required": [

--- a/api/schemas/MetricsTimeseriesRow.json
+++ b/api/schemas/MetricsTimeseriesRow.json
@@ -6,31 +6,73 @@
     "testPositivityRatio": {
       "title": "Testpositivityratio",
       "description": "Ratio of people who test positive calculated using a 7-day rolling average.",
-      "type": "number"
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "caseDensity": {
       "title": "Casedensity",
       "description": "The number of cases per 100k population calculated using a 7-day rolling average.",
-      "type": "number"
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "contactTracerCapacityRatio": {
       "title": "Contacttracercapacityratio",
       "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average.",
-      "type": "number"
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "infectionRate": {
       "title": "Infectionrate",
       "description": "R_t, or the estimated number of infections arising from a typical case.",
-      "type": "number"
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "infectionRateCI90": {
       "title": "Infectionrateci90",
       "description": "90th percentile confidence interval upper endpoint of the infection rate.",
-      "type": "number"
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "icuHeadroomRatio": {
       "title": "Icuheadroomratio",
-      "type": "number"
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "icuHeadroomDetails": {
       "$ref": "#/definitions/ICUHeadroomMetricDetails"
@@ -52,6 +94,23 @@
     "date"
   ],
   "definitions": {
+    "CovidPatientsMethod": {
+      "title": "CovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients with covid.",
+      "enum": [
+        "actual",
+        "estimated"
+      ]
+    },
+    "NonCovidPatientsMethod": {
+      "title": "NonCovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients without covid.",
+      "enum": [
+        "actual",
+        "estimated_from_typical_utilization",
+        "estimated_from_total_icu_actual"
+      ]
+    },
     "ICUHeadroomMetricDetails": {
       "title": "ICUHeadroomMetricDetails",
       "description": "Details about how the ICU Headroom Metric was calculated.",
@@ -63,12 +122,7 @@
           "type": "integer"
         },
         "currentIcuCovidMethod": {
-          "title": "Currenticucovidmethod",
-          "description": "Method used to determine number of current ICU patients with covid.",
-          "enum": [
-            "actual",
-            "estimated"
-          ]
+          "$ref": "#/definitions/CovidPatientsMethod"
         },
         "currentIcuNonCovid": {
           "title": "Currenticunoncovid",
@@ -76,13 +130,7 @@
           "type": "integer"
         },
         "currentIcuNonCovidMethod": {
-          "title": "Currenticunoncovidmethod",
-          "description": "Method used to determine number of current ICU patients without covid.",
-          "enum": [
-            "actual",
-            "estimated_from_typical_utilization",
-            "estimated_from_total_icu_actual"
-          ]
+          "$ref": "#/definitions/NonCovidPatientsMethod"
         }
       },
       "required": [

--- a/api/schemas/PredictionTimeseriesRow.json
+++ b/api/schemas/PredictionTimeseriesRow.json
@@ -22,7 +22,14 @@
     "ICUBedsInUse": {
       "title": "Icubedsinuse",
       "description": "Number of ICU beds projected to be in-use or that were actually in use (if in the past)",
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "ICUBedCapacity": {
       "title": "Icubedcapacity",
@@ -42,12 +49,26 @@
     "RtIndicator": {
       "title": "Rtindicator",
       "description": "Historical or Inferred Rt",
-      "type": "number"
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "RtIndicatorCI90": {
       "title": "Rtindicatorci90",
       "description": "Rt standard deviation",
-      "type": "number"
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "cumulativeDeaths": {
       "title": "Cumulativedeaths",
@@ -57,22 +78,50 @@
     "cumulativeInfected": {
       "title": "Cumulativeinfected",
       "description": "Number of cumulative infections",
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "currentInfected": {
       "title": "Currentinfected",
       "description": "Number of current infections",
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "currentSusceptible": {
       "title": "Currentsusceptible",
       "description": "Number of people currently susceptible ",
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "currentExposed": {
       "title": "Currentexposed",
       "description": "Number of people currently exposed",
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "required": [

--- a/api/schemas/PredictionTimeseriesRowWithHeader.json
+++ b/api/schemas/PredictionTimeseriesRowWithHeader.json
@@ -22,7 +22,14 @@
     "ICUBedsInUse": {
       "title": "Icubedsinuse",
       "description": "Number of ICU beds projected to be in-use or that were actually in use (if in the past)",
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "ICUBedCapacity": {
       "title": "Icubedcapacity",
@@ -42,12 +49,26 @@
     "RtIndicator": {
       "title": "Rtindicator",
       "description": "Historical or Inferred Rt",
-      "type": "number"
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "RtIndicatorCI90": {
       "title": "Rtindicatorci90",
       "description": "Rt standard deviation",
-      "type": "number"
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "cumulativeDeaths": {
       "title": "Cumulativedeaths",
@@ -57,22 +78,50 @@
     "cumulativeInfected": {
       "title": "Cumulativeinfected",
       "description": "Number of cumulative infections",
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "currentInfected": {
       "title": "Currentinfected",
       "description": "Number of current infections",
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "currentSusceptible": {
       "title": "Currentsusceptible",
       "description": "Number of people currently susceptible ",
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "currentExposed": {
       "title": "Currentexposed",
       "description": "Number of people currently exposed",
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "countryName": {
       "title": "Countryname",
@@ -87,7 +136,14 @@
     "countyName": {
       "title": "Countyname",
       "description": "The county name",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "intervention": {
       "title": "Intervention",
@@ -102,12 +158,26 @@
     "lat": {
       "title": "Lat",
       "description": "Latitude of point within the state or county",
-      "type": "number"
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "long": {
       "title": "Long",
       "description": "Longitude of point within the state or county",
-      "type": "number"
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "lastUpdatedDate": {
       "title": "Lastupdateddate",

--- a/api/schemas/Projections.json
+++ b/api/schemas/Projections.json
@@ -24,12 +24,26 @@
     "Rt": {
       "title": "Rt",
       "description": "Inferred Rt",
-      "type": "number"
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "RtCI90": {
       "title": "Rtci90",
       "description": "Rt 90th percentile confidence interval upper endpoint.",
-      "type": "number"
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "required": [
@@ -52,14 +66,28 @@
         "peakDate": {
           "title": "Peakdate",
           "description": "Date of peak resource utilization",
-          "type": "string",
-          "format": "date"
+          "format": "date",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "shortageStartDate": {
           "title": "Shortagestartdate",
           "description": "Date when resource shortage begins",
-          "type": "string",
-          "format": "date"
+          "format": "date",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [

--- a/api/schemas/RegionSummary.json
+++ b/api/schemas/RegionSummary.json
@@ -16,12 +16,26 @@
     "lat": {
       "title": "Lat",
       "description": "Latitude of point within the state or county",
-      "type": "number"
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "long": {
       "title": "Long",
       "description": "Longitude of point within the state or county",
-      "type": "number"
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "stateName": {
       "title": "Statename",
@@ -40,10 +54,24 @@
       "format": "date"
     },
     "projections": {
-      "$ref": "#/definitions/Projections"
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Projections"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "actuals": {
-      "$ref": "#/definitions/Actuals"
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Actuals"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "metrics": {
       "title": "Metrics",
@@ -85,14 +113,28 @@
         "peakDate": {
           "title": "Peakdate",
           "description": "Date of peak resource utilization",
-          "type": "string",
-          "format": "date"
+          "format": "date",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "shortageStartDate": {
           "title": "Shortagestartdate",
           "description": "Date when resource shortage begins",
-          "type": "string",
-          "format": "date"
+          "format": "date",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -127,12 +169,26 @@
         "Rt": {
           "title": "Rt",
           "description": "Inferred Rt",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "RtCI90": {
           "title": "Rtci90",
           "description": "Rt 90th percentile confidence interval upper endpoint.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -150,27 +206,62 @@
         "capacity": {
           "title": "Capacity",
           "description": "*deprecated*: Capacity for resource. In the case of ICUs, this refers to total capacity. For hospitalization this refers to free capacity for COVID patients. This value is calculated by (1 - typicalUsageRate) * totalCapacity * 2.07",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "totalCapacity": {
           "title": "Totalcapacity",
           "description": "Total capacity for resource.",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "currentUsageCovid": {
           "title": "Currentusagecovid",
           "description": "Currently used capacity for resource by COVID ",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "currentUsageTotal": {
           "title": "Currentusagetotal",
           "description": "Currently used capacity for resource by all patients (COVID + Non-COVID)",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "typicalUsageRate": {
           "title": "Typicalusagerate",
           "description": "Typical used capacity rate for resource. This excludes any COVID usage.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -190,7 +281,14 @@
           "title": "Population",
           "description": "Total population in geographic region [*deprecated*: refer to summary for this]",
           "exclusiveMinimum": 0,
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "intervention": {
           "title": "Intervention",
@@ -200,28 +298,70 @@
         "cumulativeConfirmedCases": {
           "title": "Cumulativeconfirmedcases",
           "description": "Number of confirmed cases so far",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "cumulativePositiveTests": {
           "title": "Cumulativepositivetests",
           "description": "Number of positive test results to date",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "cumulativeNegativeTests": {
           "title": "Cumulativenegativetests",
           "description": "Number of negative test results to date",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "cumulativeDeaths": {
           "title": "Cumulativedeaths",
           "description": "Number of deaths so far",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "hospitalBeds": {
-          "$ref": "#/definitions/ResourceUtilization"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ResourceUtilization"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "ICUBeds": {
-          "$ref": "#/definitions/ResourceUtilization"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ResourceUtilization"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "contactTracers": {
           "title": "Contacttracers",
@@ -240,6 +380,23 @@
         "ICUBeds"
       ]
     },
+    "CovidPatientsMethod": {
+      "title": "CovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients with covid.",
+      "enum": [
+        "actual",
+        "estimated"
+      ]
+    },
+    "NonCovidPatientsMethod": {
+      "title": "NonCovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients without covid.",
+      "enum": [
+        "actual",
+        "estimated_from_typical_utilization",
+        "estimated_from_total_icu_actual"
+      ]
+    },
     "ICUHeadroomMetricDetails": {
       "title": "ICUHeadroomMetricDetails",
       "description": "Details about how the ICU Headroom Metric was calculated.",
@@ -251,12 +408,7 @@
           "type": "integer"
         },
         "currentIcuCovidMethod": {
-          "title": "Currenticucovidmethod",
-          "description": "Method used to determine number of current ICU patients with covid.",
-          "enum": [
-            "actual",
-            "estimated"
-          ]
+          "$ref": "#/definitions/CovidPatientsMethod"
         },
         "currentIcuNonCovid": {
           "title": "Currenticunoncovid",
@@ -264,13 +416,7 @@
           "type": "integer"
         },
         "currentIcuNonCovidMethod": {
-          "title": "Currenticunoncovidmethod",
-          "description": "Method used to determine number of current ICU patients without covid.",
-          "enum": [
-            "actual",
-            "estimated_from_typical_utilization",
-            "estimated_from_total_icu_actual"
-          ]
+          "$ref": "#/definitions/NonCovidPatientsMethod"
         }
       },
       "required": [
@@ -288,31 +434,73 @@
         "testPositivityRatio": {
           "title": "Testpositivityratio",
           "description": "Ratio of people who test positive calculated using a 7-day rolling average.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "caseDensity": {
           "title": "Casedensity",
           "description": "The number of cases per 100k population calculated using a 7-day rolling average.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "contactTracerCapacityRatio": {
           "title": "Contacttracercapacityratio",
           "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "infectionRate": {
           "title": "Infectionrate",
           "description": "R_t, or the estimated number of infections arising from a typical case.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "infectionRateCI90": {
           "title": "Infectionrateci90",
           "description": "90th percentile confidence interval upper endpoint of the infection rate.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "icuHeadroomRatio": {
           "title": "Icuheadroomratio",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "icuHeadroomDetails": {
           "$ref": "#/definitions/ICUHeadroomMetricDetails"

--- a/api/schemas/RegionSummaryWithTimeseries.json
+++ b/api/schemas/RegionSummaryWithTimeseries.json
@@ -16,12 +16,26 @@
     "lat": {
       "title": "Lat",
       "description": "Latitude of point within the state or county",
-      "type": "number"
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "long": {
       "title": "Long",
       "description": "Longitude of point within the state or county",
-      "type": "number"
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "stateName": {
       "title": "Statename",
@@ -40,10 +54,24 @@
       "format": "date"
     },
     "projections": {
-      "$ref": "#/definitions/Projections"
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Projections"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "actuals": {
-      "$ref": "#/definitions/Actuals"
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Actuals"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "metrics": {
       "title": "Metrics",
@@ -62,10 +90,17 @@
     },
     "timeseries": {
       "title": "Timeseries",
-      "type": "array",
       "items": {
         "$ref": "#/definitions/PredictionTimeseriesRow"
-      }
+      },
+      "anyOf": [
+        {
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "actualsTimeseries": {
       "title": "Actualstimeseries",
@@ -76,10 +111,17 @@
     },
     "metricsTimeseries": {
       "title": "Metricstimeseries",
-      "type": "array",
       "items": {
         "$ref": "#/definitions/MetricsTimeseriesRow"
-      }
+      },
+      "anyOf": [
+        {
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "required": [
@@ -109,14 +151,28 @@
         "peakDate": {
           "title": "Peakdate",
           "description": "Date of peak resource utilization",
-          "type": "string",
-          "format": "date"
+          "format": "date",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "shortageStartDate": {
           "title": "Shortagestartdate",
           "description": "Date when resource shortage begins",
-          "type": "string",
-          "format": "date"
+          "format": "date",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -151,12 +207,26 @@
         "Rt": {
           "title": "Rt",
           "description": "Inferred Rt",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "RtCI90": {
           "title": "Rtci90",
           "description": "Rt 90th percentile confidence interval upper endpoint.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -174,27 +244,62 @@
         "capacity": {
           "title": "Capacity",
           "description": "*deprecated*: Capacity for resource. In the case of ICUs, this refers to total capacity. For hospitalization this refers to free capacity for COVID patients. This value is calculated by (1 - typicalUsageRate) * totalCapacity * 2.07",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "totalCapacity": {
           "title": "Totalcapacity",
           "description": "Total capacity for resource.",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "currentUsageCovid": {
           "title": "Currentusagecovid",
           "description": "Currently used capacity for resource by COVID ",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "currentUsageTotal": {
           "title": "Currentusagetotal",
           "description": "Currently used capacity for resource by all patients (COVID + Non-COVID)",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "typicalUsageRate": {
           "title": "Typicalusagerate",
           "description": "Typical used capacity rate for resource. This excludes any COVID usage.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -214,7 +319,14 @@
           "title": "Population",
           "description": "Total population in geographic region [*deprecated*: refer to summary for this]",
           "exclusiveMinimum": 0,
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "intervention": {
           "title": "Intervention",
@@ -224,28 +336,70 @@
         "cumulativeConfirmedCases": {
           "title": "Cumulativeconfirmedcases",
           "description": "Number of confirmed cases so far",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "cumulativePositiveTests": {
           "title": "Cumulativepositivetests",
           "description": "Number of positive test results to date",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "cumulativeNegativeTests": {
           "title": "Cumulativenegativetests",
           "description": "Number of negative test results to date",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "cumulativeDeaths": {
           "title": "Cumulativedeaths",
           "description": "Number of deaths so far",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "hospitalBeds": {
-          "$ref": "#/definitions/ResourceUtilization"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ResourceUtilization"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "ICUBeds": {
-          "$ref": "#/definitions/ResourceUtilization"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ResourceUtilization"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "contactTracers": {
           "title": "Contacttracers",
@@ -264,6 +418,23 @@
         "ICUBeds"
       ]
     },
+    "CovidPatientsMethod": {
+      "title": "CovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients with covid.",
+      "enum": [
+        "actual",
+        "estimated"
+      ]
+    },
+    "NonCovidPatientsMethod": {
+      "title": "NonCovidPatientsMethod",
+      "description": "Method used to determine number of current ICU patients without covid.",
+      "enum": [
+        "actual",
+        "estimated_from_typical_utilization",
+        "estimated_from_total_icu_actual"
+      ]
+    },
     "ICUHeadroomMetricDetails": {
       "title": "ICUHeadroomMetricDetails",
       "description": "Details about how the ICU Headroom Metric was calculated.",
@@ -275,12 +446,7 @@
           "type": "integer"
         },
         "currentIcuCovidMethod": {
-          "title": "Currenticucovidmethod",
-          "description": "Method used to determine number of current ICU patients with covid.",
-          "enum": [
-            "actual",
-            "estimated"
-          ]
+          "$ref": "#/definitions/CovidPatientsMethod"
         },
         "currentIcuNonCovid": {
           "title": "Currenticunoncovid",
@@ -288,13 +454,7 @@
           "type": "integer"
         },
         "currentIcuNonCovidMethod": {
-          "title": "Currenticunoncovidmethod",
-          "description": "Method used to determine number of current ICU patients without covid.",
-          "enum": [
-            "actual",
-            "estimated_from_typical_utilization",
-            "estimated_from_total_icu_actual"
-          ]
+          "$ref": "#/definitions/NonCovidPatientsMethod"
         }
       },
       "required": [
@@ -312,31 +472,73 @@
         "testPositivityRatio": {
           "title": "Testpositivityratio",
           "description": "Ratio of people who test positive calculated using a 7-day rolling average.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "caseDensity": {
           "title": "Casedensity",
           "description": "The number of cases per 100k population calculated using a 7-day rolling average.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "contactTracerCapacityRatio": {
           "title": "Contacttracercapacityratio",
           "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "infectionRate": {
           "title": "Infectionrate",
           "description": "R_t, or the estimated number of infections arising from a typical case.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "infectionRateCI90": {
           "title": "Infectionrateci90",
           "description": "90th percentile confidence interval upper endpoint of the infection rate.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "icuHeadroomRatio": {
           "title": "Icuheadroomratio",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "icuHeadroomDetails": {
           "$ref": "#/definitions/ICUHeadroomMetricDetails"
@@ -375,7 +577,14 @@
         "ICUBedsInUse": {
           "title": "Icubedsinuse",
           "description": "Number of ICU beds projected to be in-use or that were actually in use (if in the past)",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "ICUBedCapacity": {
           "title": "Icubedcapacity",
@@ -395,12 +604,26 @@
         "RtIndicator": {
           "title": "Rtindicator",
           "description": "Historical or Inferred Rt",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "RtIndicatorCI90": {
           "title": "Rtindicatorci90",
           "description": "Rt standard deviation",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "cumulativeDeaths": {
           "title": "Cumulativedeaths",
@@ -410,22 +633,50 @@
         "cumulativeInfected": {
           "title": "Cumulativeinfected",
           "description": "Number of cumulative infections",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "currentInfected": {
           "title": "Currentinfected",
           "description": "Number of current infections",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "currentSusceptible": {
           "title": "Currentsusceptible",
           "description": "Number of people currently susceptible ",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "currentExposed": {
           "title": "Currentexposed",
           "description": "Number of people currently exposed",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -454,7 +705,14 @@
           "title": "Population",
           "description": "Total population in geographic region [*deprecated*: refer to summary for this]",
           "exclusiveMinimum": 0,
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "intervention": {
           "title": "Intervention",
@@ -464,28 +722,70 @@
         "cumulativeConfirmedCases": {
           "title": "Cumulativeconfirmedcases",
           "description": "Number of confirmed cases so far",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "cumulativePositiveTests": {
           "title": "Cumulativepositivetests",
           "description": "Number of positive test results to date",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "cumulativeNegativeTests": {
           "title": "Cumulativenegativetests",
           "description": "Number of negative test results to date",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "cumulativeDeaths": {
           "title": "Cumulativedeaths",
           "description": "Number of deaths so far",
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "hospitalBeds": {
-          "$ref": "#/definitions/ResourceUtilization"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ResourceUtilization"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "ICUBeds": {
-          "$ref": "#/definitions/ResourceUtilization"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ResourceUtilization"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "contactTracers": {
           "title": "Contacttracers",
@@ -519,31 +819,73 @@
         "testPositivityRatio": {
           "title": "Testpositivityratio",
           "description": "Ratio of people who test positive calculated using a 7-day rolling average.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "caseDensity": {
           "title": "Casedensity",
           "description": "The number of cases per 100k population calculated using a 7-day rolling average.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "contactTracerCapacityRatio": {
           "title": "Contacttracercapacityratio",
           "description": "Ratio of currently hired tracers to estimated tracers needed based on 7-day daily case average.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "infectionRate": {
           "title": "Infectionrate",
           "description": "R_t, or the estimated number of infections arising from a typical case.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "infectionRateCI90": {
           "title": "Infectionrateci90",
           "description": "90th percentile confidence interval upper endpoint of the infection rate.",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "icuHeadroomRatio": {
           "title": "Icuheadroomratio",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "icuHeadroomDetails": {
           "$ref": "#/definitions/ICUHeadroomMetricDetails"

--- a/api/schemas/ResourceUsageProjection.json
+++ b/api/schemas/ResourceUsageProjection.json
@@ -11,14 +11,28 @@
     "peakDate": {
       "title": "Peakdate",
       "description": "Date of peak resource utilization",
-      "type": "string",
-      "format": "date"
+      "format": "date",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "shortageStartDate": {
       "title": "Shortagestartdate",
       "description": "Date when resource shortage begins",
-      "type": "string",
-      "format": "date"
+      "format": "date",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "required": [

--- a/api/schemas/ResourceUtilization.json
+++ b/api/schemas/ResourceUtilization.json
@@ -6,27 +6,62 @@
     "capacity": {
       "title": "Capacity",
       "description": "*deprecated*: Capacity for resource. In the case of ICUs, this refers to total capacity. For hospitalization this refers to free capacity for COVID patients. This value is calculated by (1 - typicalUsageRate) * totalCapacity * 2.07",
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "totalCapacity": {
       "title": "Totalcapacity",
       "description": "Total capacity for resource.",
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "currentUsageCovid": {
       "title": "Currentusagecovid",
       "description": "Currently used capacity for resource by COVID ",
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "currentUsageTotal": {
       "title": "Currentusagetotal",
       "description": "Currently used capacity for resource by all patients (COVID + Non-COVID)",
-      "type": "integer"
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "typicalUsageRate": {
       "title": "Typicalusagerate",
       "description": "Typical used capacity rate for resource. This excludes any COVID usage.",
-      "type": "number"
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "required": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ fastparquet==0.3.3
 us==1.0.0
 adtk==0.6.0
 -e .
-pydantic==1.5
+pydantic==1.6.1
 dill
 dictdiffer==0.8.1
 structlog==20.1.0


### PR DESCRIPTION
Updating pydantic to 1.6.1.  

The enum handling changed a bit in the latest version.  Also, it looks like the generated schemas in master for v2 were built with 1.6.1 so nothing changed for the new api.

This is definitely a hacky fix - not great code but we should be removing it soon when we yank out API v1.

Regenerated the schemas with `./run.py api update-schemas`