### PR TITLE
Un-revert provenance commit and fix series name.

### DIFF
--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -370,6 +370,16 @@ def _index_latest_df(
         return latest_df_with_index.reindex(index=all_locations)
 
 
+# An empty pd.Series with the structure expected for the provenance series. Use this when a dataset
+# does not have provenance information. Make a copy for an extra level of protection against
+# unrelated objects sharing common objects.
+_EMPTY_PROVENANCE_SERIES = pd.Series(
+    [],
+    dtype="str",
+    index=pd.MultiIndex.from_tuples([], names=[CommonFields.LOCATION_ID, PdFields.VARIABLE]),
+)
+
+
 @final
 @dataclass(frozen=True)
 class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
@@ -391,7 +401,7 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
     latest_data: pd.DataFrame
 
     # `provenance` is an array of str with a MultiIndex with names LOCATION_ID and VARIABLE.
-    provenance: Optional[pd.Series] = None
+    provenance: pd.Series
 
     @property
     def dataset_type(self) -> DatasetType:
@@ -447,7 +457,11 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
         empty_latest_df = pd.DataFrame([], index=pd.Index([], name=CommonFields.LOCATION_ID))
         if CommonFields.FIPS in timeseries_df.columns:
             timeseries_df = timeseries_df.drop(columns=[CommonFields.FIPS])
-        return MultiRegionTimeseriesDataset(timeseries_df, empty_latest_df, provenance=provenance)
+        if provenance is None:
+            provenance = _EMPTY_PROVENANCE_SERIES.copy()
+        return MultiRegionTimeseriesDataset(
+            timeseries_df, empty_latest_df, provenance=provenance.sort_index()
+        )
 
     def append_latest_df(self, latest_df: pd.DataFrame) -> "MultiRegionTimeseriesDataset":
         assert latest_df.index.names == [None]
@@ -476,15 +490,17 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
 
     def append_provenance_df(self, provenance_df: pd.DataFrame) -> "MultiRegionTimeseriesDataset":
         """Returns a new object containing data in self and given provenance information."""
-        if self.provenance is not None:
+        if not self.provenance.empty:
             raise NotImplementedError("TODO(tom): add support for merging provenance data")
         assert provenance_df.index.names == [None]
         assert CommonFields.LOCATION_ID in provenance_df.columns
         assert PdFields.VARIABLE in provenance_df.columns
         assert PdFields.PROVENANCE in provenance_df.columns
+        # Make a sorted series. The order doesn't matter and sorting makes the order depend only on
+        # what is represented, not the order it appears in the input.
         provenance_series = provenance_df.set_index([CommonFields.LOCATION_ID, PdFields.VARIABLE])[
             PdFields.PROVENANCE
-        ]
+        ].sort_index()
         return MultiRegionTimeseriesDataset(
             self.data, latest_data=self.latest_data, provenance=provenance_series
         )
@@ -549,19 +565,23 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
         assert self.data.index.is_unique
         assert self.data.index.is_monotonic_increasing
         assert self.latest_data.index.names == [CommonFields.LOCATION_ID]
-        if self.provenance is not None:
-            assert isinstance(self.provenance, pd.Series)
-            assert self.provenance.index.names == [CommonFields.LOCATION_ID, PdFields.VARIABLE]
+        assert isinstance(self.provenance, pd.Series)
+        assert self.provenance.index.names == [CommonFields.LOCATION_ID, PdFields.VARIABLE]
 
     def append_regions(
         self, other: "MultiRegionTimeseriesDataset"
     ) -> "MultiRegionTimeseriesDataset":
-        return MultiRegionTimeseriesDataset.from_timeseries_df(
-            pd.concat([self.data, other.data], ignore_index=True)
-        ).append_latest_df(
-            pd.concat(
-                [self.latest_data.reset_index(), other.latest_data.reset_index()], ignore_index=True
-            )
+        timeseries_df = pd.concat([self.data, other.data], ignore_index=True)
+        latest_df = pd.concat(
+            [self.latest_data.reset_index(), other.latest_data.reset_index()], ignore_index=True,
+        )
+        provenance_df = pd.concat(
+            [self.provenance.reset_index(), other.provenance.reset_index()], ignore_index=True,
+        )
+        return (
+            MultiRegionTimeseriesDataset.from_timeseries_df(timeseries_df)
+            .append_latest_df(latest_df)
+            .append_provenance_df(provenance_df)
         )
 
     def get_one_region(self, region: Region) -> OneRegionTimeseriesDataset:
@@ -577,8 +597,6 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
 
     def _location_id_provenance_dict(self, location_id: str) -> dict:
         """Returns the provenance dict of a location_id."""
-        if self.provenance is None:
-            return {}
         try:
             provenance_series = self.provenance.loc[location_id]
         except KeyError:
@@ -631,12 +649,9 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
         latest_df = self.latest_data.loc[
             self.latest_data.index.get_level_values(CommonFields.LOCATION_ID).isin(location_ids), :
         ].reset_index()
-        if self.provenance is not None:
-            provenance = self.provenance[
-                self.provenance.index.get_level_values(CommonFields.LOCATION_ID).isin(location_ids)
-            ]
-        else:
-            provenance = None
+        provenance = self.provenance[
+            self.provenance.index.get_level_values(CommonFields.LOCATION_ID).isin(location_ids)
+        ]
         return latest_df, provenance
 
     def groupby_region(self) -> pandas.core.groupby.generic.DataFrameGroupBy:
@@ -651,7 +666,9 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
 
         This method exists for interim use when calling code that doesn't use MultiRegionTimeseriesDataset.
         """
-        return TimeseriesDataset(self.data_with_fips, provenance=self.provenance)
+        return TimeseriesDataset(
+            self.data_with_fips, provenance=None if self.provenance.empty else self.provenance
+        )
 
     def to_csv(self, path: pathlib.Path):
         """Persists timeseries to CSV.
@@ -664,7 +681,7 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
         common_df.write_csv(
             combined, path, structlog.get_logger(), [CommonFields.LOCATION_ID, CommonFields.DATE]
         )
-        if self.provenance is not None:
+        if not self.provenance.empty:
             provenance_path = str(path).replace(".csv", "-provenance.csv")
             self.provenance.sort_index().rename(PdFields.PROVENANCE).to_csv(provenance_path)
 
@@ -718,13 +735,7 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
         #    _log.exception(f"Comparing df {self_common_geo_columns} to {other_common_geo_columns}")
         #    raise
         combined_df = pd.concat([self_df, other_df[list(other_ts_columns)]], axis=1)
-        if self.provenance is not None:
-            if other.provenance is not None:
-                combined_provenance = pd.concat([self.provenance, other.provenance])
-            else:
-                combined_provenance = self.provenance
-        else:
-            combined_provenance = other.provenance
+        combined_provenance = pd.concat([self.provenance, other.provenance])
         return MultiRegionTimeseriesDataset.from_timeseries_df(
             combined_df.reset_index(), provenance=combined_provenance,
         ).append_latest_df(self.latest_data.reset_index())

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -375,6 +375,7 @@ def _index_latest_df(
 # unrelated objects sharing common objects.
 _EMPTY_PROVENANCE_SERIES = pd.Series(
     [],
+    name=PdFields.PROVENANCE,
     dtype="str",
     index=pd.MultiIndex.from_tuples([], names=[CommonFields.LOCATION_ID, PdFields.VARIABLE]),
 )
@@ -548,6 +549,7 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
                 lambda i: (pipeline.fips_to_location_id(i[0]), i[1])
             )
             provenance.index.rename([CommonFields.LOCATION_ID, PdFields.VARIABLE], inplace=True)
+            provenance.rename(PdFields.PROVENANCE, inplace=True)
         else:
             provenance = None
 
@@ -567,6 +569,7 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
         assert self.latest_data.index.names == [CommonFields.LOCATION_ID]
         assert isinstance(self.provenance, pd.Series)
         assert self.provenance.index.names == [CommonFields.LOCATION_ID, PdFields.VARIABLE]
+        assert self.provenance.name == PdFields.PROVENANCE
 
     def append_regions(
         self, other: "MultiRegionTimeseriesDataset"

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -280,6 +280,8 @@ def test_append_regions():
             "iso1:us#fips:97111,,Bar County,county,3,\n"
             "iso1:us#fips:97222,,Foo County,county,,11\n"
         )
+    ).append_provenance_csv(
+        io.StringIO("location_id,variable,provenance\n" "iso1:us#fips:97111,m1,prov97111m1\n")
     )
     ts_cbsa = timeseries.MultiRegionTimeseriesDataset.from_csv(
         io.StringIO(
@@ -290,6 +292,8 @@ def test_append_regions():
             "iso1:us#cbsa:10100,,3\n"
             "iso1:us#cbsa:20200,,4\n"
         )
+    ).append_provenance_csv(
+        io.StringIO("location_id,variable,provenance\n" "iso1:us#cbsa:20200,m1,prov20200m2\n")
     )
     # Check that merge is symmetric
     ts_merged_1 = ts_fips.append_regions(ts_cbsa)
@@ -309,6 +313,12 @@ def test_append_regions():
             "iso1:us#fips:97222,2020-04-04,Foo County,county,,11\n"
             "iso1:us#fips:97111,,Bar County,county,3,\n"
             "iso1:us#fips:97222,,Foo County,county,,11\n"
+        )
+    ).append_provenance_csv(
+        io.StringIO(
+            "location_id,variable,provenance\n"
+            "iso1:us#fips:97111,m1,prov97111m1\n"
+            "iso1:us#cbsa:20200,m1,prov20200m2\n"
         )
     )
     assert_combined_like(ts_merged_1, ts_expected)
@@ -455,8 +465,8 @@ def test_join_columns():
         io.StringIO(
             "location_id,variable,provenance\n"
             "iso1:us#cbsa:10100,m1,ts110100prov\n"
-            "iso1:us#fips:97111,m1,ts197111prov\n"
             "iso1:us#cbsa:10100,m2,ts110100prov\n"
+            "iso1:us#fips:97111,m1,ts197111prov\n"
             "iso1:us#fips:97111,m2,ts197111prov\n"
         )
     )


### PR DESCRIPTION
This is mostly just un-reverting the  "MultiRegion append_regions preserves provenance" change.

The very small fix to it is in https://github.com/covid-projections/covid-data-model/pull/787/commits/5f38158d56b5f52a4ca79035c03ade3c05d9d071