### PR TITLE
Remove negative new cases

### DIFF
--- a/api/can_api_v2_definition.py
+++ b/api/can_api_v2_definition.py
@@ -58,6 +58,7 @@ Notable exceptions:
  1. If a region does not report cases for a period of time, the first day
     cases start reporting again will not be included. This day likely includes
     multiple days worth of cases and can be misleading to the overall series.
+ 2. Any days with negative new cases are removed.
 """,
     )
 

--- a/api/docs/open_api_schema.json
+++ b/api/docs/open_api_schema.json
@@ -662,7 +662,7 @@
                 "type": "null"
               }
             ],
-            "description": "\nNew confirmed or suspected cases.\n\nNew cases are a processed timeseries of cases - summing new cases may not equal\nthe cumulative case count.\n\nNotable exceptions:\n 1. If a region does not report cases for a period of time, the first day\n    cases start reporting again will not be included. This day likely includes\n    multiple days worth of cases and can be misleading to the overall series.\n"
+            "description": "\nNew confirmed or suspected cases.\n\nNew cases are a processed timeseries of cases - summing new cases may not equal\nthe cumulative case count.\n\nNotable exceptions:\n 1. If a region does not report cases for a period of time, the first day\n    cases start reporting again will not be included. This day likely includes\n    multiple days worth of cases and can be misleading to the overall series.\n 2. Any days with negative new cases are removed.\n"
           }
         },
         "description": "Known actuals data."
@@ -1261,7 +1261,7 @@
                 "type": "null"
               }
             ],
-            "description": "\nNew confirmed or suspected cases.\n\nNew cases are a processed timeseries of cases - summing new cases may not equal\nthe cumulative case count.\n\nNotable exceptions:\n 1. If a region does not report cases for a period of time, the first day\n    cases start reporting again will not be included. This day likely includes\n    multiple days worth of cases and can be misleading to the overall series.\n"
+            "description": "\nNew confirmed or suspected cases.\n\nNew cases are a processed timeseries of cases - summing new cases may not equal\nthe cumulative case count.\n\nNotable exceptions:\n 1. If a region does not report cases for a period of time, the first day\n    cases start reporting again will not be included. This day likely includes\n    multiple days worth of cases and can be misleading to the overall series.\n 2. Any days with negative new cases are removed.\n"
           },
           "date": {
             "title": "Date",

--- a/api/schemas_v2/Actuals.json
+++ b/api/schemas_v2/Actuals.json
@@ -83,7 +83,7 @@
     },
     "newCases": {
       "title": "Newcases",
-      "description": "\nNew confirmed or suspected cases.\n\nNew cases are a processed timeseries of cases - summing new cases may not equal\nthe cumulative case count.\n\nNotable exceptions:\n 1. If a region does not report cases for a period of time, the first day\n    cases start reporting again will not be included. This day likely includes\n    multiple days worth of cases and can be misleading to the overall series.\n",
+      "description": "\nNew confirmed or suspected cases.\n\nNew cases are a processed timeseries of cases - summing new cases may not equal\nthe cumulative case count.\n\nNotable exceptions:\n 1. If a region does not report cases for a period of time, the first day\n    cases start reporting again will not be included. This day likely includes\n    multiple days worth of cases and can be misleading to the overall series.\n 2. Any days with negative new cases are removed.\n",
       "anyOf": [
         {
           "type": "integer"

--- a/api/schemas_v2/ActualsTimeseriesRow.json
+++ b/api/schemas_v2/ActualsTimeseriesRow.json
@@ -83,7 +83,7 @@
     },
     "newCases": {
       "title": "Newcases",
-      "description": "\nNew confirmed or suspected cases.\n\nNew cases are a processed timeseries of cases - summing new cases may not equal\nthe cumulative case count.\n\nNotable exceptions:\n 1. If a region does not report cases for a period of time, the first day\n    cases start reporting again will not be included. This day likely includes\n    multiple days worth of cases and can be misleading to the overall series.\n",
+      "description": "\nNew confirmed or suspected cases.\n\nNew cases are a processed timeseries of cases - summing new cases may not equal\nthe cumulative case count.\n\nNotable exceptions:\n 1. If a region does not report cases for a period of time, the first day\n    cases start reporting again will not be included. This day likely includes\n    multiple days worth of cases and can be misleading to the overall series.\n 2. Any days with negative new cases are removed.\n",
       "anyOf": [
         {
           "type": "integer"

--- a/api/schemas_v2/AggregateFlattenedTimeseries.json
+++ b/api/schemas_v2/AggregateFlattenedTimeseries.json
@@ -152,7 +152,7 @@
         },
         "newCases": {
           "title": "Newcases",
-          "description": "\nNew confirmed or suspected cases.\n\nNew cases are a processed timeseries of cases - summing new cases may not equal\nthe cumulative case count.\n\nNotable exceptions:\n 1. If a region does not report cases for a period of time, the first day\n    cases start reporting again will not be included. This day likely includes\n    multiple days worth of cases and can be misleading to the overall series.\n",
+          "description": "\nNew confirmed or suspected cases.\n\nNew cases are a processed timeseries of cases - summing new cases may not equal\nthe cumulative case count.\n\nNotable exceptions:\n 1. If a region does not report cases for a period of time, the first day\n    cases start reporting again will not be included. This day likely includes\n    multiple days worth of cases and can be misleading to the overall series.\n 2. Any days with negative new cases are removed.\n",
           "anyOf": [
             {
               "type": "integer"

--- a/api/schemas_v2/AggregateRegionSummary.json
+++ b/api/schemas_v2/AggregateRegionSummary.json
@@ -340,7 +340,7 @@
         },
         "newCases": {
           "title": "Newcases",
-          "description": "\nNew confirmed or suspected cases.\n\nNew cases are a processed timeseries of cases - summing new cases may not equal\nthe cumulative case count.\n\nNotable exceptions:\n 1. If a region does not report cases for a period of time, the first day\n    cases start reporting again will not be included. This day likely includes\n    multiple days worth of cases and can be misleading to the overall series.\n",
+          "description": "\nNew confirmed or suspected cases.\n\nNew cases are a processed timeseries of cases - summing new cases may not equal\nthe cumulative case count.\n\nNotable exceptions:\n 1. If a region does not report cases for a period of time, the first day\n    cases start reporting again will not be included. This day likely includes\n    multiple days worth of cases and can be misleading to the overall series.\n 2. Any days with negative new cases are removed.\n",
           "anyOf": [
             {
               "type": "integer"

--- a/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
@@ -340,7 +340,7 @@
         },
         "newCases": {
           "title": "Newcases",
-          "description": "\nNew confirmed or suspected cases.\n\nNew cases are a processed timeseries of cases - summing new cases may not equal\nthe cumulative case count.\n\nNotable exceptions:\n 1. If a region does not report cases for a period of time, the first day\n    cases start reporting again will not be included. This day likely includes\n    multiple days worth of cases and can be misleading to the overall series.\n",
+          "description": "\nNew confirmed or suspected cases.\n\nNew cases are a processed timeseries of cases - summing new cases may not equal\nthe cumulative case count.\n\nNotable exceptions:\n 1. If a region does not report cases for a period of time, the first day\n    cases start reporting again will not be included. This day likely includes\n    multiple days worth of cases and can be misleading to the overall series.\n 2. Any days with negative new cases are removed.\n",
           "anyOf": [
             {
               "type": "integer"
@@ -543,7 +543,7 @@
         },
         "newCases": {
           "title": "Newcases",
-          "description": "\nNew confirmed or suspected cases.\n\nNew cases are a processed timeseries of cases - summing new cases may not equal\nthe cumulative case count.\n\nNotable exceptions:\n 1. If a region does not report cases for a period of time, the first day\n    cases start reporting again will not be included. This day likely includes\n    multiple days worth of cases and can be misleading to the overall series.\n",
+          "description": "\nNew confirmed or suspected cases.\n\nNew cases are a processed timeseries of cases - summing new cases may not equal\nthe cumulative case count.\n\nNotable exceptions:\n 1. If a region does not report cases for a period of time, the first day\n    cases start reporting again will not be included. This day likely includes\n    multiple days worth of cases and can be misleading to the overall series.\n 2. Any days with negative new cases are removed.\n",
           "anyOf": [
             {
               "type": "integer"

--- a/api/schemas_v2/RegionSummary.json
+++ b/api/schemas_v2/RegionSummary.json
@@ -440,7 +440,7 @@
         },
         "newCases": {
           "title": "Newcases",
-          "description": "\nNew confirmed or suspected cases.\n\nNew cases are a processed timeseries of cases - summing new cases may not equal\nthe cumulative case count.\n\nNotable exceptions:\n 1. If a region does not report cases for a period of time, the first day\n    cases start reporting again will not be included. This day likely includes\n    multiple days worth of cases and can be misleading to the overall series.\n",
+          "description": "\nNew confirmed or suspected cases.\n\nNew cases are a processed timeseries of cases - summing new cases may not equal\nthe cumulative case count.\n\nNotable exceptions:\n 1. If a region does not report cases for a period of time, the first day\n    cases start reporting again will not be included. This day likely includes\n    multiple days worth of cases and can be misleading to the overall series.\n 2. Any days with negative new cases are removed.\n",
           "anyOf": [
             {
               "type": "integer"

--- a/api/schemas_v2/RegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/RegionSummaryWithTimeseries.json
@@ -455,7 +455,7 @@
         },
         "newCases": {
           "title": "Newcases",
-          "description": "\nNew confirmed or suspected cases.\n\nNew cases are a processed timeseries of cases - summing new cases may not equal\nthe cumulative case count.\n\nNotable exceptions:\n 1. If a region does not report cases for a period of time, the first day\n    cases start reporting again will not be included. This day likely includes\n    multiple days worth of cases and can be misleading to the overall series.\n",
+          "description": "\nNew confirmed or suspected cases.\n\nNew cases are a processed timeseries of cases - summing new cases may not equal\nthe cumulative case count.\n\nNotable exceptions:\n 1. If a region does not report cases for a period of time, the first day\n    cases start reporting again will not be included. This day likely includes\n    multiple days worth of cases and can be misleading to the overall series.\n 2. Any days with negative new cases are removed.\n",
           "anyOf": [
             {
               "type": "integer"
@@ -658,7 +658,7 @@
         },
         "newCases": {
           "title": "Newcases",
-          "description": "\nNew confirmed or suspected cases.\n\nNew cases are a processed timeseries of cases - summing new cases may not equal\nthe cumulative case count.\n\nNotable exceptions:\n 1. If a region does not report cases for a period of time, the first day\n    cases start reporting again will not be included. This day likely includes\n    multiple days worth of cases and can be misleading to the overall series.\n",
+          "description": "\nNew confirmed or suspected cases.\n\nNew cases are a processed timeseries of cases - summing new cases may not equal\nthe cumulative case count.\n\nNotable exceptions:\n 1. If a region does not report cases for a period of time, the first day\n    cases start reporting again will not be included. This day likely includes\n    multiple days worth of cases and can be misleading to the overall series.\n 2. Any days with negative new cases are removed.\n",
           "anyOf": [
             {
               "type": "integer"

--- a/api/schemas_v2/RegionTimeseriesRowWithHeader.json
+++ b/api/schemas_v2/RegionTimeseriesRowWithHeader.json
@@ -227,7 +227,7 @@
         },
         "newCases": {
           "title": "Newcases",
-          "description": "\nNew confirmed or suspected cases.\n\nNew cases are a processed timeseries of cases - summing new cases may not equal\nthe cumulative case count.\n\nNotable exceptions:\n 1. If a region does not report cases for a period of time, the first day\n    cases start reporting again will not be included. This day likely includes\n    multiple days worth of cases and can be misleading to the overall series.\n",
+          "description": "\nNew confirmed or suspected cases.\n\nNew cases are a processed timeseries of cases - summing new cases may not equal\nthe cumulative case count.\n\nNotable exceptions:\n 1. If a region does not report cases for a period of time, the first day\n    cases start reporting again will not be included. This day likely includes\n    multiple days worth of cases and can be misleading to the overall series.\n 2. Any days with negative new cases are removed.\n",
           "anyOf": [
             {
               "type": "integer"

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -770,9 +770,12 @@ def add_new_cases(timeseries: MultiRegionTimeseriesDataset) -> MultiRegionTimese
     # We want to capture the first day a region reports a case. Since our data sources have
     # been capturing cases in all states from the beginning of the pandemic, we are treating
     # The first days as appropriate new case data.
-    df_copy[CommonFields.NEW_CASES] = grouped_df[CommonFields.CASES].apply(
-        _diff_preserving_first_value
-    )
+    new_cases = grouped_df[CommonFields.CASES].apply(_diff_preserving_first_value)
+
+    # Remove the occasional negative case adjustments.
+    new_cases[new_cases < 0] = None
+
+    df_copy[CommonFields.NEW_CASES] = new_cases
     latest_values = _add_new_cases_to_latest(df_copy, timeseries.latest_data)
 
     new_timeseries = MultiRegionTimeseriesDataset.from_timeseries_df(

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -773,7 +773,7 @@ def add_new_cases(timeseries: MultiRegionTimeseriesDataset) -> MultiRegionTimese
     new_cases = grouped_df[CommonFields.CASES].apply(_diff_preserving_first_value)
 
     # Remove the occasional negative case adjustments.
-    new_cases[new_cases < 0] = None
+    new_cases[new_cases < 0] = pd.NA
 
     df_copy[CommonFields.NEW_CASES] = new_cases
     latest_values = _add_new_cases_to_latest(df_copy, timeseries.latest_data)

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -339,6 +339,31 @@ def test_calculate_new_cases():
     assert_combined_like(mrts_expected, timeseries_after)
 
 
+def test_new_cases_remove_negative():
+    mrts_before = timeseries.MultiRegionTimeseriesDataset.from_csv(
+        io.StringIO(
+            "location_id,date,cases\n"
+            "iso1:us#fips:1,2020-01-01,100\n"
+            "iso1:us#fips:1,2020-01-02,50\n"
+            "iso1:us#fips:1,2020-01-03,75\n"
+            "iso1:us#fips:1,,75\n"
+        )
+    )
+
+    mrts_expected = timeseries.MultiRegionTimeseriesDataset.from_csv(
+        io.StringIO(
+            "location_id,date,cases,new_cases\n"
+            "iso1:us#fips:1,2020-01-01,100,100\n"
+            "iso1:us#fips:1,2020-01-02,50,\n"
+            "iso1:us#fips:1,2020-01-03,75,25\n"
+            "iso1:us#fips:1,,75,25.0\n"
+        )
+    )
+
+    timeseries_after = timeseries.add_new_cases(mrts_before)
+    assert_combined_like(mrts_expected, timeseries_after)
+
+
 def test_timeseries_long():
     ts = timeseries.MultiRegionTimeseriesDataset.from_csv(
         io.StringIO(


### PR DESCRIPTION
Sometimes the new case series can be negative, to preserve the existing behavior this makes those nans.  It looks like this generally happens if a region switches from reporting probable -> confirmed cases or small adjustments.