### PR TITLE
RFC: Install numexpr module per pandas recommendations.

### DIFF
--- a/libs/datasets/sources/covid_county_data.py
+++ b/libs/datasets/sources/covid_county_data.py
@@ -72,18 +72,23 @@ class CovidCountyDataDataSource(data_source.DataSource):
 
         # Make a copy to avoid modifying the argument when using mask with inplace=True.
         df = data.copy()
-        # HACK: isnan() is only available in numexpr3 which isn't released yet. So we use nan != nan trick.
-        # https://github.com/pydata/numexpr/issues/23#issuecomment-58774009
-        isna = lambda column: f"({column} != {column})"
-        notna = lambda column: f"({column} == {column})"
-        tests_and_cases = df.eval(
-            f"{isna('negative_tests')} & {isna('positive_tests')} & {notna('total_tests')} & {notna('cases')}"
+        tests_and_cases = (
+            df["negative_tests"].isna()
+            & df["positive_tests"].isna()
+            & df["total_tests"].notna()
+            & df["cases"].notna()
         )
-        missing_neg = df.eval(
-            f"{isna('negative_tests')} & {notna('positive_tests')} & {notna('total_tests')} & {notna('cases')}"
+        missing_neg = (
+            df["negative_tests"].isna()
+            & df["positive_tests"].notna()
+            & df["total_tests"].notna()
+            & df["cases"].notna()
         )
-        missing_pos = df.eval(
-            f"{notna('negative_tests')} & {isna('positive_tests')} & {notna('total_tests')} & {notna('cases')}"
+        missing_pos = (
+            df["negative_tests"].notna()
+            & df["positive_tests"].isna()
+            & df["total_tests"].notna()
+            & df["cases"].notna()
         )
 
         # Keep the same order of rows in `provenance` as `df` so that the same masks can be used when

--- a/libs/datasets/sources/covid_county_data.py
+++ b/libs/datasets/sources/covid_county_data.py
@@ -72,14 +72,18 @@ class CovidCountyDataDataSource(data_source.DataSource):
 
         # Make a copy to avoid modifying the argument when using mask with inplace=True.
         df = data.copy()
+        # HACK: isnan() is only available in numexpr3 which isn't released yet. So we use nan != nan trick.
+        # https://github.com/pydata/numexpr/issues/23#issuecomment-58774009
+        isna = lambda column: f"({column} != {column})"
+        notna = lambda column: f"({column} == {column})"
         tests_and_cases = df.eval(
-            "negative_tests.isna() & positive_tests.isna() & total_tests.notna() & cases.notna()"
+            f"{isna('negative_tests')} & {isna('positive_tests')} & {notna('total_tests')} & {notna('cases')}"
         )
         missing_neg = df.eval(
-            "negative_tests.isna() & positive_tests.notna() & total_tests.notna() & cases.notna()"
+            f"{isna('negative_tests')} & {notna('positive_tests')} & {notna('total_tests')} & {notna('cases')}"
         )
         missing_pos = df.eval(
-            "negative_tests.notna() & positive_tests.isna() & total_tests.notna() & cases.notna()"
+            f"{notna('negative_tests')} & {isna('positive_tests')} & {notna('total_tests')} & {notna('cases')}"
         )
 
         # Keep the same order of rows in `provenance` as `df` so that the same masks can be used when

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,3 +48,6 @@ xlrd==1.2.0  # For panda's read_excel method
 # By default, installs from local directory, but when copying this
 # to binder/requirements.txt, uncomment the following line.
 # -e git://github.com/covid-projections/covid-data-public.git#egg=covidactnow
+
+# Dependencies recommended by pandas for better performance
+numexpr==2.7.1


### PR DESCRIPTION
Adds numexpr 2.7.1 to our dependencies.  This is [recommended](https://pandas.pydata.org/pandas-docs/stable/getting_started/install.html#install-recommended-dependencies) by pandas and [according to the docs](https://pandas.pydata.org/pandas-docs/stable/user_guide/enhancingperf.html#enhancingperf-eval), "To benefit from using eval() you need to install numexpr."

That said, this PR has no meaningful perf impact (on `run.py data updata` or on full snapshot generation).  And in fact, to make our code work with numexpr I had to change one of our 2 uses of `eval()` and in doing so and measuring the perf impact I discovered that:
1. numexpr didn't affect the performance.
2. Avoiding eval() actually had better performance (saved ~0.07s, taking the CovidCountyDataDataSource.synthesize_test_metrics() method from ~0.94s to ~0.88s).

**So thoughts on whether we should bother checking this in given it has no tangible benefit other than following pandas recommendations?**