### PR TITLE
Test positivity provenance in API followup

### DIFF
--- a/api/can_api_definition.py
+++ b/api/can_api_definition.py
@@ -81,6 +81,7 @@ class TestPositivityRatioMethod(GetByValueMixin, enum.Enum):
 
     HHSTesting = "HHSTesting"
     VALORUM = "Valorum"
+    COVID_TRACKING = "covid_tracking"
     OTHER = "other"
 
 

--- a/libs/top_level_metrics.py
+++ b/libs/top_level_metrics.py
@@ -116,7 +116,7 @@ def _lookup_test_positivity_method(
     if positive_tests_provenance and positive_tests_provenance == negative_tests_provenance:
         method = TestPositivityRatioMethod.get(positive_tests_provenance)
     if method is None:
-        log.info(
+        log.debug(
             "Unable to find TestPositivityRatioMethod",
             positive_tests_provenance=positive_tests_provenance,
             negative_tests_provenance=negative_tests_provenance,


### PR DESCRIPTION
Two little things that didn't get into https://github.com/covid-projections/covid-data-model/pull/737 ...

* add TestPositivityRatioMethod.COVID_TRACKING
* downgrade noisy log from info to debug