### PR TITLE
Add new cases to latest value data structure

### DIFF
--- a/libs/datasets/dataset_utils.py
+++ b/libs/datasets/dataset_utils.py
@@ -325,6 +325,5 @@ def build_latest_for_column(timeseries_df: pd.DataFrame, column: CommonFields) -
     assert CommonFields.LOCATION_ID in timeseries_df.columns
     assert CommonFields.DATE in timeseries_df.columns
 
-    data = timeseries_df.set_index([CommonFields.LOCATION_ID, CommonFields.DATE])
-    column_data = data[column].groupby([CommonFields.LOCATION_ID]).ffill()
-    return column_data.groupby([CommonFields.LOCATION_ID]).last()
+    data = timeseries_df.set_index([CommonFields.LOCATION_ID, CommonFields.DATE]).sort_index()
+    return data[column].groupby([CommonFields.LOCATION_ID], sort=False).last()

--- a/libs/datasets/dataset_utils.py
+++ b/libs/datasets/dataset_utils.py
@@ -311,3 +311,12 @@ def fips_index_geo_data(df: pd.DataFrame) -> pd.DataFrame:
     # are rows in the input data sources that have different values for county name, state etc.
     fips_indexed = all_identifiers.set_index(CommonFields.FIPS, verify_integrity=True)
     return fips_indexed
+
+
+def build_latest_for_column(timeseries_df: pd.DataFrame, column: CommonFields) -> pd.Series:
+    assert CommonFields.LOCATION_ID in timeseries_df.columns
+    assert CommonFields.DATE in timeseries_df.columns
+
+    data = timeseries_df.set_index([CommonFields.LOCATION_ID, CommonFields.DATE])
+    column_data = data[column].groupby([CommonFields.LOCATION_ID]).ffill()
+    return column_data.groupby([CommonFields.LOCATION_ID]).last()

--- a/libs/datasets/dataset_utils.py
+++ b/libs/datasets/dataset_utils.py
@@ -314,6 +314,14 @@ def fips_index_geo_data(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def build_latest_for_column(timeseries_df: pd.DataFrame, column: CommonFields) -> pd.Series:
+    """Builds a series of the latest value for each column.
+
+    Args:
+        timeseries_df: Timeseries DF with location_id and date columns.
+        column: Column to build latest value for.
+
+    Returns: Series indexed by location_id with the latest value for `column`.
+    """
     assert CommonFields.LOCATION_ID in timeseries_df.columns
     assert CommonFields.DATE in timeseries_df.columns
 

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -754,6 +754,7 @@ def _diff_preserving_first_value(series):
 
 
 def _add_new_cases_to_latest(timeseries_df: pd.DataFrame, latest_df: pd.DataFrame) -> pd.DataFrame:
+    assert latest_df.index.names == [CommonFields.LOCATION_ID]
     latest_new_cases = dataset_utils.build_latest_for_column(timeseries_df, CommonFields.NEW_CASES)
 
     latest_copy = latest_df.copy()

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -753,6 +753,14 @@ def _diff_preserving_first_value(series):
     return series_diff
 
 
+def _add_new_cases_to_latest(timeseries_df: pd.DataFrame, latest_df: pd.DataFrame) -> pd.DataFrame:
+    latest_new_cases = dataset_utils.build_latest_for_column(timeseries_df, CommonFields.NEW_CASES)
+
+    latest_copy = latest_df.copy()
+    latest_copy[CommonFields.NEW_CASES] = latest_new_cases
+    return latest_copy.reset_index()
+
+
 def add_new_cases(timeseries: MultiRegionTimeseriesDataset) -> MultiRegionTimeseriesDataset:
     """Adds a new_cases column to this dataset by calculating the daily diff in cases."""
     df_copy = timeseries.data.copy()
@@ -764,9 +772,12 @@ def add_new_cases(timeseries: MultiRegionTimeseriesDataset) -> MultiRegionTimese
     df_copy[CommonFields.NEW_CASES] = grouped_df[CommonFields.CASES].apply(
         _diff_preserving_first_value
     )
+    latest_values = _add_new_cases_to_latest(df_copy, timeseries.latest_data)
+
     new_timeseries = MultiRegionTimeseriesDataset.from_timeseries_df(
         timeseries_df=df_copy, provenance=timeseries.provenance
-    ).append_latest_df(timeseries.latest_data.reset_index())
+    ).append_latest_df(latest_values)
+
     return new_timeseries
 
 

--- a/test/dataset_utils_test.py
+++ b/test/dataset_utils_test.py
@@ -264,3 +264,34 @@ def test_make_binary_array_exclude_fips_prefix():
         "state97",
         "country-uk",
     }
+
+
+def test_build_latest_for_column_unsorted():
+    df = pd.read_csv(
+        StringIO(
+            "location_id,date,cases\n"
+            "iso1:us#fips:1,2020-10-28,10\n"
+            "iso1:us#fips:1,2020-10-27,6\n"
+        ),
+        low_memory=False,
+    )
+    result = dataset_utils.build_latest_for_column(df, CommonFields.CASES)
+    expected = pd.Series([10], index=["iso1:us#fips:1"], name="cases")
+    expected.index.name = "location_id"
+    pd.testing.assert_series_equal(result, expected)
+
+
+def test_build_latest_for_column_missing_last_value():
+    df = pd.read_csv(
+        StringIO(
+            "location_id,date,cases\n"
+            "iso1:us#fips:1,2020-10-27,10\n"
+            "iso1:us#fips:1,2020-10-28,11\n"
+            "iso1:us#fips:1,2020-10-29,\n"
+        ),
+        low_memory=False,
+    )
+    result = dataset_utils.build_latest_for_column(df, CommonFields.CASES)
+    expected = pd.Series([11.0], index=["iso1:us#fips:1"], name="cases")
+    expected.index.name = "location_id"
+    pd.testing.assert_series_equal(result, expected)

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -311,7 +311,10 @@ def test_calculate_new_cases():
             "iso1:us#fips:2,2020-01-02,7\n"
             "iso1:us#fips:3,2020-01-01,9\n"
             "iso1:us#fips:4,2020-01-01,\n"
-            "iso1:us#fips:1,,100"
+            "iso1:us#fips:1,,100\n"
+            "iso1:us#fips:2,,\n"
+            "iso1:us#fips:3,,\n"
+            "iso1:us#fips:4,,\n"
         )
     )
 
@@ -325,12 +328,18 @@ def test_calculate_new_cases():
             "iso1:us#fips:2,2020-01-02,7,2\n"
             "iso1:us#fips:3,2020-01-01,9,9\n"
             "iso1:us#fips:4,2020-01-01,,\n"
-            "iso1:us#fips:1,,100,\n"
+            "iso1:us#fips:1,,100,0.0\n"
+            "iso1:us#fips:2,,,2.0\n"
+            "iso1:us#fips:3,,,9.0\n"
+            "iso1:us#fips:4,,,\n"
         )
     )
 
-    mrts_after = timeseries.add_new_cases(mrts_before)
-    pd.testing.assert_frame_equal(mrts_after.data, mrts_expected.data, check_like=True)
+    timeseries_after = timeseries.add_new_cases(mrts_before)
+    pd.testing.assert_frame_equal(timeseries_after.data, mrts_expected.data, check_like=True)
+    pd.testing.assert_frame_equal(
+        timeseries_after.latest_data, mrts_expected.latest_data, check_like=True
+    )
 
 
 def test_timeseries_long():

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -336,10 +336,7 @@ def test_calculate_new_cases():
     )
 
     timeseries_after = timeseries.add_new_cases(mrts_before)
-    pd.testing.assert_frame_equal(timeseries_after.data, mrts_expected.data, check_like=True)
-    pd.testing.assert_frame_equal(
-        timeseries_after.latest_data, mrts_expected.latest_data, check_like=True
-    )
+    assert_combined_like(mrts_expected, timeseries_after)
 
 
 def test_timeseries_long():


### PR DESCRIPTION
With the way things work, we still need to manually maintain the latest value in the multi region dataset.

This adds logic to add new cases into that. 

I don't want to get in a habit of this custom logic.  @TomGoBravo and I have talked about ways to calculate that dataset on the fly better, but that logic requires more refactoring, and I'd like for it to be separate from getting new cases out.