### PR TITLE
add MultiRegion.drop_stale_timeseries

### DIFF
--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -534,6 +534,17 @@ class MultiRegionDataset(SaveableDatasetInterface):
         return long.loc[unduplicated_and_last_mask, :].unstack()
 
     @staticmethod
+    def from_timeseries_wide_dates_df(timeseries_wide_dates: pd.DataFrame) -> "MultiRegionDataset":
+        """Make a new dataset from a DataFrame as returned by timeseries_wide_dates."""
+        assert timeseries_wide_dates.index.names == [CommonFields.LOCATION_ID, PdFields.VARIABLE]
+        assert timeseries_wide_dates.columns.names == [CommonFields.DATE]
+        timeseries_wide_dates.columns: pd.DatetimeIndex = pd.to_datetime(
+            timeseries_wide_dates.columns
+        )
+        timeseries_wide_variables = timeseries_wide_dates.stack().unstack(PdFields.VARIABLE)
+        return MultiRegionDataset(timeseries=timeseries_wide_variables)
+
+    @staticmethod
     def from_geodata_timeseries_df(timeseries_and_geodata_df: pd.DataFrame) -> "MultiRegionDataset":
         """Make a new dataset from a DataFrame containing timeseries (real-valued metrics) and
         static geo data (county name etc)."""
@@ -656,6 +667,13 @@ class MultiRegionDataset(SaveableDatasetInterface):
         assert self.timeseries.index.names == [CommonFields.LOCATION_ID, CommonFields.DATE]
         assert self.timeseries.index.is_unique
         assert self.timeseries.index.is_monotonic_increasing
+        if self.timeseries.columns.names == [None]:
+            # TODO(tom): Ideally __post_init__ doesn't modify any values but tracking
+            # down all the places that create a DataFrame to add a column name seems like
+            # a PITA. I'll do it another day and hack it for now.
+            self.timeseries.rename_axis(columns=PdFields.VARIABLE, inplace=True)
+        else:
+            assert self.timeseries.columns.names == [PdFields.VARIABLE]
         numeric_columns = self.timeseries.dtypes.apply(is_numeric_dtype)
         assert numeric_columns.all()
         assert self.static.index.names == [CommonFields.LOCATION_ID]

--- a/libs/test_positivity.py
+++ b/libs/test_positivity.py
@@ -148,23 +148,14 @@ class AllMethods:
         if not relevant_columns:
             raise NoMethodsWithRelevantColumns()
 
-        input_long = dataset_in._timeseries_long(relevant_columns).reorder_levels(
-            [PdFields.VARIABLE, CommonFields.LOCATION_ID, CommonFields.DATE]
+        input_wide = dataset_in.timeseries_wide_dates().reorder_levels(
+            [PdFields.VARIABLE, CommonFields.LOCATION_ID]
         )
-        dates = input_long.index.get_level_values(CommonFields.DATE)
-        if dates.empty:
+        if input_wide.empty:
             raise NoRealTimeseriesValuesException()
-        start_date = dates.min()
+        dates = input_wide.columns.get_level_values(CommonFields.DATE)
         end_date = dates.max()
-        input_date_range = pd.date_range(start=start_date, end=end_date)
-        recent_date_range = pd.date_range(end=end_date, periods=recent_days).intersection(
-            input_date_range
-        )
-        input_wide = (
-            input_long.unstack(CommonFields.DATE)
-            .reindex(columns=input_date_range)
-            .rename_axis(columns=CommonFields.DATE)
-        )
+        recent_date_range = pd.date_range(end=end_date, periods=recent_days).intersection(dates)
 
         methods_with_data = AllMethods._methods_with_columns_available(
             methods, input_wide.index.get_level_values(PdFields.VARIABLE).unique()

--- a/libs/test_positivity.py
+++ b/libs/test_positivity.py
@@ -148,9 +148,9 @@ class AllMethods:
         if not relevant_columns:
             raise NoMethodsWithRelevantColumns()
 
-        input_long = dataset_in.timeseries_long(relevant_columns).set_index(
+        input_long = dataset_in._timeseries_long(relevant_columns).reorder_levels(
             [PdFields.VARIABLE, CommonFields.LOCATION_ID, CommonFields.DATE]
-        )[PdFields.VALUE]
+        )
         dates = input_long.index.get_level_values(CommonFields.DATE)
         if dates.empty:
             raise NoRealTimeseriesValuesException()

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -474,7 +474,7 @@ def test_timeseries_long():
         parse_dates=[CommonFields.DATE],
         dtype={"value": float},
     )
-    long_series = ts._timeseries_long(["m1", "m2"])
+    long_series = ts._timeseries_long()
     assert long_series.index.names == [
         CommonFields.LOCATION_ID,
         CommonFields.DATE,
@@ -483,6 +483,55 @@ def test_timeseries_long():
     assert long_series.name == PdFields.VALUE
     long_df = long_series.reset_index()
     pd.testing.assert_frame_equal(long_df, expected, check_like=True)
+
+
+def test_timeseries_wide_dates():
+    ts = timeseries.MultiRegionDataset.from_csv(
+        io.StringIO(
+            "location_id,date,county,aggregate_level,m1,m2\n"
+            "iso1:us#cbsa:10100,2020-04-02,,,,2\n"
+            "iso1:us#cbsa:10100,2020-04-03,,,,3\n"
+            "iso1:us#cbsa:10100,,,,,3\n"
+            "iso1:us#fips:97111,2020-04-02,Bar County,county,2,\n"
+            "iso1:us#fips:97111,2020-04-04,Bar County,county,4,\n"
+            "iso1:us#fips:97111,,Bar County,county,4,\n"
+        )
+    )
+
+    timeseries_wide = ts.timeseries_wide_dates()
+    assert timeseries_wide.index.names == [CommonFields.LOCATION_ID, PdFields.VARIABLE]
+    assert timeseries_wide.columns.names == [CommonFields.DATE]
+
+    expected = (
+        pd.read_csv(
+            io.StringIO(
+                "location_id,variable,2020-04-02,2020-04-03,2020-04-04\n"
+                "iso1:us#cbsa:10100,m2,2,3,\n"
+                "iso1:us#fips:97111,m1,2,,4\n"
+            ),
+        )
+        .set_index(timeseries_wide.index.names)
+        .rename_axis(columns="date")
+        .astype(float)
+    )
+    expected.columns = pd.to_datetime(expected.columns)
+
+    pd.testing.assert_frame_equal(timeseries_wide, expected)
+
+
+def test_timeseries_wide_dates_empty():
+    ts = timeseries.MultiRegionDataset.from_csv(
+        io.StringIO(
+            "location_id,date,county,aggregate_level,m1,m2\n"
+            "iso1:us#cbsa:10100,,,,,3\n"
+            "iso1:us#fips:97111,,Bar County,county,4,\n"
+        )
+    )
+
+    timeseries_wide = ts.timeseries_wide_dates()
+    assert timeseries_wide.index.names == [CommonFields.LOCATION_ID, PdFields.VARIABLE]
+    assert timeseries_wide.columns.names == [CommonFields.DATE]
+    assert timeseries_wide.empty
 
 
 def test_timeseries_latest_values():

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -474,10 +474,15 @@ def test_timeseries_long():
         parse_dates=[CommonFields.DATE],
         dtype={"value": float},
     )
-    long = ts.timeseries_long(["m1", "m2"]).sort_values(
-        [CommonFields.LOCATION_ID, PdFields.VARIABLE, CommonFields.DATE], ignore_index=True
-    )
-    pd.testing.assert_frame_equal(long, expected, check_like=True)
+    long_series = ts._timeseries_long(["m1", "m2"])
+    assert long_series.index.names == [
+        CommonFields.LOCATION_ID,
+        CommonFields.DATE,
+        PdFields.VARIABLE,
+    ]
+    assert long_series.name == PdFields.VALUE
+    long_df = long_series.reset_index()
+    pd.testing.assert_frame_equal(long_df, expected, check_like=True)
 
 
 def test_timeseries_latest_values():

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -1,4 +1,3 @@
-import datetime
 import io
 import pathlib
 import pytest

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -486,7 +486,7 @@ def test_timeseries_long():
 
 
 def test_timeseries_wide_dates():
-    ts = timeseries.MultiRegionDataset.from_csv(
+    ds = timeseries.MultiRegionDataset.from_csv(
         io.StringIO(
             "location_id,date,county,aggregate_level,m1,m2\n"
             "iso1:us#cbsa:10100,2020-04-02,,,,2\n"
@@ -498,9 +498,9 @@ def test_timeseries_wide_dates():
         )
     )
 
-    timeseries_wide = ts.timeseries_wide_dates()
-    assert timeseries_wide.index.names == [CommonFields.LOCATION_ID, PdFields.VARIABLE]
-    assert timeseries_wide.columns.names == [CommonFields.DATE]
+    ds_wide = ds.timeseries_wide_dates()
+    assert ds_wide.index.names == [CommonFields.LOCATION_ID, PdFields.VARIABLE]
+    assert ds_wide.columns.names == [CommonFields.DATE]
 
     expected = (
         pd.read_csv(
@@ -510,13 +510,19 @@ def test_timeseries_wide_dates():
                 "iso1:us#fips:97111,m1,2,,4\n"
             ),
         )
-        .set_index(timeseries_wide.index.names)
+        .set_index(ds_wide.index.names)
         .rename_axis(columns="date")
         .astype(float)
     )
     expected.columns = pd.to_datetime(expected.columns)
 
-    pd.testing.assert_frame_equal(timeseries_wide, expected)
+    pd.testing.assert_frame_equal(ds_wide, expected)
+
+    # Recreate the dataset using `from_timeseries_wide_dates_df`.
+    ds_recreated = timeseries.MultiRegionDataset.from_timeseries_wide_dates_df(
+        ds_wide
+    ).add_static_values(ds.static.reset_index())
+    assert_dataset_like(ds, ds_recreated)
 
 
 def test_timeseries_wide_dates_empty():


### PR DESCRIPTION
This PR helps to pave the way for some test positivity cleanup which will make more use of MultiRegionDataset to pass around timeseries and provenance information together.

* Adds `MultiRegionDataset.timeseries_wide_dates` which returns the timeseries in a DataFrame with date columns and from_timeseries_wide_dates_df that makes a new dataset from such a DataFrame.
* Makes sure the timeseries column axis has a name. `stack` uses the name for the new index level.
* Removes a stale comment in _trim_timeseries
* Adds `MultiRegionDataset.drop_stale_timeseries`

