### PR TITLE
Revert "remove FIPS from infer_rt and NOLA patch (#731)"

### DIFF
--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -329,7 +329,7 @@ class RegionalData:
 
     @property  # TODO(tom): Change to cached_property when we're using Python 3.8
     def display_name(self) -> str:
-        county = self.latest.get(CommonFields.COUNTY)
+        county = self.latest[CommonFields.COUNTY]
         state = self.latest[CommonFields.STATE]
         if county:
             return f"{county}, {state}"

--- a/libs/datasets/dataset_base.py
+++ b/libs/datasets/dataset_base.py
@@ -38,9 +38,10 @@ class DatasetBase(SaveableDatasetInterface):
         raise NotImplementedError("Subsclass must implement")
 
     def yield_records(self) -> Iterable[dict]:
-        # TODO(tom): This function is only called from tests. Replace the calls and remove it.
+        # It'd be faster to use self.data.itertuples or find a way to avoid yield_records, but that
+        # needs larger changes in code calling this.
         for idx, row in self.data.iterrows():
-            yield row.loc[row.notna()].to_dict()
+            yield row.where(pd.notnull(row), None).to_dict()
 
     @classmethod
     def load_csv(cls, path_or_buf: Union[pathlib.Path, TextIO]):

--- a/libs/datasets/latest_values_dataset.py
+++ b/libs/datasets/latest_values_dataset.py
@@ -167,8 +167,6 @@ class LatestValuesDataset(dataset_base.DatasetBase):
     def get_record_for_fips(self, fips) -> dict:
         """Gets all data for a given fips code.
 
-        TODO(tom): This function is only called from tests. Replace the calls and remove it.
-
         Args:
             fips: 2 digits for a state or 5 digits for a county
 

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -533,12 +533,10 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
         try:
             latest_row = self.latest_data.loc[region.location_id, :]
         except KeyError:
-            latest_row = pd.Series([], dtype=object)
-        if ts_df.empty and latest_row.empty:
             raise RegionLatestNotFound(region)
         # Some code far away from here depends on latest_dict containing None, not np.nan, for
         # non-real values.
-        latest_dict = latest_row.loc[latest_row.notna()].to_dict()
+        latest_dict = latest_row.where(pd.notnull(latest_row), None).to_dict()
         return OneRegionTimeseriesDataset(data=ts_df, latest=latest_dict)
 
     def get_regions_subset(self, regions: Sequence[Region]) -> "MultiRegionTimeseriesDataset":
@@ -572,10 +570,9 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
     def _get_latest_and_provenance_for_locations(
         self, location_ids
     ) -> Tuple[pd.DataFrame, Optional[pd.Series]]:
-        latest_rows = self.latest_data.index.get_level_values(CommonFields.LOCATION_ID).isin(
-            location_ids
-        )
-        latest_df = self.latest_data.loc[latest_rows, :].reset_index().dropna("columns", "all")
+        latest_df = self.latest_data.loc[
+            self.latest_data.index.get_level_values(CommonFields.LOCATION_ID).isin(location_ids), :
+        ].reset_index()
         if self.provenance is not None:
             provenance = self.provenance[
                 self.provenance.index.get_level_values(CommonFields.LOCATION_ID).isin(location_ids)

--- a/pyseir/cli.py
+++ b/pyseir/cli.py
@@ -17,6 +17,7 @@ from covidactnow.datapublic import common_init
 from libs import pipeline
 from libs.datasets import AggregationLevel
 from libs.datasets import combined_datasets
+from libs.datasets.timeseries import TimeseriesDataset
 from libs.datasets.timeseries import MultiRegionTimeseriesDataset
 from libs.datasets.timeseries import OneRegionTimeseriesDataset
 from pyseir.deployment import webui_data_adaptor_v1
@@ -206,6 +207,10 @@ class SubStatePipeline:
             _combined_data=input.regional_combined_dataset,
         )
 
+    @property
+    def fips(self) -> str:
+        return self.region.fips
+
     def population(self) -> float:
         return self._combined_data.latest[CommonFields.POPULATION]
 
@@ -214,19 +219,18 @@ def _patch_substatepipeline_nola_infection_rate(
     pipelines: List[SubStatePipeline],
 ) -> List[SubStatePipeline]:
     """Returns a new list of pipeline objects with New Orleans infection rate patched."""
-    pipeline_map = {p.region: p for p in pipelines}
+    pipeline_map = {p.fips: p for p in pipelines}
 
-    input_regions = set(pipeline_map.keys())
-    new_orleans_regions = set(pipeline.Region.from_fips(f) for f in NEW_ORLEANS_FIPS)
-    regions_to_patch = input_regions & new_orleans_regions
-    if regions_to_patch:
+    input_fips = set(pipeline_map.keys())
+    fips_to_patch = input_fips & set(NEW_ORLEANS_FIPS)
+    if fips_to_patch:
         root.info("Applying New Orleans Patch")
-        if len(regions_to_patch) != len(new_orleans_regions):
+        if len(fips_to_patch) != len(NEW_ORLEANS_FIPS):
             root.warning(
-                f"Missing New Orleans counties break patch: {new_orleans_regions - input_regions}"
+                f"Missing New Orleans counties break patch: {set(NEW_ORLEANS_FIPS) - input_fips}"
             )
 
-        nola_input_pipelines = [pipeline_map[fips] for fips in regions_to_patch]
+        nola_input_pipelines = [pipeline_map[fips] for fips in fips_to_patch]
         infection_rate_map = {p.region: p.infer_df for p in nola_input_pipelines}
         population_map = {p.region: p.population() for p in nola_input_pipelines}
 
@@ -235,12 +239,12 @@ def _patch_substatepipeline_nola_infection_rate(
             infection_rate_map, population_map
         )
 
-        for region in regions_to_patch:
+        for fips in fips_to_patch:
             this_fips_infection_rate = nola_infection_rate.copy()
-            this_fips_infection_rate.insert(0, CommonFields.LOCATION_ID, region.location_id)
+            this_fips_infection_rate.insert(0, CommonFields.FIPS, fips)
             # Make a new SubStatePipeline object with the new infer_df
-            pipeline_map[region] = dataclasses.replace(
-                pipeline_map[region], infer_df=this_fips_infection_rate,
+            pipeline_map[fips] = dataclasses.replace(
+                pipeline_map[fips], infer_df=this_fips_infection_rate,
             )
 
     return list(pipeline_map.values())
@@ -254,13 +258,21 @@ def _write_pipeline_output(
 ):
 
     infection_rate_metric_df = pd.concat((p.infer_df for p in pipelines), ignore_index=True)
-    multiregion_rt = MultiRegionTimeseriesDataset.from_timeseries_df(infection_rate_metric_df)
+    # TODO: Use constructors in MultiRegionTimeseriesDataset
+    timeseries_dataset = TimeseriesDataset(infection_rate_metric_df)
+    latest = timeseries_dataset.latest_values_object()
+    multiregion_rt = MultiRegionTimeseriesDataset.from_timeseries_and_latest(
+        timeseries_dataset, latest
+    )
     output_path = pathlib.Path(output_dir) / pyseir.utils.SummaryArtifact.RT_METRIC_COMBINED.value
     multiregion_rt.to_csv(output_path)
     root.info(f"Saving Rt results to {output_path}")
 
     icu_df = pd.concat((p.icu_data.data for p in pipelines if p.icu_data), ignore_index=True)
-    multiregion_icu = MultiRegionTimeseriesDataset.from_timeseries_df(icu_df)
+    timeseries_dataset = TimeseriesDataset(icu_df)
+    latest = timeseries_dataset.latest_values_object().data.set_index(CommonFields.LOCATION_ID)
+    multiregion_icu = MultiRegionTimeseriesDataset(icu_df, latest)
+
     output_path = pathlib.Path(output_dir) / pyseir.utils.SummaryArtifact.ICU_METRIC_COMBINED.value
     multiregion_icu.to_csv(output_path)
     root.info(f"Saving ICU results to {output_path}")

--- a/pyseir/deployment/webui_data_adaptor_v1.py
+++ b/pyseir/deployment/webui_data_adaptor_v1.py
@@ -141,10 +141,8 @@ class WebUIDataAdaptorV1:
         idx_offset = int(fit_results["t_today"] - fit_results["t0"])
 
         observed_death_latest = observed_latest_dict[CommonFields.DEATHS]
-        observed_total_hosps_latest = observed_latest_dict.get(
-            CommonFields.CURRENT_HOSPITALIZED, np.nan
-        )
-        observed_icu_latest = observed_latest_dict.get(CommonFields.CURRENT_ICU, np.nan)
+        observed_total_hosps_latest = observed_latest_dict[CommonFields.CURRENT_HOSPITALIZED]
+        observed_icu_latest = observed_latest_dict[CommonFields.CURRENT_ICU]
 
         # For Deaths
         model_death_latest = pyseir_outputs[baseline_policy]["total_deaths"]["ci_50"][idx_offset]

--- a/pyseir/rt/infer_rt.py
+++ b/pyseir/rt/infer_rt.py
@@ -6,7 +6,6 @@ from typing import Optional
 
 import numpy as np
 import pandas as pd
-from covidactnow.datapublic.common_fields import CommonFields
 from scipy import stats as sps
 from matplotlib import pyplot as plt
 
@@ -660,7 +659,7 @@ class RtInferenceEngine:
                         )
 
         if df_all is None:
-            self.log.warning(f"Inference not possible for {self.regional_input.region}")
+            self.log.warning(f"Inference not possible for {self.regional_input.region.fips}")
             return pd.DataFrame()
 
         if self.include_deaths and "Rt_MAP__new_deaths" in df_all and "Rt_MAP__new_cases" in df_all:
@@ -735,5 +734,5 @@ class RtInferenceEngine:
             self.log.warning("Inference not possible")
         else:
             df_all = df_all.reset_index(drop=False)  # Move date to column from index to column
-            df_all[CommonFields.LOCATION_ID] = self.regional_input.region.location_id
+            df_all["fips"] = self.regional_input.region.fips
         return df_all

--- a/test/infer_rt_test.py
+++ b/test/infer_rt_test.py
@@ -214,41 +214,41 @@ def test_smoothing_and_causality(tmp_path):
 
 @pytest.mark.slow
 def test_generate_infection_rate_metric_one_empty():
-    fips = [
+    FIPS = [
         "51017",  # Bath County VA Almost No Cases. Will be filtered out under any thresholds.
         "51153",  # Prince William VA Lots of Cases
     ]
-    regions = [pipeline.Region.from_fips(f) for f in fips]
-    inputs = [infer_rt.RegionalInput.from_region(region) for region in regions]
+    regions = [infer_rt.RegionalInput.from_fips(region) for region in FIPS]
 
-    df = pd.concat(infer_rt.run_rt(input) for input in inputs)
-    returned_location_ids = df[CommonFields.LOCATION_ID].unique()
-    assert pipeline.fips_to_location_id("51153") in returned_location_ids
-    assert pipeline.fips_to_location_id("51017") not in returned_location_ids
+    df = pd.concat(infer_rt.run_rt(input) for input in regions)
+    returned_fips = df.fips.unique()
+    assert "51153" in returned_fips
+    assert "51017" not in returned_fips
 
 
 @pytest.mark.slow
 def test_generate_infection_rate_metric_two_aggregate_levels():
-    fips = ["06", "06075"]  # CA  # San Francisco, CA
-    regions = [pipeline.Region.from_fips(f) for f in fips]
-    inputs = [infer_rt.RegionalInput.from_region(region) for region in regions]
+    FIPS = ["06", "06075"]  # CA  # San Francisco, CA
+    regions = [infer_rt.RegionalInput.from_fips(region) for region in FIPS]
 
-    df = pd.concat(infer_rt.run_rt(input) for input in inputs)
-    returned_location_ids = df[CommonFields.LOCATION_ID].unique()
-    assert set(r.location_id for r in regions) == set(returned_location_ids)
+    df = pd.concat(infer_rt.run_rt(input) for input in regions)
+    returned_fips = df.fips.unique()
+    assert "06" in returned_fips
+    assert "06075" in returned_fips
 
 
 @pytest.mark.slow
 def test_generate_infection_rate_new_orleans_patch():
-    fips = ["22", "22051", "22071"]  # LA, Jefferson and Orleans
-    regions = [pipeline.Region.from_fips(f) for f in fips]
-    inputs = [infer_rt.RegionalInput.from_region(region) for region in regions]
+    FIPS = ["22", "22051", "22071"]  # LA, Jefferson and Orleans
+    regions = [infer_rt.RegionalInput.from_fips(region) for region in FIPS]
 
-    df = pd.concat(infer_rt.run_rt(input) for input in inputs)
+    df = pd.concat(infer_rt.run_rt(input) for input in regions)
+    returned_fips = df.fips.unique()
+    assert "22" in returned_fips
+    assert "22051" in returned_fips
+    assert "22071" in returned_fips
     assert not df[CommonFields.DATE].isna().any()
-    assert not df[CommonFields.LOCATION_ID].isna().any()
-    returned_location_ids = df[CommonFields.LOCATION_ID].unique()
-    assert set(r.location_id for r in regions) == set(returned_location_ids)
+    assert not df[CommonFields.FIPS].isna().any()
 
 
 def test_generate_infection_rate_metric_fake_fips():
@@ -263,14 +263,14 @@ def test_generate_infection_rate_metric_fake_fips():
         infer_rt.RegionalInput.from_fips("48998")
 
 
-@pytest.mark.slow
+@pytest.mark.xfail(raises=ValueError)
 def test_generate_infection_rate_with_nans():
-    # Check that MA counties are still working
-    region = pipeline.Region.from_fips("25001")
-    input = infer_rt.RegionalInput.from_region(region)
-    df = infer_rt.run_rt(input)
-    returned_location_ids = df[CommonFields.LOCATION_ID].unique()
-    assert {region.location_id} == set(returned_location_ids)
+    # Ma Counties is currently failing with a ValueError due to recent period of non-reporting
+    FIPS = ["25001"]  # MA lots of NaN
+    regions = [infer_rt.RegionalInput.from_fips(region) for region in FIPS]
+    df = pd.concat(infer_rt.run_rt(input) for input in regions)
+    returned_fips = df.fips.unique()
+    assert "25001" in returned_fips
 
 
 @pytest.mark.slow
@@ -295,6 +295,6 @@ def test_patch_substatepipeline_nola_infection_rate():
     patched = cli._patch_substatepipeline_nola_infection_rate(pipelines)
 
     df = pd.concat(p.infer_df for p in patched)
-    returned_location_ids = df[CommonFields.LOCATION_ID].unique()
-    assert pipeline.fips_to_location_id("22051") in returned_location_ids
-    assert pipeline.fips_to_location_id("51017") not in returned_location_ids
+    returned_fips = df.fips.unique()
+    assert "22051" in returned_fips
+    assert "51017" not in returned_fips

--- a/test/libs/datasets/combined_dataset_utils_test.py
+++ b/test/libs/datasets/combined_dataset_utils_test.py
@@ -5,6 +5,7 @@ from covidactnow.datapublic.common_fields import CommonFields
 from libs.datasets import combined_dataset_utils
 from libs.datasets import combined_datasets
 from libs.datasets.latest_values_dataset import LatestValuesDataset
+from libs.datasets.timeseries import MultiRegionTimeseriesDataset
 from libs.datasets.timeseries import TimeseriesDataset
 from libs.pipeline import Region
 from libs.qa.common_df_diff import DatasetDiff
@@ -27,9 +28,12 @@ def test_persist_and_load_dataset(tmp_path, nyc_fips):
 
 
 def test_update_and_load(tmp_path: pathlib.Path, nyc_fips, nyc_region):
+    us_combined_df = combined_datasets.load_us_timeseries_dataset().combined_df
+
     # restricting the datasets being persisted to one county to speed up tests a bit.
-    multiregion_timeseries_nyc = combined_datasets.load_us_timeseries_dataset().get_regions_subset(
-        [nyc_region]
+    nyc_combined_df = us_combined_df.loc[us_combined_df[CommonFields.FIPS] == nyc_fips, :]
+    multiregion_timeseries_nyc = MultiRegionTimeseriesDataset.from_combined_dataframe(
+        nyc_combined_df
     )
     latest_nyc = LatestValuesDataset(multiregion_timeseries_nyc.latest_data_with_fips.reset_index())
     latest_nyc_record = latest_nyc.get_record_for_fips(nyc_fips)
@@ -43,4 +47,4 @@ def test_update_and_load(tmp_path: pathlib.Path, nyc_fips, nyc_region):
     timeseries_loaded = combined_datasets.load_us_timeseries_dataset(pointer_directory=tmp_path)
     latest_loaded = combined_datasets.load_us_latest_dataset(pointer_directory=tmp_path)
     assert latest_loaded.get_record_for_fips(nyc_fips) == latest_nyc_record
-    assert_combined_like(timeseries_loaded, multiregion_timeseries_nyc, drop_na_timeseries=True)
+    assert_combined_like(timeseries_loaded, multiregion_timeseries_nyc)

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -224,26 +224,19 @@ def test_multiregion_provenance():
     assert counties.provenance.loc["iso1:us#fips:97222"].at["m1"] == "src21"
 
 
-def _combined_sorted_by_location_date(
-    ts: timeseries.MultiRegionTimeseriesDataset, drop_na_timeseries: bool
-) -> pd.DataFrame:
+def _combined_sorted_by_location_date(ts: timeseries.MultiRegionTimeseriesDataset) -> pd.DataFrame:
     """Returns the combined data, sorted by LOCATION_ID and DATE."""
-    df = ts.combined_df.sort_values(
+    return ts.combined_df.sort_values(
         [CommonFields.LOCATION_ID, CommonFields.DATE], ignore_index=True
     )
-    if drop_na_timeseries:
-        df = df.dropna("columns", "all")
-    return df
 
 
 def assert_combined_like(
-    ts1: timeseries.MultiRegionTimeseriesDataset,
-    ts2: timeseries.MultiRegionTimeseriesDataset,
-    drop_na_timeseries=False,
+    ts1: timeseries.MultiRegionTimeseriesDataset, ts2: timeseries.MultiRegionTimeseriesDataset
 ):
     """Asserts that two datasets contain similar date, ignoring order."""
-    sorted1 = _combined_sorted_by_location_date(ts1, drop_na_timeseries=drop_na_timeseries)
-    sorted2 = _combined_sorted_by_location_date(ts2, drop_na_timeseries=drop_na_timeseries)
+    sorted1 = _combined_sorted_by_location_date(ts1)
+    sorted2 = _combined_sorted_by_location_date(ts2)
     pd.testing.assert_frame_equal(sorted1, sorted2, check_like=True)
 
 

--- a/test/libs/generate_api_test.py
+++ b/test/libs/generate_api_test.py
@@ -20,8 +20,8 @@ from libs.pipelines import api_pipeline
     "include_projections,rt_null", [(True, True), (True, False), (False, False)]
 )
 def test_build_summary_for_fips(
-    include_projections: bool,
-    rt_null: bool,
+    include_projections,
+    rt_null,
     nyc_model_output_path,
     nyc_region,
     nyc_rt_dataset,
@@ -88,7 +88,7 @@ def test_build_summary_for_fips(
                 "currentUsageTotal": None,
                 "typicalUsageRate": nyc_latest["icu_occupancy_rate"],
             },
-            contactTracers=nyc_latest.get("contact_tracers_count"),  # Only available for states
+            contactTracers=nyc_latest["contact_tracers_count"],
         ),
         lastUpdatedDate=datetime.datetime.utcnow(),
         projections=expected_projections,
@@ -109,6 +109,7 @@ def test_generate_timeseries_for_fips(
 
     nyc_latest = us_latest.get_record_for_fips(nyc_region.fips)
     nyc_timeseries = us_timeseries.get_one_region(nyc_region)
+    intervention = Intervention.OBSERVED_INTERVENTION
     model_output = CANPyseirLocationOutput.load_from_path(nyc_model_output_path)
     metrics_series, latest_metric = api_pipeline.generate_metrics_and_latest(
         nyc_timeseries, nyc_rt_dataset, nyc_icu_dataset

--- a/test/libs/generate_api_v2_test.py
+++ b/test/libs/generate_api_v2_test.py
@@ -13,7 +13,7 @@ from libs.pipelines import api_v2_pipeline
     "include_model_output,rt_null", [(True, True), (True, False), (False, False)]
 )
 def test_build_summary_for_fips(
-    include_model_output: bool, rt_null: bool, nyc_region, nyc_icu_dataset, nyc_rt_dataset
+    include_model_output, rt_null, nyc_region, nyc_icu_dataset, nyc_rt_dataset
 ):
     us_latest = combined_datasets.load_us_latest_dataset()
     us_timeseries = combined_datasets.load_us_timeseries_dataset()
@@ -63,7 +63,7 @@ def test_build_summary_for_fips(
                 "currentUsageTotal": None,
                 "typicalUsageRate": nyc_latest["icu_occupancy_rate"],
             },
-            contactTracers=nyc_latest.get("contact_tracers_count"),  # only available for states
+            contactTracers=nyc_latest["contact_tracers_count"],
         ),
         lastUpdatedDate=datetime.datetime.utcnow(),
     )


### PR DESCRIPTION
This reverts commit 7bb086bc2817b78ef1b938e4453713b8e0bd9db9.

This is temporary, seems to be causing https://sentry.io/organizations/covidactnow/issues/1957780407/?project=5203044&query=is%3Aunresolved

