### PR TITLE
rm MultiRegionTimeseriesDataset.from_combined_dataframe

### DIFF
--- a/libs/datasets/statistical_areas.py
+++ b/libs/datasets/statistical_areas.py
@@ -24,15 +24,11 @@ class CountyToCBSAAggregator:
 
     def aggregate(self, dataset_in: MultiRegionTimeseriesDataset) -> MultiRegionTimeseriesDataset:
         """Returns a dataset of CBSA regions, created by aggregating counties in the input data."""
-        return MultiRegionTimeseriesDataset.from_combined_dataframe(
-            pd.concat(
-                [
-                    self._aggregate_fips_df(dataset_in.data_with_fips, groupby_date=True),
-                    # No need to reset latest_data_with_fips LOCATION_ID index because FIPS is used.
-                    self._aggregate_fips_df(dataset_in.latest_data_with_fips, groupby_date=False),
-                ],
-                ignore_index=True,
-            )
+        return MultiRegionTimeseriesDataset.from_timeseries_df(
+            self._aggregate_fips_df(dataset_in.data_with_fips, groupby_date=True)
+        ).append_latest_df(
+            # No need to reset latest_data_with_fips LOCATION_ID index because FIPS is used.
+            self._aggregate_fips_df(dataset_in.latest_data_with_fips, groupby_date=False),
         )
 
     @staticmethod

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -601,20 +601,23 @@ def _build_one_column_multiregion_dataset(
 ):
 
     dates = pd.date_range(start_date, periods=len(values), freq="D")
-    rows = []
+    ts_rows = []
 
     for i, value in enumerate(values):
-        rows.append({CommonFields.LOCATION_ID: location_id, "date": dates[i], column: value})
+        ts_rows.append({CommonFields.LOCATION_ID: location_id, "date": dates[i], column: value})
+    timeseries_df = pd.DataFrame(ts_rows)
 
     # Find last non nan value, which simulates building the latest value entry
     for value in reversed(values):
         if not pd.isna(value) and value is not None:
             break
+    latest_df = pd.DataFrame(
+        [{CommonFields.LOCATION_ID: location_id, "date": pd.NaT, column: value}]
+    )
 
-    rows.append({CommonFields.LOCATION_ID: location_id, "date": pd.NaT, column: value})
-
-    df = pd.DataFrame(rows)
-    return timeseries.MultiRegionTimeseriesDataset.from_combined_dataframe(df)
+    return timeseries.MultiRegionTimeseriesDataset.from_timeseries_df(
+        timeseries_df
+    ).append_latest_df(latest_df)
 
 
 def test_remove_outliers():


### PR DESCRIPTION
This PR removes `MultiRegionTimeseriesDataset.from_combined_dataframe` which is useful for parsing a CSV with metrics in columns but wasn't otherwise useful. Removing it reduces the number of ways that a `MultiRegionTimeseriesDataset` can be created.