### PR TITLE
Use both static and timeseries fields in data availability sheet

### DIFF
--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -142,7 +142,7 @@ def load_us_latest_dataset(
 ) -> latest_values_dataset.LatestValuesDataset:
     us_timeseries = load_us_timeseries_dataset(pointer_directory=pointer_directory)
     # Returned object contains a DataFrame with a LOCATION_ID column
-    return LatestValuesDataset(us_timeseries.static_data_with_fips.reset_index())
+    return LatestValuesDataset(us_timeseries.static_and_timeseries_latest_with_fips().reset_index())
 
 
 def get_county_name(region: Region) -> Optional[str]:

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -488,7 +488,7 @@ class MultiRegionDataset(SaveableDatasetInterface):
         return data_copy.set_index(CommonFields.LOCATION_ID)
 
     @lru_cache(maxsize=None)
-    def _static_and_timeseries_latest_with_fips(self) -> pd.DataFrame:
+    def static_and_timeseries_latest_with_fips(self) -> pd.DataFrame:
         """Static values merged with the latest timeseries values."""
         return _merge_attributes(
             self._timeseries_latest_values().reset_index(), self.static.reset_index()
@@ -755,7 +755,7 @@ class MultiRegionDataset(SaveableDatasetInterface):
     def _location_id_latest_dict(self, location_id: str) -> dict:
         """Returns the latest values dict of a location_id."""
         try:
-            attributes_series = self._static_and_timeseries_latest_with_fips().loc[location_id, :]
+            attributes_series = self.static_and_timeseries_latest_with_fips().loc[location_id, :]
         except KeyError:
             attributes_series = pd.Series([], dtype=object)
         return attributes_series.where(pd.notnull(attributes_series), None).to_dict()
@@ -856,7 +856,7 @@ class MultiRegionDataset(SaveableDatasetInterface):
               values were calculated upstream.
         """
         if write_timeseries_latest_values:
-            latest_data = self._static_and_timeseries_latest_with_fips().reset_index()
+            latest_data = self.static_and_timeseries_latest_with_fips().reset_index()
         else:
             latest_data = self.static_data_with_fips.reset_index()
         # A DataFrame with timeseries data and latest data (with DATE=NaT) together

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -297,7 +297,7 @@ def _latest_sorted_by_location_date(
     ts: timeseries.MultiRegionDataset, drop_na: bool
 ) -> pd.DataFrame:
     """Returns the latest data, sorted by LOCATION_ID."""
-    df = ts._static_and_timeseries_latest_with_fips().sort_values(
+    df = ts.static_and_timeseries_latest_with_fips().sort_values(
         [CommonFields.LOCATION_ID], ignore_index=True
     )
     if drop_na:


### PR DESCRIPTION
This will soon change when we remove latest, but a quick patch to load both the timeseries and static values when loading the latest values dataset for the data availability report