### PR TITLE
Disable RI county test positivity from covid-county-data, since the rates seem to be way higher than CMS.

### DIFF
--- a/libs/datasets/sources/covid_county_data.py
+++ b/libs/datasets/sources/covid_county_data.py
@@ -12,7 +12,7 @@ from libs.datasets.timeseries import TimeseriesDataset
 # 2020/11/01: By manual comparison of test positivity calculated via Covid County Data vs CMS
 # and local dashboards where available, these states have data that seems less credible than
 # our CMS data source.
-DISABLED_TEST_POSITIVITY_STATES = ["AL", "DE", "FL", "IN", "IA", "MD", "ND", "PA", "WI"]
+DISABLED_TEST_POSITIVITY_STATES = ["AL", "DE", "FL", "IN", "IA", "MD", "ND", "PA", "WI", "RI"]
 
 
 class CovidCountyDataDataSource(data_source.DataSource):


### PR DESCRIPTION
The CMS rates are way lower and inline with the state-level positivity, so I think we should use CMS.
https://trello.com/c/e9o3mhjW/585-try-switching-to-cms-test-positivity-data-for-rhode-island

Demo snapshot here (FYI- also includes reenabling OR, NE, and CA HHS data): https://covid-projections-git-mikelehen-demo-snapshot.covidactnow.vercel.app/internal/compare