### PR TITLE
Use numba to speed up process matrix

### DIFF
--- a/pyseir/cli.py
+++ b/pyseir/cli.py
@@ -85,6 +85,12 @@ class StatePipeline:
         return StatePipeline(region=region, infer_df=infer_df, icu_data=icu_data)
 
 
+def _build_region_pipeline_input(region: pipeline.Region):
+    return SubStateRegionPipelineInput(
+        region=region, regional_combined_dataset=combined_datasets.RegionalData.from_region(region),
+    )
+
+
 @dataclass
 class SubStateRegionPipelineInput:
     region: pipeline.Region
@@ -106,14 +112,8 @@ class SubStateRegionPipelineInput:
                     states=states,
                 )
             }
-        pipeline_inputs = [
-            SubStateRegionPipelineInput(
-                region=region,
-                regional_combined_dataset=combined_datasets.RegionalData.from_region(region),
-            )
-            for region in regions
-        ]
-        return pipeline_inputs
+        pipeline_inputs = parallel_utils.parallel_map(_build_region_pipeline_input, regions)
+        return list(pipeline_inputs)
 
 
 @dataclass

--- a/pyseir/rt/constants.py
+++ b/pyseir/rt/constants.py
@@ -63,7 +63,7 @@ class InferRtConstants:
     SERIAL_PERIOD = 1 / _sigma + 0.5 * 1 / _delta
 
     # The quantization of the R Buckets
-    R_BUCKETS = np.linspace(0, 10, 501)
+    R_BUCKETS = np.linspace(0, 10, 501).astype(np.float64)
 
     # Reference date to compute from.
     REF_DATE = datetime(year=2020, month=1, day=1)

--- a/pyseir/rt/infer_rt.py
+++ b/pyseir/rt/infer_rt.py
@@ -41,7 +41,7 @@ def normal_pdf(x, mean, std_deviation):
     return math.exp(-0.5 * u ** 2) / (SQRT2PI * std_deviation)
 
 
-@numba.njit(fastmath=True, parallel=True)
+@numba.njit(fastmath=True)
 def pdf_vector(x, loc, scale):
     """Replacement for scipy pdf function."""
     array = np.empty((x.size, loc.size))

--- a/pyseir/rt/infer_rt.py
+++ b/pyseir/rt/infer_rt.py
@@ -6,9 +6,12 @@ import structlog
 
 
 import numpy as np
+import numba
+import math
 import pandas as pd
 from scipy import stats as sps
 from matplotlib import pyplot as plt
+
 
 from libs.datasets import combined_datasets
 from libs import pipeline
@@ -20,6 +23,33 @@ from pyseir.rt.constants import InferRtConstants
 from pyseir.rt import plotting, utils
 
 rt_log = structlog.get_logger(__name__)
+
+
+SQRT2PI = math.sqrt(2.0 * math.pi)
+
+
+@numba.vectorize([numba.float64(numba.float64, numba.float64, numba.float64)], fastmath=True)
+def normal_pdf(x, mean, std_deviation):
+    """Probability density function at `x` of a normal distribution.
+
+    Args:
+        x: Value
+        mean: Mean of distribution
+        std_deviation: Standard deviation of distribution.
+    """
+    u = (x - mean) / std_deviation
+    return math.exp(-0.5 * u ** 2) / (SQRT2PI * std_deviation)
+
+
+@numba.njit(fastmath=True)
+def pdf_vector(x, loc, scale):
+    """Replacement for scipy pdf function."""
+    array = np.empty((x.size, loc.size))
+    for i, a in enumerate(x):
+        for j, b in enumerate(loc):
+            array[i, j] = normal_pdf(a, b, scale)
+
+    return array
 
 
 @dataclass(frozen=True)
@@ -276,7 +306,10 @@ class RtInferenceEngine:
 
         use_sigma = min(a, b) * self.default_process_sigma
 
-        process_matrix = sps.norm(loc=self.r_list, scale=use_sigma).pdf(self.r_list[:, None])
+        # Build process matrix using optimized numba pdf function.
+        # This function is equivalent to the following call, but runs about 50% faster:
+        # process_matrix = sps.norm(loc=self.r_list, scale=use_sigma).pdf(self.r_list[:, None])
+        process_matrix = pdf_vector(self.r_list, self.r_list, use_sigma)
 
         # process_matrix applies gaussian smoothing to the previous posterior to make the prior.
         # But when the gaussian is wide much of its distribution function can be outside of the

--- a/pyseir/rt/infer_rt.py
+++ b/pyseir/rt/infer_rt.py
@@ -41,7 +41,7 @@ def normal_pdf(x, mean, std_deviation):
     return math.exp(-0.5 * u ** 2) / (SQRT2PI * std_deviation)
 
 
-@numba.njit(fastmath=True)
+@numba.njit(fastmath=True, parallel=True)
 def pdf_vector(x, loc, scale):
     """Replacement for scipy pdf function."""
     array = np.empty((x.size, loc.size))

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,3 +49,5 @@ xlrd==1.2.0  # For panda's read_excel method
 # By default, installs from local directory, but when copying this
 # to binder/requirements.txt, uncomment the following line.
 # -e git://github.com/covid-projections/covid-data-public.git#egg=covidactnow
+
+icc_rt

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,5 +49,3 @@ xlrd==1.2.0  # For panda's read_excel method
 # By default, installs from local directory, but when copying this
 # to binder/requirements.txt, uncomment the following line.
 # -e git://github.com/covid-projections/covid-data-public.git#egg=covidactnow
-
-icc_rt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 boto3==1.15.6
 scipy==1.4.1
+numba==0.51.2
 astroid==2.4.1
 certifi==2019.11.28
 chardet==3.0.4


### PR DESCRIPTION
This PR uses numba to speed up a scipy pdf function.  It speeds up the function call from 8ms per call to ~2ms per call. I checked and the input and output of the function was the same.

Loading the regions in parallel shaves off around 2 min of the run.  Now all of pyseir (rt calculation + icu calc) runs in 2 min 33 seconds.