### PR TITLE
add pyseir build-all --location-id-matches

### DIFF
--- a/libs/datasets/dataset_utils.py
+++ b/libs/datasets/dataset_utils.py
@@ -263,6 +263,7 @@ def make_rows_key(
     on=None,
     after=None,
     before=None,
+    location_id_matches: Optional[str] = None,
     exclude_county_999: bool = False,
     exclude_fips_prefix: Optional[str] = None,
 ):
@@ -291,6 +292,11 @@ def make_rows_key(
         # create a binary Series here and refer to it from the query.
         not_county_999 = data[CommonFields.FIPS].str[-3:] != "999"
         query_parts.append("@not_county_999")
+    if location_id_matches:
+        location_id_match_mask = data.index.get_level_values(CommonFields.LOCATION_ID).str.match(
+            location_id_matches
+        )
+        query_parts.append("@location_id_match_mask")
     if exclude_fips_prefix:
         not_fips_prefix = data[CommonFields.FIPS].str[0:2] != exclude_fips_prefix
         query_parts.append("@not_fips_prefix")

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -576,6 +576,7 @@ class MultiRegionDataset(SaveableDatasetInterface):
         fips: Optional[str] = None,
         state: Optional[str] = None,
         states: Optional[List[str]] = None,
+        location_id_matches: Optional[str] = None,
         exclude_county_999: bool = False,
     ) -> "MultiRegionDataset":
         """Returns a new object containing data for a subset of the regions in `self`."""
@@ -585,6 +586,7 @@ class MultiRegionDataset(SaveableDatasetInterface):
             fips=fips,
             state=state,
             states=states,
+            location_id_matches=location_id_matches,
             exclude_county_999=exclude_county_999,
         )
         location_ids = self.static.loc[rows_key, :].index

--- a/pyseir/cli.py
+++ b/pyseir/cli.py
@@ -130,13 +130,17 @@ def run_infer_rt(state, states_only):
     help="Directory to deploy " "webui output.",
 )
 @click.option(
+    "--location-id-matches",
+    help="If set only location_id matching this regular expression are processed",
+)
+@click.option(
     "--generate-api-v2",
     default=False,
     is_flag=True,
     type=bool,
     help="Generate API v2 output after PySEIR finishes",
 )
-def build_all(states, output_dir, level, fips, generate_api_v2: bool):
+def build_all(states, output_dir, level, fips, location_id_matches: str, generate_api_v2: bool):
     # split columns by ',' and remove whitespace
     states = [c.strip() for c in states]
     states = [us.states.lookup(state).abbr for state in states]
@@ -146,7 +150,11 @@ def build_all(states, output_dir, level, fips, generate_api_v2: bool):
     _cache_global_datasets()
 
     regions_dataset = combined_datasets.load_us_timeseries_dataset().get_subset(
-        fips=fips, aggregation_level=level, exclude_county_999=True, states=states,
+        fips=fips,
+        aggregation_level=level,
+        exclude_county_999=True,
+        states=states,
+        location_id_matches=location_id_matches,
     )
     regions = [one_region for _, one_region in regions_dataset.iter_one_regions()]
     root.info(f"Executing pipeline for {len(regions)} regions")


### PR DESCRIPTION
This PR helps me test https://trello.com/c/EyISOtVY/623-country-aggregation-breaking-pyseir-output-and-doesnt-output-api-files-properly

Running the following generates API output for one CBSA.
```
python ./pyseir/cli.py build-all --location-id-matches='(iso1\:us\#cbsa\:10100|.+\#fips\:46013|.+\#fips\:46045)' --generate-api-v2 --output-dir output-cbsa-10100
```

