### PR TITLE
Update new case logic to not throw away first case

### DIFF
--- a/cli/data.py
+++ b/cli/data.py
@@ -17,7 +17,7 @@ from libs.datasets.combined_datasets import (
 )
 from libs.datasets.latest_values_dataset import LatestValuesDataset
 from libs.datasets.timeseries import MultiRegionTimeseriesDataset
-from libs.datasets.timeseries import add_new_cases
+from libs.datasets import timeseries
 from libs.qa import dataset_summary
 from libs.qa import data_availability
 from libs.datasets.timeseries import TimeseriesDataset
@@ -88,7 +88,7 @@ def update(summary_filename, wide_dates_filename, aggregate_to_msas: bool):
     multiregion_dataset = MultiRegionTimeseriesDataset.from_timeseries_and_latest(
         timeseries_dataset, latest_dataset
     )
-    multiregion_dataset = add_new_cases(multiregion_dataset)
+    multiregion_dataset = timeseries.add_new_cases(multiregion_dataset)
     if aggregate_to_msas:
         aggregator = statistical_areas.CountyToCBSAAggregator.from_local_public_data()
         multiregion_dataset = multiregion_dataset.append_regions(

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -288,13 +288,13 @@ def test_calculate_new_cases():
     mrts_before = timeseries.MultiRegionTimeseriesDataset.from_csv(
         io.StringIO(
             "location_id,date,cases\n"
-            "iso1:us#fips:1,2000-01-01,0\n"
-            "iso1:us#fips:1,2000-01-02,1\n"
-            "iso1:us#fips:1,2000-01-03,1\n"
-            "iso1:us#fips:2,2000-01-01,5\n"
-            "iso1:us#fips:2,2000-01-02,7\n"
-            "iso1:us#fips:3,2000-01-01,9\n"
-            "iso1:us#fips:4,2000-01-01,\n"
+            "iso1:us#fips:1,2020-01-01,0\n"
+            "iso1:us#fips:1,2020-01-02,1\n"
+            "iso1:us#fips:1,2020-01-03,1\n"
+            "iso1:us#fips:2,2020-01-01,5\n"
+            "iso1:us#fips:2,2020-01-02,7\n"
+            "iso1:us#fips:3,2020-01-01,9\n"
+            "iso1:us#fips:4,2020-01-01,\n"
             "iso1:us#fips:1,,100"
         )
     )
@@ -302,18 +302,18 @@ def test_calculate_new_cases():
     mrts_expected = timeseries.MultiRegionTimeseriesDataset.from_csv(
         io.StringIO(
             "location_id,date,cases,new_cases\n"
-            "iso1:us#fips:1,2000-01-01,0,\n"
-            "iso1:us#fips:1,2000-01-02,1,1\n"
-            "iso1:us#fips:1,2000-01-03,1,0\n"
-            "iso1:us#fips:2,2000-01-01,5,\n"
-            "iso1:us#fips:2,2000-01-02,7,2\n"
-            "iso1:us#fips:3,2000-01-01,9,\n"
-            "iso1:us#fips:4,2000-01-01,,\n"
+            "iso1:us#fips:1,2020-01-01,0,0\n"
+            "iso1:us#fips:1,2020-01-02,1,1\n"
+            "iso1:us#fips:1,2020-01-03,1,0\n"
+            "iso1:us#fips:2,2020-01-01,5,5\n"
+            "iso1:us#fips:2,2020-01-02,7,2\n"
+            "iso1:us#fips:3,2020-01-01,9,9\n"
+            "iso1:us#fips:4,2020-01-01,,\n"
             "iso1:us#fips:1,,100,\n"
         )
     )
 
-    mrts_after = timeseries.add_new_cases(mrts=mrts_before)
+    mrts_after = timeseries.add_new_cases(mrts_before)
     pd.testing.assert_frame_equal(mrts_after.data, mrts_expected.data, check_like=True)
 
 


### PR DESCRIPTION
This updates the new cases logic to not throw away the first case.  Small logic change before we can use it in a couple of other places.