### PR TITLE
Adding ability to trigger api build from github action

### DIFF
--- a/.github/workflows/update_repo_datasets.yml
+++ b/.github/workflows/update_repo_datasets.yml
@@ -26,6 +26,8 @@ env:
 
   GOOGLE_SHEETS_SERVICE_ACCOUNT_DATA: ${{ secrets.GOOGLE_SHEETS_SERVICE_ACCOUNT_DATA }}
 
+  TRIGGER_API_BUILD: ${{ github.event.client_payload.trigger_api_build }}
+
 jobs:
   update-and-promote-datasets:
     runs-on: ubuntu-latest
@@ -78,6 +80,22 @@ jobs:
     - name: Create Update Commit
       working-directory: ./covid-data-model
       run: ./tools/push-data-update.sh
+
+    - name: Maybe Trigger API build
+      if: ${{ env.TRIGGER_API_BUILD }}
+      working-directory: ./covid-data-model
+      env:
+        GITHUB_TOKEN: ${{ secrets.CAN_ROBOT_PERSONAL_ACCESS_TOKEN }}
+      run: |
+        ./tools/build-snapshot.sh master
+    - name: Slack notification
+      if: ${{ env.TRIGGER_API_BUILD }}
+      env:
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_DEV_ALERTS }}
+      uses: Ilshidur/action-slack@fb92a78
+      with:
+        args: 'Started new API build from dataset updater action.'
+
     - name: Update Data Availability Sheet
       working-directory: ./covid-data-model
       run: |


### PR DESCRIPTION
Adds an option in the dataset updater to optionally trigger api build on dataset update.