### PR TITLE
MultiRegion more private attributes

### DIFF
--- a/libs/datasets/statistical_areas.py
+++ b/libs/datasets/statistical_areas.py
@@ -26,7 +26,7 @@ class CountyToCBSAAggregator:
         """Returns a dataset of CBSA regions, created by aggregating counties in the input data."""
         return MultiRegionTimeseriesDataset.from_timeseries_df(
             self._aggregate_fips_df(dataset_in.data_with_fips, groupby_date=True)
-        ).append_latest_df(
+        ).add_latest_df(
             # No need to reset latest_data_with_fips LOCATION_ID index because FIPS is used.
             self._aggregate_fips_df(dataset_in.latest_data_with_fips, groupby_date=False),
         )

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -384,7 +384,12 @@ _EMPTY_PROVENANCE_SERIES = pd.Series(
 @final
 @dataclass(frozen=True)
 class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
-    """A set of timeseries and constant values from any number of regions."""
+    """A set of timeseries and constant values from any number of regions.
+
+    Methods named `append_...` return a new object with more regions of data. Methods named `add_...` and
+    `join_...` return a new object with more data about the same regions, such as new metrics and provenance
+    information.
+    """
 
     # TODO(tom): rename to MultiRegionDataset
 
@@ -417,7 +422,11 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
 
     @property
     def latest_data_with_fips(self) -> pd.DataFrame:
-        """_latest_data with FIPS column and LOCATION_ID index, use `_latest_data` when FIPS is not need."""
+        """_latest_data with FIPS column and LOCATION_ID index.
+
+        TODO(tom): This data is usually accessed via OneRegionTimeseriesDataset. Retire this
+        property.
+        """
         data_copy = self._latest_data.reset_index()
         _add_fips_if_missing(data_copy)
         return data_copy.set_index(CommonFields.LOCATION_ID)
@@ -468,7 +477,7 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
 
         return MultiRegionTimeseriesDataset(self.data, latest_df, _provenance=self._provenance)
 
-    def append_provenance_csv(
+    def add_provenance_csv(
         self, path_or_buf: Union[pathlib.Path, TextIO]
     ) -> "MultiRegionTimeseriesDataset":
         df = pd.read_csv(path_or_buf)
@@ -510,7 +519,7 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
         if isinstance(path_or_buf, pathlib.Path):
             provenance_path = pathlib.Path(str(path_or_buf).replace(".csv", "-provenance.csv"))
             if provenance_path.exists():
-                dataset = dataset.append_provenance_csv(provenance_path)
+                dataset = dataset.add_provenance_csv(provenance_path)
         return dataset
 
     @staticmethod

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -452,7 +452,7 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
         provenance = _EMPTY_PROVENANCE_SERIES.copy()
         return MultiRegionTimeseriesDataset(timeseries_df, empty_latest_df, _provenance=provenance)
 
-    def append_latest_df(self, latest_df: pd.DataFrame) -> "MultiRegionTimeseriesDataset":
+    def add_latest_df(self, latest_df: pd.DataFrame) -> "MultiRegionTimeseriesDataset":
         assert latest_df.index.names == [None]
         assert CommonFields.LOCATION_ID in latest_df.columns
 
@@ -505,7 +505,7 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
 
         dataset = MultiRegionTimeseriesDataset.from_timeseries_df(timeseries_df)
         if not latest_df.empty:
-            dataset = dataset.append_latest_df(latest_df)
+            dataset = dataset.add_latest_df(latest_df)
 
         if isinstance(path_or_buf, pathlib.Path):
             provenance_path = pathlib.Path(str(path_or_buf).replace(".csv", "-provenance.csv"))
@@ -524,7 +524,7 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
 
         latest_df = latest.data.copy()
         _add_location_id(latest_df)
-        dataset = dataset.append_latest_df(latest_df)
+        dataset = dataset.add_latest_df(latest_df)
 
         if ts.provenance is not None:
             # Check that current index is as expected. Names will be fixed after remapping, below.
@@ -563,7 +563,7 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
         provenance = pd.concat([self._provenance, other._provenance])
         return (
             MultiRegionTimeseriesDataset.from_timeseries_df(timeseries_df)
-            .append_latest_df(latest_df)
+            .add_latest_df(latest_df)
             .add_provenance_series(provenance)
         )
 
@@ -604,7 +604,7 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
         latest_df, provenance = self._get_latest_and_provenance_for_locations(location_ids)
         return (
             MultiRegionTimeseriesDataset.from_timeseries_df(timeseries_df)
-            .append_latest_df(latest_df)
+            .add_latest_df(latest_df)
             .add_provenance_series(provenance)
         )
 
@@ -626,7 +626,7 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
 
         return (
             MultiRegionTimeseriesDataset.from_timeseries_df(ts_df)
-            .append_latest_df(latest_df)
+            .add_latest_df(latest_df)
             .add_provenance_series(provenance)
         )
 
@@ -686,7 +686,7 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
         ]
         return (
             MultiRegionTimeseriesDataset.from_timeseries_df(df)
-            .append_latest_df(latest_data)
+            .add_latest_df(latest_data)
             .add_provenance_series(provenance)
         )
 
@@ -730,7 +730,7 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
         combined_provenance = pd.concat([self._provenance, other._provenance])
         return (
             MultiRegionTimeseriesDataset.from_timeseries_df(combined_df.reset_index())
-            .append_latest_df(self._latest_data.reset_index())
+            .add_latest_df(self._latest_data.reset_index())
             .add_provenance_series(combined_provenance)
         )
 
@@ -792,7 +792,7 @@ def add_new_cases(timeseries: MultiRegionTimeseriesDataset) -> MultiRegionTimese
 
     new_timeseries = (
         MultiRegionTimeseriesDataset.from_timeseries_df(timeseries_df=df_copy)
-        .append_latest_df(latest_values)
+        .add_latest_df(latest_values)
         .add_provenance_series(timeseries._provenance)
     )
 
@@ -852,7 +852,7 @@ def drop_new_case_outliers(
     latest_values = _add_new_cases_to_latest(df_copy, timeseries._latest_data)
     new_timeseries = (
         MultiRegionTimeseriesDataset.from_timeseries_df(timeseries_df=df_copy)
-        .append_latest_df(latest_values)
+        .add_latest_df(latest_values)
         .add_provenance_series(timeseries._provenance)
     )
 

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -687,9 +687,7 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
     def drop_column_if_present(self, column: str) -> "MultiRegionTimeseriesDataset":
         """Drops the specified column from the timeseries if it exists"""
         df = self.data_with_fips.drop(column, axis="columns", errors="ignore")
-        latest_data = self.latest_data_with_fips.drop(
-            column, axis="columns", errors="ignore"
-        ).reset_index()
+        latest_data = self._latest_data.drop(column, axis="columns", errors="ignore").reset_index()
         provenance = self._provenance[
             self._provenance.index.get_level_values(PdFields.VARIABLE) != column
         ]

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -396,13 +396,13 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
     # be non-null in every row.
     data: pd.DataFrame
 
-    # `latest_data` contains columns from CommonFields and a LOCATION_ID index.
+    # `_latest_data` contains columns from CommonFields and a LOCATION_ID index.
     # If you need FIPS read from `latest_data_with_fips` so we can easily find code that depends on
     # the column.
-    latest_data: pd.DataFrame
+    _latest_data: pd.DataFrame
 
     # `provenance` is an array of str with a MultiIndex with names LOCATION_ID and VARIABLE.
-    provenance: pd.Series
+    _provenance: pd.Series
 
     @property
     def dataset_type(self) -> DatasetType:
@@ -417,8 +417,8 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
 
     @property
     def latest_data_with_fips(self) -> pd.DataFrame:
-        """latest_data with FIPS column and LOCATION_ID index, use `latest_data` when FIPS is not need."""
-        data_copy = self.latest_data.reset_index()
+        """_latest_data with FIPS column and LOCATION_ID index, use `_latest_data` when FIPS is not need."""
+        data_copy = self._latest_data.reset_index()
         _add_fips_if_missing(data_copy)
         return data_copy.set_index(CommonFields.LOCATION_ID)
 
@@ -443,19 +443,14 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
         return long
 
     @staticmethod
-    def from_timeseries_df(
-        timeseries_df: pd.DataFrame, provenance: Optional[pd.Series] = None
-    ) -> "MultiRegionTimeseriesDataset":
+    def from_timeseries_df(timeseries_df: pd.DataFrame) -> "MultiRegionTimeseriesDataset":
         assert timeseries_df.index.names == [None]
         assert CommonFields.LOCATION_ID in timeseries_df.columns
         empty_latest_df = pd.DataFrame([], index=pd.Index([], name=CommonFields.LOCATION_ID))
         if CommonFields.FIPS in timeseries_df.columns:
             timeseries_df = timeseries_df.drop(columns=[CommonFields.FIPS])
-        if provenance is None:
-            provenance = _EMPTY_PROVENANCE_SERIES.copy()
-        return MultiRegionTimeseriesDataset(
-            timeseries_df, empty_latest_df, provenance=provenance.sort_index()
-        )
+        provenance = _EMPTY_PROVENANCE_SERIES.copy()
+        return MultiRegionTimeseriesDataset(timeseries_df, empty_latest_df, _provenance=provenance)
 
     def append_latest_df(self, latest_df: pd.DataFrame) -> "MultiRegionTimeseriesDataset":
         assert latest_df.index.names == [None]
@@ -466,12 +461,12 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
         ts_locations = self.data[CommonFields.LOCATION_ID].unique()
         ts_locations.sort()
         latest_df = _index_latest_df(latest_df, ts_locations)
-        common_columns = set(latest_df.columns) & set(self.latest_data.columns)
+        common_columns = set(latest_df.columns) & set(self._latest_data.columns)
         if common_columns:
             warnings.warn(f"Common columns {common_columns}")
-        latest_df = pd.concat([self.latest_data, latest_df], axis=1)
+        latest_df = pd.concat([self._latest_data, latest_df], axis=1)
 
-        return MultiRegionTimeseriesDataset(self.data, latest_df, provenance=self.provenance)
+        return MultiRegionTimeseriesDataset(self.data, latest_df, _provenance=self._provenance)
 
     def append_provenance_csv(
         self, path_or_buf: Union[pathlib.Path, TextIO]
@@ -480,23 +475,18 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
         if PdFields.VALUE in df.columns:
             # Handle older CSV files that used 'value' header for provenance.
             df = df.rename(columns={PdFields.VALUE: PdFields.PROVENANCE})
-        return self.append_provenance_df(df)
+        series = df.set_index([CommonFields.LOCATION_ID, PdFields.VARIABLE])[PdFields.PROVENANCE]
+        return self.add_provenance_series(series)
 
-    def append_provenance_df(self, provenance_df: pd.DataFrame) -> "MultiRegionTimeseriesDataset":
+    def add_provenance_series(self, provenance: pd.Series) -> "MultiRegionTimeseriesDataset":
         """Returns a new object containing data in self and given provenance information."""
-        if not self.provenance.empty:
+        if not self._provenance.empty:
             raise NotImplementedError("TODO(tom): add support for merging provenance data")
-        assert provenance_df.index.names == [None]
-        assert CommonFields.LOCATION_ID in provenance_df.columns
-        assert PdFields.VARIABLE in provenance_df.columns
-        assert PdFields.PROVENANCE in provenance_df.columns
+
         # Make a sorted series. The order doesn't matter and sorting makes the order depend only on
         # what is represented, not the order it appears in the input.
-        provenance_series = provenance_df.set_index([CommonFields.LOCATION_ID, PdFields.VARIABLE])[
-            PdFields.PROVENANCE
-        ].sort_index()
         return MultiRegionTimeseriesDataset(
-            self.data, latest_data=self.latest_data, provenance=provenance_series
+            self.data, _latest_data=self._latest_data, _provenance=provenance.sort_index()
         )
 
     @staticmethod
@@ -530,9 +520,11 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
         """Converts legacy FIPS to new LOCATION_ID and calls `from_timeseries_df` to finish construction."""
         timeseries_df = ts.data.copy()
         _add_location_id(timeseries_df)
+        dataset = MultiRegionTimeseriesDataset.from_timeseries_df(timeseries_df)
 
         latest_df = latest.data.copy()
         _add_location_id(latest_df)
+        dataset = dataset.append_latest_df(latest_df)
 
         if ts.provenance is not None:
             # Check that current index is as expected. Names will be fixed after remapping, below.
@@ -543,15 +535,12 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
             )
             provenance.index.rename([CommonFields.LOCATION_ID, PdFields.VARIABLE], inplace=True)
             provenance.rename(PdFields.PROVENANCE, inplace=True)
-        else:
-            provenance = None
+            dataset = dataset.add_provenance_series(provenance)
 
         # TODO(tom): Either copy latest.provenance to its own series, blend with the timeseries
         # provenance (though some variable names are the same), or retire latest as a separate thing upstream.
 
-        return MultiRegionTimeseriesDataset.from_timeseries_df(
-            timeseries_df, provenance=provenance
-        ).append_latest_df(latest_df)
+        return dataset
 
     def __post_init__(self):
         # Some integrity checks
@@ -559,25 +548,23 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
         assert self.data[CommonFields.LOCATION_ID].notna().all()
         assert self.data.index.is_unique
         assert self.data.index.is_monotonic_increasing
-        assert self.latest_data.index.names == [CommonFields.LOCATION_ID]
-        assert isinstance(self.provenance, pd.Series)
-        assert self.provenance.index.names == [CommonFields.LOCATION_ID, PdFields.VARIABLE]
-        assert self.provenance.name == PdFields.PROVENANCE
+        assert self._latest_data.index.names == [CommonFields.LOCATION_ID]
+        assert isinstance(self._provenance, pd.Series)
+        assert self._provenance.index.names == [CommonFields.LOCATION_ID, PdFields.VARIABLE]
+        assert self._provenance.name == PdFields.PROVENANCE
 
     def append_regions(
         self, other: "MultiRegionTimeseriesDataset"
     ) -> "MultiRegionTimeseriesDataset":
         timeseries_df = pd.concat([self.data, other.data], ignore_index=True)
         latest_df = pd.concat(
-            [self.latest_data.reset_index(), other.latest_data.reset_index()], ignore_index=True,
+            [self._latest_data.reset_index(), other._latest_data.reset_index()], ignore_index=True,
         )
-        provenance_df = pd.concat(
-            [self.provenance.reset_index(), other.provenance.reset_index()], ignore_index=True,
-        )
+        provenance = pd.concat([self._provenance, other._provenance])
         return (
             MultiRegionTimeseriesDataset.from_timeseries_df(timeseries_df)
             .append_latest_df(latest_df)
-            .append_provenance_df(provenance_df)
+            .add_provenance_series(provenance)
         )
 
     def get_one_region(self, region: Region) -> OneRegionTimeseriesDataset:
@@ -594,7 +581,7 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
     def _location_id_provenance_dict(self, location_id: str) -> dict:
         """Returns the provenance dict of a location_id."""
         try:
-            provenance_series = self.provenance.loc[location_id]
+            provenance_series = self._provenance.loc[location_id]
         except KeyError:
             return {}
         else:
@@ -603,7 +590,7 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
     def _location_id_latest_dict(self, location_id: str) -> dict:
         """Returns the latest values dict of a location_id."""
         try:
-            latest_row = self.latest_data.loc[location_id, :]
+            latest_row = self._latest_data.loc[location_id, :]
         except KeyError:
             latest_row = pd.Series([], dtype=object)
         return latest_row.where(pd.notnull(latest_row), None).to_dict()
@@ -615,9 +602,11 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
     def get_locations_subset(self, location_ids: Sequence[str]) -> "MultiRegionTimeseriesDataset":
         timeseries_df = self.data.loc[self.data[CommonFields.LOCATION_ID].isin(location_ids), :]
         latest_df, provenance = self._get_latest_and_provenance_for_locations(location_ids)
-        return MultiRegionTimeseriesDataset.from_timeseries_df(
-            timeseries_df, provenance=provenance
-        ).append_latest_df(latest_df)
+        return (
+            MultiRegionTimeseriesDataset.from_timeseries_df(timeseries_df)
+            .append_latest_df(latest_df)
+            .add_provenance_series(provenance)
+        )
 
     def get_counties(
         self, after: Optional[datetime.datetime] = None
@@ -635,18 +624,20 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
         # metrics which no longer have real values are excluded.
         latest_df, provenance = self._get_latest_and_provenance_for_locations(location_ids)
 
-        return MultiRegionTimeseriesDataset.from_timeseries_df(
-            ts_df, provenance=provenance
-        ).append_latest_df(latest_df)
+        return (
+            MultiRegionTimeseriesDataset.from_timeseries_df(ts_df)
+            .append_latest_df(latest_df)
+            .add_provenance_series(provenance)
+        )
 
     def _get_latest_and_provenance_for_locations(
         self, location_ids
     ) -> Tuple[pd.DataFrame, Optional[pd.Series]]:
-        latest_df = self.latest_data.loc[
-            self.latest_data.index.get_level_values(CommonFields.LOCATION_ID).isin(location_ids), :
+        latest_df = self._latest_data.loc[
+            self._latest_data.index.get_level_values(CommonFields.LOCATION_ID).isin(location_ids), :
         ].reset_index()
-        provenance = self.provenance[
-            self.provenance.index.get_level_values(CommonFields.LOCATION_ID).isin(location_ids)
+        provenance = self._provenance[
+            self._provenance.index.get_level_values(CommonFields.LOCATION_ID).isin(location_ids)
         ]
         return latest_df, provenance
 
@@ -663,7 +654,7 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
         This method exists for interim use when calling code that doesn't use MultiRegionTimeseriesDataset.
         """
         return TimeseriesDataset(
-            self.data_with_fips, provenance=None if self.provenance.empty else self.provenance
+            self.data_with_fips, provenance=None if self._provenance.empty else self._provenance
         )
 
     def to_csv(self, path: pathlib.Path):
@@ -680,9 +671,9 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
         common_df.write_csv(
             combined, path, structlog.get_logger(), [CommonFields.LOCATION_ID, CommonFields.DATE]
         )
-        if not self.provenance.empty:
+        if not self._provenance.empty:
             provenance_path = str(path).replace(".csv", "-provenance.csv")
-            self.provenance.sort_index().rename(PdFields.PROVENANCE).to_csv(provenance_path)
+            self._provenance.sort_index().rename(PdFields.PROVENANCE).to_csv(provenance_path)
 
     def drop_column_if_present(self, column: str) -> "MultiRegionTimeseriesDataset":
         """Drops the specified column from the timeseries if it exists"""
@@ -690,12 +681,14 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
         latest_data = self.latest_data_with_fips.drop(
             column, axis="columns", errors="ignore"
         ).reset_index()
-        provenance = self.provenance[
-            self.provenance.index.get_level_values(PdFields.VARIABLE) != column
+        provenance = self._provenance[
+            self._provenance.index.get_level_values(PdFields.VARIABLE) != column
         ]
-        return MultiRegionTimeseriesDataset.from_timeseries_df(
-            df, provenance=provenance
-        ).append_latest_df(latest_data)
+        return (
+            MultiRegionTimeseriesDataset.from_timeseries_df(df)
+            .append_latest_df(latest_data)
+            .add_provenance_series(provenance)
+        )
 
     def join_columns(self, other: "MultiRegionTimeseriesDataset") -> "MultiRegionTimeseriesDataset":
         """Joins the timeseries columns in `other` with those in `self`.
@@ -704,8 +697,8 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
             other: The timeseries dataset to join with `self`. all columns except the "geo" columns
                    will be joined into `self`.
         """
-        if not other.latest_data.empty:
-            raise NotImplementedError("No support for joining other with latest_data")
+        if not other._latest_data.empty:
+            raise NotImplementedError("No support for joining other with _latest_data")
         other_df = other.data.set_index([CommonFields.LOCATION_ID, CommonFields.DATE])
         self_df = self.data.set_index([CommonFields.LOCATION_ID, CommonFields.DATE])
         other_geo_columns = set(other_df.columns) & set(GEO_DATA_COLUMNS)
@@ -734,10 +727,12 @@ class MultiRegionTimeseriesDataset(SaveableDatasetInterface):
         #    _log.exception(f"Comparing df {self_common_geo_columns} to {other_common_geo_columns}")
         #    raise
         combined_df = pd.concat([self_df, other_df[list(other_ts_columns)]], axis=1)
-        combined_provenance = pd.concat([self.provenance, other.provenance])
-        return MultiRegionTimeseriesDataset.from_timeseries_df(
-            combined_df.reset_index(), provenance=combined_provenance,
-        ).append_latest_df(self.latest_data.reset_index())
+        combined_provenance = pd.concat([self._provenance, other._provenance])
+        return (
+            MultiRegionTimeseriesDataset.from_timeseries_df(combined_df.reset_index())
+            .append_latest_df(self._latest_data.reset_index())
+            .add_provenance_series(combined_provenance)
+        )
 
     def iter_one_regions(self) -> Iterable[Tuple[Region, OneRegionTimeseriesDataset]]:
         """Iterates through all the regions in this object"""
@@ -793,11 +788,13 @@ def add_new_cases(timeseries: MultiRegionTimeseriesDataset) -> MultiRegionTimese
     new_cases[new_cases < 0] = pd.NA
 
     df_copy[CommonFields.NEW_CASES] = new_cases
-    latest_values = _add_new_cases_to_latest(df_copy, timeseries.latest_data)
+    latest_values = _add_new_cases_to_latest(df_copy, timeseries._latest_data)
 
-    new_timeseries = MultiRegionTimeseriesDataset.from_timeseries_df(
-        timeseries_df=df_copy, provenance=timeseries.provenance
-    ).append_latest_df(latest_values)
+    new_timeseries = (
+        MultiRegionTimeseriesDataset.from_timeseries_df(timeseries_df=df_copy)
+        .append_latest_df(latest_values)
+        .add_provenance_series(timeseries._provenance)
+    )
 
     return new_timeseries
 
@@ -852,11 +849,12 @@ def drop_new_case_outliers(
     to_exclude = (zscores > zscore_threshold) & (df_copy[CommonFields.NEW_CASES] > case_threshold)
     df_copy.loc[to_exclude, CommonFields.NEW_CASES] = None
 
-    latest_values = _add_new_cases_to_latest(df_copy, timeseries.latest_data)
-
-    new_timeseries = MultiRegionTimeseriesDataset.from_timeseries_df(
-        timeseries_df=df_copy, provenance=timeseries.provenance
-    ).append_latest_df(latest_values)
+    latest_values = _add_new_cases_to_latest(df_copy, timeseries._latest_data)
+    new_timeseries = (
+        MultiRegionTimeseriesDataset.from_timeseries_df(timeseries_df=df_copy)
+        .append_latest_df(latest_values)
+        .add_provenance_series(timeseries._provenance)
+    )
 
     return new_timeseries
 
@@ -867,9 +865,9 @@ def drop_regions_without_population(
     log: Union[structlog.BoundLoggerBase, structlog._config.BoundLoggerLazyProxy],
 ) -> MultiRegionTimeseriesDataset:
     # latest_population is a Series with location_id index
-    latest_population = mrts.latest_data[CommonFields.POPULATION]
-    locations_with_population = mrts.latest_data.loc[latest_population.notna()].index
-    locations_without_population = mrts.latest_data.loc[latest_population.isna()].index
+    latest_population = mrts._latest_data[CommonFields.POPULATION]
+    locations_with_population = mrts._latest_data.loc[latest_population.notna()].index
+    locations_without_population = mrts._latest_data.loc[latest_population.isna()].index
     unexpected_drops = set(locations_without_population) - set(known_location_id_to_drop)
     if unexpected_drops:
         log.warning(

--- a/libs/test_positivity.py
+++ b/libs/test_positivity.py
@@ -209,8 +209,7 @@ class AllMethods:
 
         test_positivity = MultiRegionTimeseriesDataset.from_timeseries_df(
             positivity.stack().rename(CommonFields.TEST_POSITIVITY).reset_index(),
-            provenance=provenance,
-        )
+        ).add_provenance_series(provenance)
 
         return AllMethods(all_methods_timeseries=all_wide, test_positivity=test_positivity)
 

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -631,9 +631,9 @@ def _build_one_column_multiregion_dataset(
         [{CommonFields.LOCATION_ID: location_id, "date": pd.NaT, column: value}]
     )
 
-    return timeseries.MultiRegionTimeseriesDataset.from_timeseries_df(
-        timeseries_df
-    ).append_latest_df(latest_df)
+    return timeseries.MultiRegionTimeseriesDataset.from_timeseries_df(timeseries_df).add_latest_df(
+        latest_df
+    )
 
 
 def test_remove_outliers():

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -83,7 +83,7 @@ def test_multi_region_to_from_timeseries_and_latest_values(tmp_path: pathlib.Pat
     )
     multiregion = timeseries.MultiRegionTimeseriesDataset.from_timeseries_and_latest(
         ts, latest_values
-    ).append_provenance_csv(
+    ).add_provenance_csv(
         io.StringIO("location_id,variable,provenance\n" "iso1:us#fips:97111,m1,ts197111prov\n")
     )
     region_97111 = multiregion.get_one_region(Region.from_fips("97111"))
@@ -286,7 +286,7 @@ def test_append_regions():
             "iso1:us#fips:97111,,Bar County,county,3,\n"
             "iso1:us#fips:97222,,Foo County,county,,11\n"
         )
-    ).append_provenance_csv(
+    ).add_provenance_csv(
         io.StringIO("location_id,variable,provenance\n" "iso1:us#fips:97111,m1,prov97111m1\n")
     )
     ts_cbsa = timeseries.MultiRegionTimeseriesDataset.from_csv(
@@ -298,7 +298,7 @@ def test_append_regions():
             "iso1:us#cbsa:10100,,3\n"
             "iso1:us#cbsa:20200,,4\n"
         )
-    ).append_provenance_csv(
+    ).add_provenance_csv(
         io.StringIO("location_id,variable,provenance\n" "iso1:us#cbsa:20200,m1,prov20200m2\n")
     )
     # Check that merge is symmetric
@@ -320,7 +320,7 @@ def test_append_regions():
             "iso1:us#fips:97111,,Bar County,county,3,\n"
             "iso1:us#fips:97222,,Foo County,county,,11\n"
         )
-    ).append_provenance_csv(
+    ).add_provenance_csv(
         io.StringIO(
             "location_id,variable,provenance\n"
             "iso1:us#fips:97111,m1,prov97111m1\n"
@@ -435,7 +435,7 @@ def test_join_columns():
             "iso1:us#fips:97111,2020-04-04,Bar County,county,4\n"
             "iso1:us#fips:97111,,Bar County,county,4\n"
         )
-    ).append_provenance_csv(
+    ).add_provenance_csv(
         io.StringIO(
             "location_id,variable,provenance\n"
             "iso1:us#cbsa:10100,m1,ts110100prov\n"
@@ -450,7 +450,7 @@ def test_join_columns():
             "iso1:us#fips:97111,2020-04-02,Bar County,county,\n"
             "iso1:us#fips:97111,2020-04-04,Bar County,county,\n"
         )
-    ).append_provenance_csv(
+    ).add_provenance_csv(
         io.StringIO(
             "location_id,variable,provenance\n"
             "iso1:us#cbsa:10100,m2,ts110100prov\n"
@@ -467,7 +467,7 @@ def test_join_columns():
             "iso1:us#fips:97111,2020-04-04,Bar County,county,4,\n"
             "iso1:us#fips:97111,,Bar County,county,4,\n"
         )
-    ).append_provenance_csv(
+    ).add_provenance_csv(
         io.StringIO(
             "location_id,variable,provenance\n"
             "iso1:us#cbsa:10100,m1,ts110100prov\n"
@@ -602,12 +602,12 @@ def test_merge_provenance():
             "iso1:us#fips:97111,2020-04-04,Bar County,county,4\n"
             "iso1:us#fips:97111,,Bar County,county,4\n"
         )
-    ).append_provenance_csv(
+    ).add_provenance_csv(
         io.StringIO("location_id,variable,provenance\n" "iso1:us#cbsa:10100,m1,ts110100prov\n")
     )
 
     with pytest.raises(NotImplementedError):
-        ts.append_provenance_csv(
+        ts.add_provenance_csv(
             io.StringIO("location_id,variable,provenance\n" "iso1:us#fips:97111,m1,ts197111prov\n")
         )
 

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -227,16 +227,16 @@ def test_multiregion_provenance():
         ts, ts.latest_values_object()
     )
     # Use loc[...].at[...] as work-around for https://github.com/pandas-dev/pandas/issues/26989
-    assert out.provenance.loc["iso1:us#fips:97111"].at["m1"] == "src11"
+    assert out._provenance.loc["iso1:us#fips:97111"].at["m1"] == "src11"
     assert out.get_one_region(Region.from_fips("97111")).provenance["m1"] == "src11"
-    assert out.provenance.loc["iso1:us#fips:97222"].at["m2"] == "src22"
+    assert out._provenance.loc["iso1:us#fips:97222"].at["m2"] == "src22"
     assert out.get_one_region(Region.from_fips("97222")).provenance["m2"] == "src22"
-    assert out.provenance.loc["iso1:us#fips:03"].at["m2"] == "src32"
+    assert out._provenance.loc["iso1:us#fips:03"].at["m2"] == "src32"
     assert out.get_one_region(Region.from_fips("03")).provenance["m2"] == "src32"
 
     counties = out.get_counties(after=pd.to_datetime("2020-04-01"))
-    assert "iso1:us#fips:03" not in counties.provenance.index
-    assert counties.provenance.loc["iso1:us#fips:97222"].at["m1"] == "src21"
+    assert "iso1:us#fips:03" not in counties._provenance.index
+    assert counties._provenance.loc["iso1:us#fips:97222"].at["m1"] == "src21"
     assert counties.get_one_region(Region.from_fips("97222")).provenance["m1"] == "src21"
 
 
@@ -254,7 +254,7 @@ def _latest_sorted_by_location_date(
     ts: timeseries.MultiRegionTimeseriesDataset, drop_na: bool
 ) -> pd.DataFrame:
     """Returns the latest data, sorted by LOCATION_ID."""
-    df = ts.latest_data.sort_values([CommonFields.LOCATION_ID], ignore_index=True)
+    df = ts._latest_data.sort_values([CommonFields.LOCATION_ID], ignore_index=True)
     if drop_na:
         df = df.dropna("columns", "all")
     return df
@@ -273,7 +273,7 @@ def assert_dataset_like(
     latest1 = _latest_sorted_by_location_date(ds1, drop_na_latest)
     latest2 = _latest_sorted_by_location_date(ds2, drop_na_latest)
     pd.testing.assert_frame_equal(latest1, latest2, check_like=True, check_dtype=False)
-    pd.testing.assert_series_equal(ds1.provenance, ds2.provenance)
+    pd.testing.assert_series_equal(ds1._provenance, ds2._provenance)
 
 
 def test_append_regions():

--- a/test/libs/generate_api_v2_test.py
+++ b/test/libs/generate_api_v2_test.py
@@ -17,10 +17,7 @@ from libs.pipelines import api_v2_pipeline
 def test_build_summary_for_fips(
     include_model_output: bool, rt_null: bool, nyc_region, nyc_icu_dataset, nyc_rt_dataset
 ):
-    us_latest = combined_datasets.load_us_latest_dataset()
     us_timeseries = combined_datasets.load_us_timeseries_dataset()
-    nyc_latest = us_latest.get_record_for_fips(nyc_region.fips)
-    expected_projections = None
 
     if include_model_output:
         if rt_null:
@@ -30,6 +27,7 @@ def test_build_summary_for_fips(
         nyc_rt_dataset = None
 
     fips_timeseries = us_timeseries.get_one_region(nyc_region)
+    nyc_latest = fips_timeseries.latest
 
     metrics_series, latest_metric = api_v2_pipeline.generate_metrics_and_latest(
         fips_timeseries, nyc_rt_dataset, nyc_icu_dataset, structlog.get_logger()
@@ -76,11 +74,10 @@ def test_build_summary_for_fips(
 
 
 def test_generate_timeseries_for_fips(nyc_region, nyc_rt_dataset, nyc_icu_dataset):
-    us_latest = combined_datasets.load_us_latest_dataset()
     us_timeseries = combined_datasets.load_us_timeseries_dataset()
 
-    nyc_latest = us_latest.get_record_for_fips(nyc_region.fips)
     nyc_timeseries = us_timeseries.get_one_region(nyc_region)
+    nyc_latest = nyc_timeseries.latest
     metrics_series, latest_metric = api_v2_pipeline.generate_metrics_and_latest(
         nyc_timeseries, nyc_rt_dataset, nyc_icu_dataset, structlog.get_logger()
     )

--- a/test/libs/test_positivity_test.py
+++ b/test/libs/test_positivity_test.py
@@ -6,6 +6,7 @@ from covidactnow.datapublic import common_df
 from covidactnow.datapublic.common_fields import CommonFields
 
 from libs.datasets import timeseries
+from libs.pipeline import Region
 from libs.test_positivity import AllMethods
 from libs.test_positivity import DivisionMethod
 from libs import test_positivity
@@ -63,7 +64,7 @@ def test_basic():
     )
     assert_dataset_like(all_methods.test_positivity, expected_positivity)
 
-    positivity_provenance = all_methods.test_positivity.provenance
+    positivity_provenance = all_methods.test_positivity._provenance
     # Use loc[...].at[...] as work-around for https://github.com/pandas-dev/pandas/issues/26989
     assert positivity_provenance.loc["iso1:us#iso2:as"].to_dict() == {
         CommonFields.TEST_POSITIVITY: "method2"
@@ -77,14 +78,14 @@ def test_recent_days():
     ts = timeseries.MultiRegionTimeseriesDataset.from_csv(
         io.StringIO(
             "location_id,date,positive_tests,positive_tests_viral,total_tests,\n"
-            "iso1:us#iso2:as,2020-04-01,0,0,100\n"
-            "iso1:us#iso2:as,2020-04-02,2,20,200\n"
-            "iso1:us#iso2:as,2020-04-03,4,,300\n"
-            "iso1:us#iso2:as,2020-04-04,6,,400\n"
-            "iso1:us#iso2:tx,2020-04-01,1,10,100\n"
-            "iso1:us#iso2:tx,2020-04-02,2,20,200\n"
-            "iso1:us#iso2:tx,2020-04-03,3,30,300\n"
-            "iso1:us#iso2:tx,2020-04-04,4,40,400\n"
+            "iso1:us#iso2:us-as,2020-04-01,0,0,100\n"
+            "iso1:us#iso2:us-as,2020-04-02,2,20,200\n"
+            "iso1:us#iso2:us-as,2020-04-03,4,,300\n"
+            "iso1:us#iso2:us-as,2020-04-04,6,,400\n"
+            "iso1:us#iso2:us-tx,2020-04-01,1,10,100\n"
+            "iso1:us#iso2:us-tx,2020-04-02,2,20,200\n"
+            "iso1:us#iso2:us-tx,2020-04-03,3,30,300\n"
+            "iso1:us#iso2:us-tx,2020-04-04,4,40,400\n"
         )
     )
     methods = [
@@ -95,45 +96,43 @@ def test_recent_days():
 
     expected_all = _parse_wide_dates(
         "location_id,variable,2020-04-01,2020-04-02,2020-04-03,2020-04-04\n"
-        "iso1:us#iso2:as,method1,,0.2,,\n"
-        "iso1:us#iso2:as,method2,,0.02,0.02,0.02\n"
-        "iso1:us#iso2:tx,method1,,0.1,0.1,0.1\n"
-        "iso1:us#iso2:tx,method2,,0.01,0.01,0.01\n"
+        "iso1:us#iso2:us-as,method1,,0.2,,\n"
+        "iso1:us#iso2:us-as,method2,,0.02,0.02,0.02\n"
+        "iso1:us#iso2:us-tx,method1,,0.1,0.1,0.1\n"
+        "iso1:us#iso2:us-tx,method2,,0.01,0.01,0.01\n"
     )
     pd.testing.assert_frame_equal(all_methods.all_methods_timeseries, expected_all, check_like=True)
     expected_positivity = timeseries.MultiRegionTimeseriesDataset.from_csv(
         io.StringIO(
             "location_id,date,test_positivity\n"
-            "iso1:us#iso2:as,2020-04-02,0.02\n"
-            "iso1:us#iso2:as,2020-04-03,0.02\n"
-            "iso1:us#iso2:as,2020-04-04,0.02\n"
-            "iso1:us#iso2:tx,2020-04-02,0.1\n"
-            "iso1:us#iso2:tx,2020-04-03,0.1\n"
-            "iso1:us#iso2:tx,2020-04-04,0.1\n"
+            "iso1:us#iso2:us-as,2020-04-02,0.02\n"
+            "iso1:us#iso2:us-as,2020-04-03,0.02\n"
+            "iso1:us#iso2:us-as,2020-04-04,0.02\n"
+            "iso1:us#iso2:us-tx,2020-04-02,0.1\n"
+            "iso1:us#iso2:us-tx,2020-04-03,0.1\n"
+            "iso1:us#iso2:us-tx,2020-04-04,0.1\n"
         )
     ).append_provenance_csv(
         io.StringIO(
             "location_id,variable,provenance\n"
-            "iso1:us#iso2:as,test_positivity,method2\n"
-            "iso1:us#iso2:tx,test_positivity,method1\n"
+            "iso1:us#iso2:us-as,test_positivity,method2\n"
+            "iso1:us#iso2:us-tx,test_positivity,method1\n"
         )
     )
     assert_dataset_like(all_methods.test_positivity, expected_positivity)
-    # Use loc[...].at[...] as work-around for https://github.com/pandas-dev/pandas/issues/26989
-    positivity_provenance = all_methods.test_positivity.provenance
-    assert positivity_provenance.loc["iso1:us#iso2:as"].to_dict() == {
+    assert all_methods.test_positivity.get_one_region(Region.from_state("AS")).provenance == {
         CommonFields.TEST_POSITIVITY: "method2"
     }
-    assert positivity_provenance.loc["iso1:us#iso2:tx"].to_dict() == {
+    assert all_methods.test_positivity.get_one_region(Region.from_state("TX")).provenance == {
         CommonFields.TEST_POSITIVITY: "method1"
     }
 
     all_methods = AllMethods.run(ts, methods, diff_days=1, recent_days=4)
-    positivity_provenance = all_methods.test_positivity.provenance
-    assert positivity_provenance.loc["iso1:us#iso2:as"].to_dict() == {
+    positivity_provenance = all_methods.test_positivity._provenance
+    assert positivity_provenance.loc["iso1:us#iso2:us-as"].to_dict() == {
         CommonFields.TEST_POSITIVITY: "method1"
     }
-    assert positivity_provenance.loc["iso1:us#iso2:tx"].to_dict() == {
+    assert positivity_provenance.loc["iso1:us#iso2:us-tx"].to_dict() == {
         CommonFields.TEST_POSITIVITY: "method1"
     }
 
@@ -157,7 +156,7 @@ def test_missing_column_for_one_method():
     ]
     assert (
         AllMethods.run(ts, methods, diff_days=1, recent_days=4)
-        .test_positivity.provenance.loc["iso1:us#iso2:tx"]
+        .test_positivity._provenance.loc["iso1:us#iso2:tx"]
         .at[CommonFields.TEST_POSITIVITY]
         == "method1"
     )

--- a/test/libs/test_positivity_test.py
+++ b/test/libs/test_positivity_test.py
@@ -55,7 +55,7 @@ def test_basic():
             "iso1:us#iso2:as,2020-04-04,0.02\n"
             "iso1:us#iso2:tx,2020-04-04,0.1\n"
         )
-    ).append_provenance_csv(
+    ).add_provenance_csv(
         io.StringIO(
             "location_id,variable,provenance\n"
             "iso1:us#iso2:as,test_positivity,method2\n"
@@ -112,7 +112,7 @@ def test_recent_days():
             "iso1:us#iso2:us-tx,2020-04-03,0.1\n"
             "iso1:us#iso2:us-tx,2020-04-04,0.1\n"
         )
-    ).append_provenance_csv(
+    ).add_provenance_csv(
         io.StringIO(
             "location_id,variable,provenance\n"
             "iso1:us#iso2:us-as,test_positivity,method2\n"


### PR DESCRIPTION
This PR simplifies the MultiRegionTimeseriesDataset interface, easing future changes to it.

-  mark latest_data and provenance attributes as private with single underscore
-  replace use of `from_timeseries_df(provenance=...)` with call to new add_provenance_series method
-  in `test_recent_days replace` direct access `to _provenance` with getting it from get_one_region return value.
-  rename append_latest_df to add_latest_df
-  rename append_provenance_csv to add_provenance_csv
-  remove some access to latest values in effort to remove latest values
-  drop_column_if_present using _latest_data instead of latest_data_with_fips
