### PR TITLE
attempt at fixing load_data_sources_by_name

### DIFF
--- a/libs/notebook_helpers.py
+++ b/libs/notebook_helpers.py
@@ -41,7 +41,7 @@ def load_data_sources_by_name() -> Dict[str, pd.DataFrame]:
     for source_cls in sources:
         dataset = source_cls.local().multi_region_dataset().static_and_timeseries_latest_with_fips()
 
-        dataset.data["source"] = source_cls.__name__
+        dataset["source"] = source_cls.__name__
         source_map[source_cls.__name__] = dataset
 
     return source_map


### PR DESCRIPTION
Attempt at fix for error seen at https://covidactnow.slack.com/archives/C011Z21ST8V/p1607427998029100
Breakage was introduced by https://github.com/covid-projections/covid-data-model/pull/829
Stack trace from https://github.com/covid-projections/covid-data-model/runs/1517069782?check_suite_focus=true
```
  File "/home/runner/work/covid-data-model/covid-data-model/covid-data-model/cli/data.py", line 190, in update_availability_report
    data_sources_by_source_name = data_availability.load_all_latest_sources()
  File "/home/runner/work/covid-data-model/covid-data-model/covid-data-model/libs/qa/data_availability.py", line 22, in load_all_latest_sources
    sources = notebook_helpers.load_data_sources_by_name()
  File "/home/runner/work/covid-data-model/covid-data-model/covid-data-model/libs/notebook_helpers.py", line 44, in load_data_sources_by_name
    dataset.data["source"] = source_cls.__name__
  File "/opt/hostedtoolcache/Python/3.7.9/x64/lib/python3.7/site-packages/pandas/core/generic.py", line 5274, in __getattr__
    return object.__getattribute__(self, name)
AttributeError: 'DataFrame' object has no attribute 'data'
```

My first push to this branch had lots of commits. I then force pushed a branch with 1 commit.