### PR TITLE
provenance read and write

### DIFF
--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -520,7 +520,7 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
         )
         if isinstance(path_or_buf, pathlib.Path):
             provenance_path = pathlib.Path(str(path_or_buf).replace(".csv", "-provenance.csv"))
-            if provenance_path.is_file():
+            if provenance_path.exists():
                 dataset = dataset.append_provenance_csv(provenance_path)
         return dataset
 

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -80,6 +80,8 @@ def test_multi_region_to_from_timeseries_and_latest_values(tmp_path: pathlib.Pat
     )
     multiregion = timeseries.MultiRegionTimeseriesDataset.from_timeseries_and_latest(
         ts, latest_values
+    ).append_provenance_csv(
+        io.StringIO("location_id,variable,provenance\n" "iso1:us#fips:97111,m1,ts197111prov\n")
     )
     region_97111 = multiregion.get_one_region(Region.from_fips("97111"))
     assert region_97111.date_indexed.at["2020-04-02", "m1"] == 2
@@ -93,6 +95,7 @@ def test_multi_region_to_from_timeseries_and_latest_values(tmp_path: pathlib.Pat
     assert region_97111.date_indexed.at["2020-04-02", "m1"] == 2
     assert region_97111.latest["c1"] == 3
     assert multiregion_loaded.get_one_region(Region.from_fips("01")).latest["c2"] == 123.4
+    assert_combined_like(multiregion, multiregion_loaded)
 
 
 def test_multi_region_get_one_region():

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -216,12 +216,16 @@ def test_multiregion_provenance():
     )
     # Use loc[...].at[...] as work-around for https://github.com/pandas-dev/pandas/issues/26989
     assert out.provenance.loc["iso1:us#fips:97111"].at["m1"] == "src11"
+    assert out.get_one_region(Region.from_fips("97111")).provenance["m1"] == "src11"
     assert out.provenance.loc["iso1:us#fips:97222"].at["m2"] == "src22"
+    assert out.get_one_region(Region.from_fips("97222")).provenance["m2"] == "src22"
     assert out.provenance.loc["iso1:us#fips:03"].at["m2"] == "src32"
+    assert out.get_one_region(Region.from_fips("03")).provenance["m2"] == "src32"
 
     counties = out.get_counties(after=pd.to_datetime("2020-04-01"))
     assert "iso1:us#fips:03" not in counties.provenance.index
     assert counties.provenance.loc["iso1:us#fips:97222"].at["m1"] == "src21"
+    assert counties.get_one_region(Region.from_fips("97222")).provenance["m1"] == "src21"
 
 
 def _combined_sorted_by_location_date(ts: timeseries.MultiRegionTimeseriesDataset) -> pd.DataFrame:
@@ -238,6 +242,15 @@ def assert_combined_like(
     sorted1 = _combined_sorted_by_location_date(ts1)
     sorted2 = _combined_sorted_by_location_date(ts2)
     pd.testing.assert_frame_equal(sorted1, sorted2, check_like=True)
+    if ts1.provenance is not None:
+        assert (
+            ts2.provenance is not None
+        ), f"ts1.provenance is {ts1.provenance}, ts2.provenance is {ts2.provenance}"
+        pd.testing.assert_series_equal(ts1.provenance, ts2.provenance)
+    else:
+        assert (
+            ts2.provenance is None
+        ), f"ts1.provenance is {ts1.provenance}, ts2.provenance is {ts2.provenance}"
 
 
 def test_append_regions():
@@ -358,6 +371,12 @@ def test_join_columns():
             "iso1:us#fips:97111,2020-04-04,Bar County,county,4\n"
             "iso1:us#fips:97111,,Bar County,county,4\n"
         )
+    ).append_provenance_csv(
+        io.StringIO(
+            "location_id,variable,provenance\n"
+            "iso1:us#cbsa:10100,m1,ts110100prov\n"
+            "iso1:us#fips:97111,m1,ts197111prov\n"
+        )
     )
     ts_2 = timeseries.MultiRegionTimeseriesDataset.from_csv(
         io.StringIO(
@@ -366,6 +385,12 @@ def test_join_columns():
             "iso1:us#cbsa:10100,2020-04-03,,,3\n"
             "iso1:us#fips:97111,2020-04-02,Bar County,county,\n"
             "iso1:us#fips:97111,2020-04-04,Bar County,county,\n"
+        )
+    ).append_provenance_csv(
+        io.StringIO(
+            "location_id,variable,provenance\n"
+            "iso1:us#cbsa:10100,m2,ts110100prov\n"
+            "iso1:us#fips:97111,m2,ts197111prov\n"
         )
     )
     ts_expected = timeseries.MultiRegionTimeseriesDataset.from_csv(
@@ -377,6 +402,14 @@ def test_join_columns():
             "iso1:us#fips:97111,2020-04-02,Bar County,county,2,\n"
             "iso1:us#fips:97111,2020-04-04,Bar County,county,4,\n"
             "iso1:us#fips:97111,,Bar County,county,4,\n"
+        )
+    ).append_provenance_csv(
+        io.StringIO(
+            "location_id,variable,provenance\n"
+            "iso1:us#cbsa:10100,m1,ts110100prov\n"
+            "iso1:us#fips:97111,m1,ts197111prov\n"
+            "iso1:us#cbsa:10100,m2,ts110100prov\n"
+            "iso1:us#fips:97111,m2,ts197111prov\n"
         )
     )
     ts_joined = ts_1.join_columns(ts_2)
@@ -457,6 +490,7 @@ def test_iter_one_region():
         one_region = ts.get_one_region(it_region)
         assert (one_region.data.fillna("") == it_one_region.data.fillna("")).all(axis=None)
         assert one_region.latest == it_one_region.latest
+        assert one_region.provenance == it_one_region.provenance
 
 
 def test_drop_regions_without_population():
@@ -491,3 +525,24 @@ def test_drop_regions_without_population():
 
     assert [l["event"] for l in logs] == ["Dropping unexpected regions without populaton"]
     assert [l["location_ids"] for l in logs] == [["iso1:us#cbsa:20200"]]
+
+
+def test_merge_provenance():
+    ts = timeseries.MultiRegionTimeseriesDataset.from_csv(
+        io.StringIO(
+            "location_id,date,county,aggregate_level,m1\n"
+            "iso1:us#cbsa:10100,2020-04-02,,,\n"
+            "iso1:us#cbsa:10100,2020-04-03,,,\n"
+            "iso1:us#cbsa:10100,,,,\n"
+            "iso1:us#fips:97111,2020-04-02,Bar County,county,2\n"
+            "iso1:us#fips:97111,2020-04-04,Bar County,county,4\n"
+            "iso1:us#fips:97111,,Bar County,county,4\n"
+        )
+    ).append_provenance_csv(
+        io.StringIO("location_id,variable,provenance\n" "iso1:us#cbsa:10100,m1,ts110100prov\n")
+    )
+
+    with pytest.raises(NotImplementedError):
+        ts.append_provenance_csv(
+            io.StringIO("location_id,variable,provenance\n" "iso1:us#fips:97111,m1,ts197111prov\n")
+        )

--- a/test/libs/test_positivity_test.py
+++ b/test/libs/test_positivity_test.py
@@ -10,7 +10,6 @@ from libs.test_positivity import AllMethods
 from libs.test_positivity import Method
 from libs import test_positivity
 from test.libs.datasets.timeseries_test import assert_combined_like
-from test.libs.datasets.timeseries_test import parse_provenance_csv
 
 
 def _parse_wide_dates(csv_str: str) -> pd.DataFrame:
@@ -49,18 +48,18 @@ def test_basic():
     )
     pd.testing.assert_frame_equal(all_methods.all_methods_timeseries, expected_df, check_like=True)
 
-    expected_provenance = parse_provenance_csv(
-        "location_id,variable,provenance\n"
-        "iso1:us#iso2:as,test_positivity,method2\n"
-        "iso1:us#iso2:tx,test_positivity,method1\n"
-    )
     expected_positivity = timeseries.MultiRegionTimeseriesDataset.from_csv(
         io.StringIO(
             "location_id,date,test_positivity\n"
             "iso1:us#iso2:as,2020-04-04,0.02\n"
             "iso1:us#iso2:tx,2020-04-04,0.1\n"
-        ),
-        provenance=expected_provenance,
+        )
+    ).append_provenance_csv(
+        io.StringIO(
+            "location_id,variable,provenance\n"
+            "iso1:us#iso2:as,test_positivity,method2\n"
+            "iso1:us#iso2:tx,test_positivity,method1\n"
+        )
     )
     assert_combined_like(all_methods.test_positivity, expected_positivity)
 
@@ -102,11 +101,6 @@ def test_recent_days():
         "iso1:us#iso2:tx,method2,,0.01,0.01,0.01\n"
     )
     pd.testing.assert_frame_equal(all_methods.all_methods_timeseries, expected_all, check_like=True)
-    expected_provenance = parse_provenance_csv(
-        "location_id,variable,provenance\n"
-        "iso1:us#iso2:as,test_positivity,method2\n"
-        "iso1:us#iso2:tx,test_positivity,method1\n"
-    )
     expected_positivity = timeseries.MultiRegionTimeseriesDataset.from_csv(
         io.StringIO(
             "location_id,date,test_positivity\n"
@@ -116,8 +110,13 @@ def test_recent_days():
             "iso1:us#iso2:tx,2020-04-02,0.1\n"
             "iso1:us#iso2:tx,2020-04-03,0.1\n"
             "iso1:us#iso2:tx,2020-04-04,0.1\n"
-        ),
-        provenance=expected_provenance,
+        )
+    ).append_provenance_csv(
+        io.StringIO(
+            "location_id,variable,provenance\n"
+            "iso1:us#iso2:as,test_positivity,method2\n"
+            "iso1:us#iso2:tx,test_positivity,method1\n"
+        )
     )
     assert_combined_like(all_methods.test_positivity, expected_positivity)
     # Use loc[...].at[...] as work-around for https://github.com/pandas-dev/pandas/issues/26989

--- a/test/libs/test_positivity_test.py
+++ b/test/libs/test_positivity_test.py
@@ -10,6 +10,7 @@ from libs.test_positivity import AllMethods
 from libs.test_positivity import Method
 from libs import test_positivity
 from test.libs.datasets.timeseries_test import assert_combined_like
+from test.libs.datasets.timeseries_test import parse_provenance_csv
 
 
 def _parse_wide_dates(csv_str: str) -> pd.DataFrame:
@@ -48,14 +49,21 @@ def test_basic():
     )
     pd.testing.assert_frame_equal(all_methods.all_methods_timeseries, expected_df, check_like=True)
 
+    expected_provenance = parse_provenance_csv(
+        "location_id,variable,provenance\n"
+        "iso1:us#iso2:as,test_positivity,method2\n"
+        "iso1:us#iso2:tx,test_positivity,method1\n"
+    )
     expected_positivity = timeseries.MultiRegionTimeseriesDataset.from_csv(
         io.StringIO(
             "location_id,date,test_positivity\n"
             "iso1:us#iso2:as,2020-04-04,0.02\n"
             "iso1:us#iso2:tx,2020-04-04,0.1\n"
-        )
+        ),
+        provenance=expected_provenance,
     )
     assert_combined_like(all_methods.test_positivity, expected_positivity)
+
     positivity_provenance = all_methods.test_positivity.provenance
     # Use loc[...].at[...] as work-around for https://github.com/pandas-dev/pandas/issues/26989
     assert positivity_provenance.loc["iso1:us#iso2:as"].to_dict() == {
@@ -94,6 +102,11 @@ def test_recent_days():
         "iso1:us#iso2:tx,method2,,0.01,0.01,0.01\n"
     )
     pd.testing.assert_frame_equal(all_methods.all_methods_timeseries, expected_all, check_like=True)
+    expected_provenance = parse_provenance_csv(
+        "location_id,variable,provenance\n"
+        "iso1:us#iso2:as,test_positivity,method2\n"
+        "iso1:us#iso2:tx,test_positivity,method1\n"
+    )
     expected_positivity = timeseries.MultiRegionTimeseriesDataset.from_csv(
         io.StringIO(
             "location_id,date,test_positivity\n"
@@ -103,7 +116,8 @@ def test_recent_days():
             "iso1:us#iso2:tx,2020-04-02,0.1\n"
             "iso1:us#iso2:tx,2020-04-03,0.1\n"
             "iso1:us#iso2:tx,2020-04-04,0.1\n"
-        )
+        ),
+        provenance=expected_provenance,
     )
     assert_combined_like(all_methods.test_positivity, expected_positivity)
     # Use loc[...].at[...] as work-around for https://github.com/pandas-dev/pandas/issues/26989


### PR DESCRIPTION
This PR is the timeseries part of https://github.com/covid-projections/covid-data-model/pull/737

* Adds provenance to OneRegionTimeseriesDataset
* Changes `MultiRegionTimeseriesDataset.from_csv` to read provenance data if `to_csv` wrote it.


## Tested

Tests pass.

Only change introduced by `python ./run.py data update --summary-filename=''` is renaming `value` column in `data/multiregion-provenance.csv` to `provenance`.