### PR TITLE
Remove time restrictions on label-api and pr-generation

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -130,12 +130,12 @@ jobs:
         # automatically cleaned up.
         rm -r /data/api-results-${{env.SNAPSHOT_ID}}
 
-    - name: Trigger website PR generation if conditions are met (master branch, morning build, etc)
+    - name: Trigger website PR generation if master branch build
       env:
         GITHUB_TOKEN: ${{ secrets.CAN_ROBOT_PERSONAL_ACCESS_TOKEN }}
       run: ./covid-data-model/tools/maybe-trigger-web-snapshot-update.sh ${{env.SNAPSHOT_ID}} ${{env.COVID_DATA_MODEL_REF}} ${{env.COVID_DATA_PUBLIC_REF}}
 
-    - name: Trigger Label API if conditions are met (master branch, morning build, etc)
+    - name: Trigger Label API if master branch build
       env:
         GITHUB_TOKEN: ${{ secrets.CAN_ROBOT_PERSONAL_ACCESS_TOKEN }}
       run: ./covid-data-model/tools/maybe-trigger-label-api.sh ${{env.SNAPSHOT_ID}} ${{env.COVID_DATA_MODEL_REF}}

--- a/tools/maybe-trigger-label-api.sh
+++ b/tools/maybe-trigger-label-api.sh
@@ -32,14 +32,6 @@ prepare () {
     exit 0
   fi
 
-  # TODO(chris) Comment: Should we trigger update regardless?
-  # We have daily jobs scheduled at 00:30 and 12:30 GMT. We want to run after the 12:30 one.
-  currenttime=$(date -u +%H:%M)
-  if [[ "$currenttime" < "12:00" ]]; then
-    echo "Not triggering label-api since time (${currenttime}) is before 12:00 GMT."
-    exit 0
-  fi
-
   if [[ -z ${GITHUB_TOKEN:-} ]]; then
     echo "Error: GITHUB_TOKEN must be set to a personal access token. See:"
     echo "https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line"

--- a/tools/maybe-trigger-web-snapshot-update.sh
+++ b/tools/maybe-trigger-web-snapshot-update.sh
@@ -35,13 +35,6 @@ prepare () {
     exit 0
   fi
 
-  # We have daily jobs scheduled at 00:30 and 12:30 GMT. We want to run after the 12:30 one.
-  currenttime=$(date -u +%H:%M)
-  if [[ "$currenttime" < "12:00" ]]; then
-    echo "Not triggering covid-projections update-snapshot since time (${currenttime}) is before 12:00 GMT."
-    exit 0
-  fi
-
   if [[ -z ${GITHUB_TOKEN:-} ]]; then
     echo "Error: GITHUB_TOKEN must be set to a personal access token. See:"
     echo "https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line"


### PR DESCRIPTION
This removes the time restrictions to kick of snapshot PRs on the website and label api.