### PR TITLE
Set openblas num threads to 1 to improve multiprocessing performance

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -41,6 +41,9 @@ env:
   # use a webhook to write to slack channel dev-alerts for QA
   SLACK_DEV_ALERTS_WEBHOOK: ${{ secrets.SLACK_DEV_ALERTS_WEBHOOK }}
 
+  # Setting openblas threading to one to speed up numpy in multiprocessing.
+  OPENBLAS_NUM_THREADS: 1
+
 jobs:
   build-and-publish-snapshot:
     runs-on: self-hosted


### PR DESCRIPTION
Setting openblas threads to 1 drops pyseir runtime from 1hr 26 min -> ~10min (!).  I believe this is due to threading contention in openblas when using multiproccessing.  

I don't have a 100% detailed understanding for why it's this way, but https://github.com/xianyi/OpenBLAS/issues/731 gives some insight.  

There are some other optimizations i'd like to do that will bring the build time down to ~2min 30s, but will throw that in a separate PR