### PR TITLE
test positivity cleaner output and provenance cleanup

### DIFF
--- a/cli/api.py
+++ b/cli/api.py
@@ -66,18 +66,20 @@ def update_v2_schemas(api_output_path, schemas_output_dir):
 
 @main.command()
 @click.option(
-    "--test-positivity-all-methods",
-    default="results/output/test-positivity-all.csv",
-    type=pathlib.Path,
+    "--test-positivity-all-methods", default="test-positivity-all.csv", type=pathlib.Path,
 )
 @click.option(
-    "--final_result", default="results/output/test-positivity-output.csv", type=pathlib.Path,
+    "--final-result", default="test-positivity-output.csv", type=pathlib.Path,
+)
+@click.option(
+    "--output-dir", default="results/output", type=pathlib.Path,
 )
 @click.option("--state", type=str)
 @click.option("--fips", type=str)
 def generate_test_positivity(
     test_positivity_all_methods: pathlib.Path,
     final_result: pathlib.Path,
+    output_dir: pathlib.Path,
     state: Optional[str],
     fips: Optional[str],
 ):
@@ -91,7 +93,7 @@ def generate_test_positivity(
         exclude_county_999=True, states=active_states, fips=fips,
     )
     test_positivity_results = test_positivity.AllMethods.run(selected_dataset)
-    test_positivity_results.write(test_positivity_all_methods)
+    test_positivity_results.write(output_dir / test_positivity_all_methods)
 
     # Similar to test_positivity.run_and_maybe_join_columns
     joined_dataset = selected_dataset.drop_column_if_present(
@@ -109,10 +111,10 @@ def generate_test_positivity(
         source_map[region.location_id] = details.source.value
     positivity_wide_date_df = pd.DataFrame.from_dict(positivity_time_series, orient="index")
     source_df = pd.DataFrame.from_dict(source_map, orient="index", columns=[PdFields.PROVENANCE])
-    df = pd.concat([source_df, positivity_wide_date_df], axis=1)
+    df = pd.concat([source_df, positivity_wide_date_df], axis=1, sort=True)
     # The column headers are output as yyyy-mm-dd 00:00:00; I haven't found an easy way to write
     # only the date.
-    df.to_csv(final_result, index=True, float_format="%.05g")
+    df.to_csv(output_dir / final_result, index=True, float_format="%.05g")
 
 
 @main.command()

--- a/libs/test_positivity.py
+++ b/libs/test_positivity.py
@@ -219,7 +219,7 @@ class AllMethods:
         return list(set(chain.from_iterable(method.columns for method in methods)))
 
     def write(self, csv_path: pathlib.Path):
-        self.all_methods_timeseries.dropna("columns", "all").to_csv(
+        self.all_methods_timeseries.dropna("columns", "all").sort_index().to_csv(
             csv_path, date_format="%Y-%m-%d", index=True, float_format="%.05g",
         )
 

--- a/libs/test_positivity.py
+++ b/libs/test_positivity.py
@@ -228,7 +228,7 @@ class AllMethods:
         return list(set(chain.from_iterable(method.columns for method in methods)))
 
     def write(self, csv_path: pathlib.Path):
-        self.all_methods_timeseries.to_csv(
+        self.all_methods_timeseries.dropna("columns", "all").to_csv(
             csv_path, date_format="%Y-%m-%d", index=True, float_format="%.05g",
         )
 

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -581,13 +581,29 @@ def test_timeseries_drop_stale_timeseries_one_metric():
         "iso1:us#fips:97111,2020-04-04,Bar County,county,4,\n"
         "iso1:us#fips:97111,,Bar County,county,4,\n"
     )
-    ds_in = timeseries.MultiRegionDataset.from_csv(io.StringIO(csv_in))
+    ds_in = timeseries.MultiRegionDataset.from_csv(io.StringIO(csv_in)).add_provenance_csv(
+        io.StringIO(
+            "location_id,variable,provenance\n"
+            "iso1:us#cbsa:10100,m1,m1-10100prov\n"
+            "iso1:us#cbsa:10100,m2,m2-10100prov\n"
+            "iso1:us#fips:97111,m1,m1-97111prov\n"
+        )
+    )
 
     ds_out = ds_in.drop_stale_timeseries(pd.to_datetime("2020-04-03"))
 
     # The only timeseries that is stale with cutoff of 4/3 is the CBSA m1. The expected
-    # dataset is the same as the input with "11" removed.
-    ds_expected = timeseries.MultiRegionDataset.from_csv(io.StringIO(csv_in.replace(",11,", ",,")))
+    # dataset is the same as the input with "11" removed from the timeseries and
+    # corresponding provenance removed.
+    ds_expected = timeseries.MultiRegionDataset.from_csv(
+        io.StringIO(csv_in.replace(",11,", ",,"))
+    ).add_provenance_csv(
+        io.StringIO(
+            "location_id,variable,provenance\n"
+            "iso1:us#cbsa:10100,m2,m2-10100prov\n"
+            "iso1:us#fips:97111,m1,m1-97111prov\n"
+        )
+    )
     assert_dataset_like(ds_out, ds_expected)
 
 

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -283,7 +283,9 @@ def _timeseries_sorted_by_location_date(
     ts: timeseries.MultiRegionDataset, drop_na: bool
 ) -> pd.DataFrame:
     """Returns the timeseries data, sorted by LOCATION_ID and DATE."""
-    df = ts.data.sort_values([CommonFields.LOCATION_ID, CommonFields.DATE], ignore_index=True)
+    df = ts.timeseries.reset_index().sort_values(
+        [CommonFields.LOCATION_ID, CommonFields.DATE], ignore_index=True
+    )
     if drop_na:
         df = df.dropna("columns", "all")
     return df

--- a/test/libs/test_positivity_test.py
+++ b/test/libs/test_positivity_test.py
@@ -127,7 +127,7 @@ def test_recent_days():
         CommonFields.TEST_POSITIVITY: "method1"
     }
 
-    all_methods = AllMethods.run(ts, methods, diff_days=1, recent_days=4)
+    all_methods = AllMethods.run(ts, methods, diff_days=1, recent_days=3)
     positivity_provenance = all_methods.test_positivity.provenance
     assert positivity_provenance.loc["iso1:us#iso2:us-as"].to_dict() == {
         CommonFields.TEST_POSITIVITY: "method1"


### PR DESCRIPTION
This PR follows https://github.com/covid-projections/covid-data-model/pull/815 with a bit more paving the way for some test positivity cleanup

* drop columns that are all na and sort by index when writing test positivity debug output
* add generate_test_positivity output_dir to make changing output path easier
* make test_positivity_test.test_recent_days one day stricter so off-by-one bugs with recent_days are found
* change `drop_stale_timeseries` to also drop provenance info for dropped timeseries
* remove a use of `MultiRegionDataset.data` in `_timeseries_sorted_by_location_date`