### PR TITLE
Use CMS as backfill for test positivity, and disable questionable counties from Valorum

### DIFF
--- a/api/can_api_definition.py
+++ b/api/can_api_definition.py
@@ -79,6 +79,7 @@ class CovidPatientsMethod(enum.Enum):
 class TestPositivityRatioMethod(GetByValueMixin, enum.Enum):
     """Method used to determine test positivity ratio."""
 
+    CMSTesting = "CMSTesting"
     HHSTesting = "HHSTesting"
     VALORUM = "Valorum"
     OTHER = "other"

--- a/api/docs/open_api_schema.json
+++ b/api/docs/open_api_schema.json
@@ -670,6 +670,7 @@
       "TestPositivityRatioMethod": {
         "title": "TestPositivityRatioMethod",
         "enum": [
+          "CMSTesting",
           "HHSTesting",
           "Valorum",
           "covid_tracking",

--- a/api/schemas_v2/AggregateFlattenedTimeseries.json
+++ b/api/schemas_v2/AggregateFlattenedTimeseries.json
@@ -178,6 +178,7 @@
       "title": "TestPositivityRatioMethod",
       "description": "Method used to determine test positivity ratio.",
       "enum": [
+        "CMSTesting",
         "HHSTesting",
         "Valorum",
         "covid_tracking",

--- a/api/schemas_v2/AggregateRegionSummary.json
+++ b/api/schemas_v2/AggregateRegionSummary.json
@@ -19,6 +19,7 @@
       "title": "TestPositivityRatioMethod",
       "description": "Method used to determine test positivity ratio.",
       "enum": [
+        "CMSTesting",
         "HHSTesting",
         "Valorum",
         "covid_tracking",

--- a/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
@@ -19,6 +19,7 @@
       "title": "TestPositivityRatioMethod",
       "description": "Method used to determine test positivity ratio.",
       "enum": [
+        "CMSTesting",
         "HHSTesting",
         "Valorum",
         "covid_tracking",

--- a/api/schemas_v2/Metrics.json
+++ b/api/schemas_v2/Metrics.json
@@ -94,6 +94,7 @@
       "title": "TestPositivityRatioMethod",
       "description": "Method used to determine test positivity ratio.",
       "enum": [
+        "CMSTesting",
         "HHSTesting",
         "Valorum",
         "covid_tracking",

--- a/api/schemas_v2/MetricsTimeseriesRow.json
+++ b/api/schemas_v2/MetricsTimeseriesRow.json
@@ -101,6 +101,7 @@
       "title": "TestPositivityRatioMethod",
       "description": "Method used to determine test positivity ratio.",
       "enum": [
+        "CMSTesting",
         "HHSTesting",
         "Valorum",
         "covid_tracking",

--- a/api/schemas_v2/RegionSummary.json
+++ b/api/schemas_v2/RegionSummary.json
@@ -119,6 +119,7 @@
       "title": "TestPositivityRatioMethod",
       "description": "Method used to determine test positivity ratio.",
       "enum": [
+        "CMSTesting",
         "HHSTesting",
         "Valorum",
         "covid_tracking",

--- a/api/schemas_v2/RegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/RegionSummaryWithTimeseries.json
@@ -134,6 +134,7 @@
       "title": "TestPositivityRatioMethod",
       "description": "Method used to determine test positivity ratio.",
       "enum": [
+        "CMSTesting",
         "HHSTesting",
         "Valorum",
         "covid_tracking",

--- a/api/schemas_v2/RegionTimeseriesRowWithHeader.json
+++ b/api/schemas_v2/RegionTimeseriesRowWithHeader.json
@@ -253,6 +253,7 @@
       "title": "TestPositivityRatioMethod",
       "description": "Method used to determine test positivity ratio.",
       "enum": [
+        "CMSTesting",
         "HHSTesting",
         "Valorum",
         "covid_tracking",

--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -26,6 +26,7 @@ from libs.datasets.timeseries import OneRegionTimeseriesDataset
 from libs.datasets.timeseries import TimeseriesDataset
 from libs.datasets.latest_values_dataset import LatestValuesDataset
 from libs.datasets.sources.nytimes_dataset import NYTimesDataset
+from libs.datasets.sources.cms_testing_dataset import CMSTestingDataset
 from libs.datasets.sources.covid_tracking_source import CovidTrackingDataSource
 from libs.datasets.sources.covid_care_map import CovidCareMapBeds
 from libs.datasets.sources.fips_population import FIPSPopulation
@@ -101,6 +102,7 @@ ALL_TIMESERIES_FEATURE_DEFINITION: FeatureDataSourceMap = {
     CommonFields.POSITIVE_CASES_VIRAL: [CovidTrackingDataSource],
     CommonFields.TOTAL_TESTS_PEOPLE_VIRAL: [CovidTrackingDataSource],
     CommonFields.TOTAL_TEST_ENCOUNTERS_VIRAL: [CovidTrackingDataSource],
+    CommonFields.TEST_POSITIVITY: [CMSTestingDataset],
 }
 
 ALL_FIELDS_FEATURE_DEFINITION: FeatureDataSourceMap = {

--- a/libs/datasets/sources/cms_testing_dataset.py
+++ b/libs/datasets/sources/cms_testing_dataset.py
@@ -5,14 +5,15 @@ from libs.datasets import dataset_utils
 from libs.datasets.timeseries import TimeseriesDataset
 
 
-class HHSTestingDataset(data_source.DataSource):
-    SOURCE_NAME = "HHSTesting"
+class CMSTestingDataset(data_source.DataSource):
+    SOURCE_NAME = "CMSTesting"
+    FILL_MISSING_STATE_LEVEL_DATA = False
 
-    DATA_PATH = "data/testing-hhs/timeseries-common.csv"
+    DATA_PATH = "data/testing-cms/timeseries-common.csv"
 
     INDEX_FIELD_MAP = {f: f for f in TimeseriesDataset.INDEX_FIELDS}
 
-    COMMON_FIELD_MAP = {f: f for f in {CommonFields.NEGATIVE_TESTS, CommonFields.POSITIVE_TESTS,}}
+    COMMON_FIELD_MAP = {CommonFields.TEST_POSITIVITY: CommonFields.TEST_POSITIVITY}
 
     @classmethod
     def local(cls):

--- a/libs/datasets/sources/cms_testing_dataset.py
+++ b/libs/datasets/sources/cms_testing_dataset.py
@@ -19,5 +19,5 @@ class CMSTestingDataset(data_source.DataSource):
     def local(cls):
         data_root = dataset_utils.LOCAL_PUBLIC_DATA_PATH
         input_path = data_root / cls.DATA_PATH
-        data = common_df.read_csv(input_path).reset_index()
+        data = common_df.read_csv(input_path, set_index=False)
         return cls(data)

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -685,7 +685,15 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
     def join_columns(
         self, other: "MultiRegionTimeseriesDataset", replace: bool = False
     ) -> "MultiRegionTimeseriesDataset":
-        """Joins the timeseries columns in `other` with those in `self`."""
+        """Joins the timeseries columns in `other` with those in `self`.
+
+        Args:
+            other: The timeseries dataset to join with `self`. all columns except the "geo" columns
+                   will be joined into `self`.
+            replace: Whether to allow `other` to contain columns that already exist in `self`.
+                     If set to True, the existing columns will be replaced. Else, an error will
+                     be thrown.
+        """
         if not other.latest_data.empty:
             raise NotImplementedError("No support for joining other with latest_data")
         other_df = other.data_with_fips.set_index([CommonFields.LOCATION_ID, CommonFields.DATE])

--- a/libs/test_positivity.py
+++ b/libs/test_positivity.py
@@ -97,7 +97,8 @@ class PassThruMethod(Method):
 
 
 TEST_POSITIVITY_METHODS = (
-    PassThruMethod("passthru_testPositivity", CommonFields.TEST_POSITIVITY),
+    # HACK: For now we assume TEST_POSITIVITY came from CMS and use that as the name that gets plumbed into provenance.
+    PassThruMethod("CMSTesting", CommonFields.TEST_POSITIVITY),
     DivisionMethod(
         "positiveTestsViral_totalTestsViral",
         CommonFields.POSITIVE_TESTS_VIRAL,

--- a/libs/test_positivity.py
+++ b/libs/test_positivity.py
@@ -242,4 +242,6 @@ def run_and_maybe_join_columns(
         return mrts
     else:
         # We overwrite the test_positivity column if it exists.
-        return mrts.join_columns(test_positivity_results.test_positivity, replace=True)
+        return mrts.drop_column_if_present(CommonFields.TEST_POSITIVITY).join_columns(
+            test_positivity_results.test_positivity
+        )

--- a/libs/test_positivity.py
+++ b/libs/test_positivity.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 import dataclasses
 import pathlib
 from itertools import chain
@@ -21,35 +22,83 @@ from libs.datasets.timeseries import MultiRegionTimeseriesDataset
 _log = structlog.get_logger()
 
 
-@dataclasses.dataclass
-class Method:
+class Method(ABC):
     """A method of calculating test positivity"""
 
-    name: str
-    numerator: FieldName
-    denominator: FieldName
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        pass
 
     @property
+    @abstractmethod
     def columns(self) -> Set[FieldName]:
-        return {self.numerator, self.denominator}
+        pass
 
-    def calculate(self, delta_df: pd.DataFrame) -> pd.DataFrame:
+    @abstractmethod
+    def calculate(self, df: pd.DataFrame, delta_df: pd.DataFrame) -> pd.DataFrame:
         """Calculate a DataFrame with LOCATION_ID index and DATE columns.
 
         Args:
-            delta_df: DataFrame with rows having MultiIndex of [VARIABLE, LOCATION_ID] and columns with DATE
+            df: DataFrame with rows having MultiIndex of [VARIABLE, LOCATION_ID] and columns with DATE
                 index. Must contain at least one real value for each of self.columns.
+            delta_df: DataFrame with rows having MultiIndex of [VARIABLE, LOCATION_ID] and columns with DATE
+                index. Values are 7-day deltas. Must contain at least one real value for each of self.columns.
         """
+        pass
+
+
+@dataclasses.dataclass
+class DivisionMethod(Method):
+    """A method of calculating test positivity by dividing a numerator by a denominator"""
+
+    _name: str
+    _numerator: FieldName
+    _denominator: FieldName
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def columns(self) -> Set[FieldName]:
+        return {self._numerator, self._denominator}
+
+    def calculate(self, df: pd.DataFrame, delta_df: pd.DataFrame) -> pd.DataFrame:
         assert delta_df.columns.names == [CommonFields.DATE]
         assert delta_df.index.names == [PdFields.VARIABLE, CommonFields.LOCATION_ID]
         # delta_df has the field name as the first level of the index. delta_df.loc[field, :] returns a
         # DataFrame without the field label so operators such as `/` are calculated for each
         # region/state and date.
-        return delta_df.loc[self.numerator, :] / delta_df.loc[self.denominator, :]
+        return delta_df.loc[self._numerator, :] / delta_df.loc[self._denominator, :]
+
+
+@dataclasses.dataclass
+class PassThruMethod(Method):
+    """A method of calculating test positivity by passing through a column directly"""
+
+    _name: str
+    _column: FieldName
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def columns(self) -> Set[FieldName]:
+        return {self._column}
+
+    def calculate(self, df: pd.DataFrame, delta_df: pd.DataFrame) -> pd.DataFrame:
+        assert df.columns.names == [CommonFields.DATE]
+        assert df.index.names == [PdFields.VARIABLE, CommonFields.LOCATION_ID]
+        # df has the field name as the first level of the index. delta_df.loc[field, :] returns a
+        # DataFrame without the field label
+        return df.loc[self._column, :]
 
 
 TEST_POSITIVITY_METHODS = (
-    Method(
+    PassThruMethod("passthru_testPositivity", CommonFields.TEST_POSITIVITY),
+    DivisionMethod(
         "positiveTestsViral_totalTestsViral",
         CommonFields.POSITIVE_TESTS_VIRAL,
         CommonFields.TOTAL_TESTS_VIRAL,
@@ -115,19 +164,23 @@ class AllMethods:
             .reindex(columns=input_date_range)
             .rename_axis(columns=CommonFields.DATE)
         )
-        # This calculates the difference only when the cumulative value is a real value `diff_days` apart.
-        # It looks like our input data has few or no holes so this works well enough.
-        diff_df = input_wide.diff(periods=diff_days, axis=1)
 
         methods_with_data = AllMethods._methods_with_columns_available(
-            methods, diff_df.index.get_level_values(PdFields.VARIABLE).unique()
+            methods, input_wide.index.get_level_values(PdFields.VARIABLE).unique()
         )
         if not methods_with_data:
             raise NoColumnsWithDataException()
 
+        # This calculates the difference only when the cumulative value is a real value `diff_days` apart.
+        # It looks like our input data has few or no holes so this works well enough.
+        diff_df = input_wide.diff(periods=diff_days, axis=1)
+
         all_wide = (
             pd.concat(
-                {method.name: method.calculate(diff_df) for method in methods_with_data},
+                {
+                    method.name: method.calculate(input_wide, diff_df)
+                    for method in methods_with_data
+                },
                 names=[PdFields.VARIABLE],
             )
             .reorder_levels([CommonFields.LOCATION_ID, PdFields.VARIABLE])
@@ -188,4 +241,5 @@ def run_and_maybe_join_columns(
         log.exception("test_positivity failed")
         return mrts
     else:
-        return mrts.join_columns(test_positivity_results.test_positivity)
+        # We overwrite the test_positivity column if it exists.
+        return mrts.join_columns(test_positivity_results.test_positivity, replace=True)

--- a/libs/top_level_metrics.py
+++ b/libs/top_level_metrics.py
@@ -22,7 +22,8 @@ CONTACT_TRACERS_PER_CASE = 5
 RT_TRUNCATION_DAYS = 7
 
 
-MAX_METRIC_LOOKBACK_DAYS = 7
+# CMS and HHS testing data can both lag by more than 7 days. Let's use it unless it's 2 weeks old.
+MAX_METRIC_LOOKBACK_DAYS = 13
 
 
 EMPTY_TS = pd.Series([], dtype="float64")

--- a/test/combined_dataset_test.py
+++ b/test/combined_dataset_test.py
@@ -59,8 +59,8 @@ def test_combined_county_has_some_data(fips):
     assert latest.get_record_for_fips(fips=fips)[CommonFields.DEATHS] > 1
 
 
-# Check some counties picked arbitrarily: (Marion County, IN)/18097 and (Harris County, TX)/48201
-@pytest.mark.parametrize("fips", ["18097", "48201"])
+# Check some counties picked arbitrarily: (Orange County, CA)/06059 and (Harris County, TX)/48201
+@pytest.mark.parametrize("fips", ["06059", "48201"])
 def test_combined_county_has_some_timeseries_data(fips):
     region = Region.from_fips(fips)
     latest = combined_datasets.load_us_timeseries_dataset().get_one_region(region)

--- a/test/libs/api_v2_pipeline_test.py
+++ b/test/libs/api_v2_pipeline_test.py
@@ -43,7 +43,9 @@ def il_regional_input_empty_test_positivity_column(rt_dataset, icu_dataset):
         )
     )
 
-    regional_data = regional_data.join_columns(empty_test_positivity, replace=True)
+    regional_data = regional_data.drop_column_if_present(CommonFields.TEST_POSITIVITY).join_columns(
+        empty_test_positivity
+    )
     return api_v2_pipeline.RegionalInput.from_region_and_model_output(
         region, regional_data, rt_dataset, icu_dataset
     )

--- a/test/libs/api_v2_pipeline_test.py
+++ b/test/libs/api_v2_pipeline_test.py
@@ -43,7 +43,7 @@ def il_regional_input_empty_test_positivity_column(rt_dataset, icu_dataset):
         )
     )
 
-    regional_data = regional_data.join_columns(empty_test_positivity)
+    regional_data = regional_data.join_columns(empty_test_positivity, replace=True)
     return api_v2_pipeline.RegionalInput.from_region_and_model_output(
         region, regional_data, rt_dataset, icu_dataset
     )

--- a/test/libs/datasets/sources/covid_county_data_test.py
+++ b/test/libs/datasets/sources/covid_county_data_test.py
@@ -14,9 +14,9 @@ pytestmark = pytest.mark.filterwarnings("error")
 
 def test_fix_tests_and_cases():
     df = read_csv_and_index_fips_date(
-        "fips,date,negative_tests,positive_tests,total_tests,cases\n"
-        "97123,2020-04-01,9,1,10,1\n"
-        "97123,2020-04-02,,,20,2\n"
+        "fips,state,date,negative_tests,positive_tests,total_tests,cases\n"
+        "97123,,2020-04-01,9,1,10,1\n"
+        "97123,,2020-04-02,,,20,2\n"
     ).reset_index()
 
     result_df, provenance = CovidCountyDataDataSource.synthesize_test_metrics(df)
@@ -43,9 +43,9 @@ def test_fix_tests_and_cases():
 
 def test_fix_missing_neg():
     df = read_csv_and_index_fips_date(
-        "fips,date,negative_tests,positive_tests,total_tests,cases\n"
-        "97123,2020-04-01,9,1,10,1\n"
-        "97123,2020-04-02,,3,20,2\n"
+        "fips,state,date,negative_tests,positive_tests,total_tests,cases\n"
+        "97123,,2020-04-01,9,1,10,1\n"
+        "97123,,2020-04-02,,3,20,2\n"
     ).reset_index()
 
     result_df, provenance = CovidCountyDataDataSource.synthesize_test_metrics(df)
@@ -72,10 +72,10 @@ def test_fix_missing_neg():
 
 def test_fix_missing_pos():
     df = read_csv_and_index_fips_date(
-        "fips,date,negative_tests,positive_tests,total_tests,cases\n"
-        "97123,2020-04-01,9,1,10,1\n"
-        "97123,2020-04-02,17,,20,2\n"
-        "97123,2020-04-03,26,4,30,4\n"
+        "fips,state,date,negative_tests,positive_tests,total_tests,cases\n"
+        "97123,,2020-04-01,9,1,10,1\n"
+        "97123,,2020-04-02,17,,20,2\n"
+        "97123,,2020-04-03,26,4,30,4\n"
     ).reset_index()
 
     result_df, provenance = CovidCountyDataDataSource.synthesize_test_metrics(df)

--- a/test/libs/test_positivity_test.py
+++ b/test/libs/test_positivity_test.py
@@ -7,7 +7,7 @@ from covidactnow.datapublic.common_fields import CommonFields
 
 from libs.datasets import timeseries
 from libs.test_positivity import AllMethods
-from libs.test_positivity import Method
+from libs.test_positivity import DivisionMethod
 from libs import test_positivity
 from test.libs.datasets.timeseries_test import assert_combined_like
 
@@ -35,8 +35,8 @@ def test_basic():
         )
     )
     methods = [
-        Method("method1", CommonFields.POSITIVE_TESTS_VIRAL, CommonFields.TOTAL_TESTS),
-        Method("method2", CommonFields.POSITIVE_TESTS, CommonFields.TOTAL_TESTS),
+        DivisionMethod("method1", CommonFields.POSITIVE_TESTS_VIRAL, CommonFields.TOTAL_TESTS),
+        DivisionMethod("method2", CommonFields.POSITIVE_TESTS, CommonFields.TOTAL_TESTS),
     ]
     all_methods = AllMethods.run(ts, methods, 3, 14)
 
@@ -88,8 +88,8 @@ def test_recent_days():
         )
     )
     methods = [
-        Method("method1", CommonFields.POSITIVE_TESTS_VIRAL, CommonFields.TOTAL_TESTS),
-        Method("method2", CommonFields.POSITIVE_TESTS, CommonFields.TOTAL_TESTS),
+        DivisionMethod("method1", CommonFields.POSITIVE_TESTS_VIRAL, CommonFields.TOTAL_TESTS),
+        DivisionMethod("method2", CommonFields.POSITIVE_TESTS, CommonFields.TOTAL_TESTS),
     ]
     all_methods = AllMethods.run(ts, methods, diff_days=1, recent_days=2)
 
@@ -149,9 +149,11 @@ def test_missing_column_for_one_method():
         )
     )
     methods = [
-        Method("method1", CommonFields.POSITIVE_TESTS_VIRAL, CommonFields.TOTAL_TESTS),
-        Method("method2", CommonFields.POSITIVE_TESTS, CommonFields.TOTAL_TESTS),
-        Method("method3", CommonFields.POSITIVE_TESTS, CommonFields.TOTAL_TESTS_PEOPLE_VIRAL),
+        DivisionMethod("method1", CommonFields.POSITIVE_TESTS_VIRAL, CommonFields.TOTAL_TESTS),
+        DivisionMethod("method2", CommonFields.POSITIVE_TESTS, CommonFields.TOTAL_TESTS),
+        DivisionMethod(
+            "method3", CommonFields.POSITIVE_TESTS, CommonFields.TOTAL_TESTS_PEOPLE_VIRAL
+        ),
     ]
     assert (
         AllMethods.run(ts, methods, diff_days=1, recent_days=4)
@@ -172,9 +174,11 @@ def test_missing_columns_for_all_tests():
         )
     )
     methods = [
-        Method("method1", CommonFields.POSITIVE_TESTS_VIRAL, CommonFields.TOTAL_TESTS),
-        Method("method2", CommonFields.POSITIVE_TESTS, CommonFields.TOTAL_TESTS),
-        Method("method3", CommonFields.POSITIVE_TESTS, CommonFields.TOTAL_TESTS_PEOPLE_VIRAL),
+        DivisionMethod("method1", CommonFields.POSITIVE_TESTS_VIRAL, CommonFields.TOTAL_TESTS),
+        DivisionMethod("method2", CommonFields.POSITIVE_TESTS, CommonFields.TOTAL_TESTS),
+        DivisionMethod(
+            "method3", CommonFields.POSITIVE_TESTS, CommonFields.TOTAL_TESTS_PEOPLE_VIRAL
+        ),
     ]
     with pytest.raises(test_positivity.NoMethodsWithRelevantColumns):
         AllMethods.run(ts, methods, diff_days=1, recent_days=4)
@@ -195,7 +199,7 @@ def test_column_present_with_no_data():
     ts_df[CommonFields.POSITIVE_TESTS] = pd.NA
     ts = timeseries.MultiRegionTimeseriesDataset.from_timeseries_df(ts_df)
     methods = [
-        Method("method2", CommonFields.POSITIVE_TESTS, CommonFields.TOTAL_TESTS),
+        DivisionMethod("method2", CommonFields.POSITIVE_TESTS, CommonFields.TOTAL_TESTS),
     ]
     with pytest.raises(test_positivity.NoColumnsWithDataException):
         AllMethods.run(ts, methods, diff_days=1, recent_days=1)
@@ -216,7 +220,7 @@ def test_all_columns_na():
     ts_df[CommonFields.POSITIVE_TESTS] = pd.NA
     ts = timeseries.MultiRegionTimeseriesDataset.from_timeseries_df(ts_df)
     methods = [
-        Method("method2", CommonFields.POSITIVE_TESTS, CommonFields.TOTAL_TESTS),
+        DivisionMethod("method2", CommonFields.POSITIVE_TESTS, CommonFields.TOTAL_TESTS),
     ]
     with pytest.raises(test_positivity.NoRealTimeseriesValuesException):
         AllMethods.run(ts, methods, diff_days=1, recent_days=1)

--- a/test/libs/top_level_metrics_test.py
+++ b/test/libs/top_level_metrics_test.py
@@ -342,7 +342,7 @@ def test_lookback_days():
     data = _build_metrics_df(
         f"2020-08-12,36,10,0.1,0.06,{prev_rt},{prev_rt_ci90}\n"
         f"2020-08-13,36,10,0.1,0.06,,\n"
-        "2020-08-20,,,,,,\n"
+        "2020-08-26,,,,,,\n"
     )
     metrics = top_level_metrics.calculate_latest_metrics(data, None)
     assert not metrics.caseDensity


### PR DESCRIPTION
* Adds CMSTesting dataset.
* Modifies Valorum dataset to drop test data from states we don't trust.
* Adds a `PassThruMethod` to test_positivity.py that lets us use the `test_positivity` column as-is.
