### PR TITLE
rm combined_df property

### DIFF
--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -421,13 +421,6 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
         _add_fips_if_missing(data_copy)
         return data_copy.set_index(CommonFields.LOCATION_ID)
 
-    @property
-    def combined_df(self) -> pd.DataFrame:
-        """"A DataFrame with timeseries data and latest data (with DATE=NaT) together."""
-        return pd.concat(
-            [self.data_with_fips, self.latest_data_with_fips.reset_index()], ignore_index=True
-        )
-
     @classmethod
     def load_csv(cls, path_or_buf: Union[pathlib.Path, TextIO]):
         return MultiRegionTimeseriesDataset.from_csv(path_or_buf)
@@ -676,7 +669,10 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
         Args:
             path: Path to write to.
         """
-        combined = self.combined_df
+        # A DataFrame with timeseries data and latest data (with DATE=NaT) together
+        combined = pd.concat(
+            [self.data_with_fips, self.latest_data_with_fips.reset_index()], ignore_index=True
+        )
         assert combined[CommonFields.LOCATION_ID].notna().all()
         common_df.write_csv(
             combined, path, structlog.get_logger(), [CommonFields.LOCATION_ID, CommonFields.DATE]

--- a/test/libs/datasets/combined_dataset_utils_test.py
+++ b/test/libs/datasets/combined_dataset_utils_test.py
@@ -7,7 +7,7 @@ from libs.datasets import combined_datasets
 from libs.datasets.latest_values_dataset import LatestValuesDataset
 from libs.pipeline import Region
 from libs.qa.common_df_diff import DatasetDiff
-from test.libs.datasets.timeseries_test import assert_combined_like
+from test.libs.datasets.timeseries_test import assert_dataset_like
 
 
 def test_persist_and_load_dataset(tmp_path, nyc_fips):
@@ -42,4 +42,4 @@ def test_update_and_load(tmp_path: pathlib.Path, nyc_fips, nyc_region):
     timeseries_loaded = combined_datasets.load_us_timeseries_dataset(pointer_directory=tmp_path)
     latest_loaded = combined_datasets.load_us_latest_dataset(pointer_directory=tmp_path)
     assert latest_loaded.get_record_for_fips(nyc_fips) == latest_nyc_record
-    assert_combined_like(timeseries_loaded, multiregion_timeseries_nyc, drop_na_timeseries=True)
+    assert_dataset_like(timeseries_loaded, multiregion_timeseries_nyc, drop_na_timeseries=True)

--- a/test/libs/test_positivity_test.py
+++ b/test/libs/test_positivity_test.py
@@ -9,7 +9,7 @@ from libs.datasets import timeseries
 from libs.test_positivity import AllMethods
 from libs.test_positivity import Method
 from libs import test_positivity
-from test.libs.datasets.timeseries_test import assert_combined_like
+from test.libs.datasets.timeseries_test import assert_dataset_like
 
 
 def _parse_wide_dates(csv_str: str) -> pd.DataFrame:
@@ -61,7 +61,7 @@ def test_basic():
             "iso1:us#iso2:tx,test_positivity,method1\n"
         )
     )
-    assert_combined_like(all_methods.test_positivity, expected_positivity)
+    assert_dataset_like(all_methods.test_positivity, expected_positivity)
 
     positivity_provenance = all_methods.test_positivity.provenance
     # Use loc[...].at[...] as work-around for https://github.com/pandas-dev/pandas/issues/26989
@@ -118,7 +118,7 @@ def test_recent_days():
             "iso1:us#iso2:tx,test_positivity,method1\n"
         )
     )
-    assert_combined_like(all_methods.test_positivity, expected_positivity)
+    assert_dataset_like(all_methods.test_positivity, expected_positivity)
     # Use loc[...].at[...] as work-around for https://github.com/pandas-dev/pandas/issues/26989
     positivity_provenance = all_methods.test_positivity.provenance
     assert positivity_provenance.loc["iso1:us#iso2:as"].to_dict() == {


### PR DESCRIPTION
* rm combined_df property
* rename assert_combined_like to assert_dataset_like
* add drop_na_latest to fix tests that depended on combined_df creating columns

This follows up on https://github.com/covid-projections/covid-data-model/pull/784