### PR TITLE
Stop updating api v1

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -106,7 +106,6 @@ jobs:
 
     - name: Build API (run.sh .. .. execute_api)
       run: |
-        ./covid-data-model/run.sh ./covid-data-public /data/api-results-${{env.SNAPSHOT_ID}} execute_api
         ./covid-data-model/run.sh ./covid-data-public /data/api-results-${{env.SNAPSHOT_ID}} execute_api_v2
 
     - name: make and copy to local tmp directory


### PR DESCRIPTION
Stops running updates for api v1.  The existing files in /latest should still remain, meaning you will still be able to download the existing api, but it will no longer update.