### PR TITLE
Add MultiRegion iterator

### DIFF
--- a/cli/api.py
+++ b/cli/api.py
@@ -212,18 +212,23 @@ def generate_api_v2(model_output_dir, output, aggregation_level, state, fips):
 
     icu_data_path = model_output_dir / SummaryArtifact.ICU_METRIC_COMBINED.value
     icu_data = MultiRegionTimeseriesDataset.from_csv(icu_data_path)
+    icu_data_map = dict(icu_data.iter_one_regions())
 
     rt_data_path = model_output_dir / SummaryArtifact.RT_METRIC_COMBINED.value
     rt_data = MultiRegionTimeseriesDataset.from_csv(rt_data_path)
+    rt_data_map = dict(rt_data.iter_one_regions())
 
-    build_input = functools.partial(
-        api_v2_pipeline.RegionalInput.from_region_and_model_output,
-        icu_data=icu_data,
-        rt_data=rt_data,
-    )
+    regions_data = combined_datasets.load_us_timeseries_dataset().get_regions_subset(regions)
 
-    with multiprocessing.Pool(maxtasksperchild=1) as pool:
-        regional_inputs = pool.map(build_input, regions)
+    regional_inputs = [
+        api_v2_pipeline.RegionalInput.from_one_regions(
+            region,
+            regional_data,
+            icu_data=icu_data_map.get(region),
+            rt_data=rt_data_map.get(region),
+        )
+        for region, regional_data in regions_data.iter_one_regions()
+    ]
 
     _logger.info(f"Finished loading all regional inputs.")
 

--- a/cli/data.py
+++ b/cli/data.py
@@ -91,7 +91,9 @@ def update(summary_filename, wide_dates_filename, aggregate_to_msas: bool):
     multiregion_dataset = add_new_cases(multiregion_dataset)
     if aggregate_to_msas:
         aggregator = statistical_areas.CountyToCBSAAggregator.from_local_public_data()
-        multiregion_dataset = multiregion_dataset.merge(aggregator.aggregate(multiregion_dataset))
+        multiregion_dataset = multiregion_dataset.append_regions(
+            aggregator.aggregate(multiregion_dataset)
+        )
 
     _, multiregion_pointer = combined_dataset_utils.update_data_public_head(
         path_prefix, latest_dataset, multiregion_dataset,

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -29,6 +29,7 @@ from libs.datasets.dataset_base import SaveableDatasetInterface
 from libs.datasets.dataset_utils import AggregationLevel
 import libs.qa.dataset_summary_gen
 from libs.datasets.dataset_utils import DatasetType
+from libs.datasets.dataset_utils import GEO_DATA_COLUMNS
 from libs.datasets.latest_values_dataset import LatestValuesDataset
 from libs.pipeline import Region
 import pandas.core.groupby.generic
@@ -519,7 +520,9 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
         assert self.data.index.is_monotonic_increasing
         assert self.latest_data.index.names == [CommonFields.LOCATION_ID]
 
-    def merge(self, other: "MultiRegionTimeseriesDataset") -> "MultiRegionTimeseriesDataset":
+    def append_regions(
+        self, other: "MultiRegionTimeseriesDataset"
+    ) -> "MultiRegionTimeseriesDataset":
         return MultiRegionTimeseriesDataset.from_timeseries_df(
             pd.concat([self.data, other.data], ignore_index=True)
         ).append_latest_df(
@@ -530,14 +533,17 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
 
     def get_one_region(self, region: Region) -> OneRegionTimeseriesDataset:
         ts_df = self.data.loc[self.data[CommonFields.LOCATION_ID] == region.location_id, :]
-        try:
-            latest_row = self.latest_data.loc[region.location_id, :]
-        except KeyError:
+        latest_dict = self._location_id_latest_dict(region.location_id)
+        if ts_df.empty and not latest_dict:
             raise RegionLatestNotFound(region)
-        # Some code far away from here depends on latest_dict containing None, not np.nan, for
-        # non-real values.
-        latest_dict = latest_row.where(pd.notnull(latest_row), None).to_dict()
         return OneRegionTimeseriesDataset(data=ts_df, latest=latest_dict)
+
+    def _location_id_latest_dict(self, location_id: str) -> dict:
+        try:
+            latest_row = self.latest_data.loc[location_id, :]
+        except KeyError:
+            latest_row = pd.Series([], dtype=object)
+        return latest_row.where(pd.notnull(latest_row), None).to_dict()
 
     def get_regions_subset(self, regions: Sequence[Region]) -> "MultiRegionTimeseriesDataset":
         location_ids = pd.Index(sorted(r.location_id for r in regions))
@@ -609,6 +615,50 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
         if self.provenance is not None:
             provenance_path = str(path).replace(".csv", "-provenance.csv")
             self.provenance.sort_index().to_csv(provenance_path)
+
+    def join_columns(self, other: "MultiRegionTimeseriesDataset") -> "MultiRegionTimeseriesDataset":
+        """Joins the timeseries columns in `other` with those in `self`."""
+        if not other.latest_data.empty:
+            raise NotImplementedError("No support for joining other with latest_data")
+        other_df = other.data_with_fips.set_index([CommonFields.LOCATION_ID, CommonFields.DATE])
+        self_df = self.data_with_fips.set_index([CommonFields.LOCATION_ID, CommonFields.DATE])
+        other_geo_columns = set(other_df.columns) & set(GEO_DATA_COLUMNS)
+        other_ts_columns = (
+            set(other_df.columns) - set(GEO_DATA_COLUMNS) - set(TimeseriesDataset.INDEX_FIELDS)
+        )
+        common_ts_columns = other_ts_columns & set(self.data_with_fips.columns)
+        if common_ts_columns:
+            # columns to be joined need to be disjoint
+            raise ValueError(f"Columns are in both dataset: {common_ts_columns}")
+        common_geo_columns = list(set(self.data_with_fips.columns) & other_geo_columns)
+        # TODO(tom): fix geo columns check, no later than when self.data is changed to contain only
+        # timeseries
+        # self_common_geo_columns = self_df.loc[:, common_geo_columns].fillna("")
+        # other_common_geo_columns = other_df.loc[:, common_geo_columns].fillna("")
+        # try:
+        #    if (self_common_geo_columns != other_common_geo_columns).any(axis=None):
+        #        unequal_rows = (self_common_geo_columns != other_common_geo_columns).any(axis=1)
+        #        _log.info(
+        #            "Geo data unexpectedly varies",
+        #            self_rows=self_df.loc[unequal_rows, common_geo_columns],
+        #            other_rows=other_df.loc[unequal_rows, common_geo_columns],
+        #        )
+        #        raise ValueError("Geo data unexpectedly varies")
+        # except Exception:
+        #    _log.exception(f"Comparing df {self_common_geo_columns} to {other_common_geo_columns}")
+        #    raise
+        combined_df = pd.concat([self_df, other_df[list(other_ts_columns)]], axis=1)
+        return MultiRegionTimeseriesDataset.from_timeseries_df(
+            combined_df.reset_index()
+        ).append_latest_df(self.latest_data_with_fips.reset_index())
+
+    def iter_one_regions(self) -> Iterable[Tuple[Region, OneRegionTimeseriesDataset]]:
+        """Iterates through all the regions in this object"""
+        for location_id, data_group in self.data_with_fips.groupby(CommonFields.LOCATION_ID):
+            latest_dict = self._location_id_latest_dict(location_id)
+            yield Region(location_id=location_id, fips=None), OneRegionTimeseriesDataset(
+                data_group, latest_dict
+            )
 
 
 def _remove_padded_nans(df, columns):

--- a/libs/icu_headroom_metric.py
+++ b/libs/icu_headroom_metric.py
@@ -105,7 +105,7 @@ class ICUMetricData:
         if has_any_data and not self._require_recent_data:
             return timeseries.loc[timeseries.last_valid_index()]
 
-        return self._latest_values[CommonFields.ICU_BEDS]
+        return self._latest_values.get(CommonFields.ICU_BEDS)
 
     @property
     def total_icu_beds(self) -> Union[pd.Series, float]:
@@ -119,7 +119,7 @@ class ICUMetricData:
 
     @property
     def typical_usage_rate(self) -> float:
-        typical_occupancy = self._latest_values[CommonFields.ICU_TYPICAL_OCCUPANCY_RATE]
+        typical_occupancy = self._latest_values.get(CommonFields.ICU_TYPICAL_OCCUPANCY_RATE)
         if typical_occupancy is None or np.isnan(typical_occupancy):
             return DEFAULT_ICU_UTILIZATION
 

--- a/test/libs/api_v2_pipeline_test.py
+++ b/test/libs/api_v2_pipeline_test.py
@@ -1,7 +1,6 @@
 import pytest
 from covidactnow.datapublic.common_fields import CommonFields
 
-from libs import test_positivity
 from libs.datasets import timeseries
 from libs.pipeline import Region
 from libs.pipelines import api_v2_pipeline


### PR DESCRIPTION
This is the subset of https://github.com/covid-projections/covid-data-model/pull/728 that is not expected to change the output.


* Rename `MultiRegionTimeseriesDataset.merge` to `append_regions`
* Add `MultiRegionTimeseriesDataset.join_columns` and `iter_one_regions`
* Change `api_v2_pipeline.RegionalInput` to get combined data as OneRegionTimeseriesDataset parameters instead of loading it from disk to a RegionalData
* Change how generate-api-v2 creates `api_v2_pipeline.RegionalInput` to use  `iter_one_regions` which makes a single groupby call for each MultiRegion instead of a query for each region. With this making the inputs for all regions takes ~10 seconds.
