### PR TITLE
Fix additional test positivity columns and NYC CBSA aggregation

### DIFF
--- a/libs/datasets/statistical_areas.py
+++ b/libs/datasets/statistical_areas.py
@@ -9,6 +9,7 @@ from libs.datasets import timeseries
 from libs.datasets.timeseries import MultiRegionDataset
 from covidactnow.datapublic.common_fields import CommonFields
 from libs.datasets import dataset_utils
+from libs.datasets import custom_aggregations
 
 
 CBSA_LIST_PATH = "data/census-msa/list1_2020.xls"
@@ -51,6 +52,10 @@ class CountyToCBSAAggregator:
         )
         df[CommonFields.FIPS] = df["FIPS State Code"] + df["FIPS County Code"]
         df = df.loc[df[CommonFields.FIPS].notna(), :]
+
+        # Remove NYC Fips so that NY aggregations work properly. This should be removed
+        # once NYC aggregation is removed.
+        df = df.loc[~df[CommonFields.FIPS].isin(custom_aggregations.NYC_BOROUGH_FIPS), :]
 
         dups = df.duplicated(CommonFields.FIPS, keep=False)
         if dups.any():

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -841,6 +841,8 @@ WEIGHTED_AGGREGATIONS = (
     # Maybe test_positivity is better averaged using time-varying total tests, but it isn't
     # implemented. See TODO next to call to _find_scale_factors.
     StaticWeightedAverageAggregation(CommonFields.TEST_POSITIVITY, CommonFields.POPULATION),
+    StaticWeightedAverageAggregation(CommonFields.TEST_POSITIVITY_7D, CommonFields.POPULATION),
+    StaticWeightedAverageAggregation(CommonFields.TEST_POSITIVITY_14D, CommonFields.POPULATION),
     StaticWeightedAverageAggregation(
         CommonFields.ALL_BED_TYPICAL_OCCUPANCY_RATE, CommonFields.MAX_BED_COUNT
     ),

--- a/pyseir/run.py
+++ b/pyseir/run.py
@@ -10,7 +10,6 @@ from covidactnow.datapublic.common_fields import CommonFields
 from typing_extensions import final
 
 from libs import pipeline
-from libs.datasets import AggregationLevel
 from libs.datasets.timeseries import MultiRegionDataset
 from libs.datasets.timeseries import OneRegionTimeseriesDataset
 from pyseir.icu import infer_icu
@@ -43,15 +42,13 @@ class OneRegionPipeline:
 
         icu_data = None
 
-        # TODO: Re-enable for CBSAs once typical utilization number aggregation fixed.
-        if input.region.level is not AggregationLevel.CBSA:
-            icu_input = infer_icu.RegionalInput.from_regional_data(input)
-            try:
-                icu_data = infer_icu.get_icu_timeseries_from_regional_input(
-                    icu_input, weight_by=infer_icu.ICUWeightsPath.ONE_MONTH_TRAILING_CASES
-                )
-            except KeyError:
-                _log.exception(f"Failed to run icu data for {input.region}")
+        icu_input = infer_icu.RegionalInput.from_regional_data(input)
+        try:
+            icu_data = infer_icu.get_icu_timeseries_from_regional_input(
+                icu_input, weight_by=infer_icu.ICUWeightsPath.ONE_MONTH_TRAILING_CASES
+            )
+        except KeyError:
+            _log.exception(f"Failed to run icu data for {input.region}")
 
         return OneRegionPipeline(
             region=input.region, infer_df=infer_df, icu_data=icu_data, _combined_data=input,

--- a/pyseir/run.py
+++ b/pyseir/run.py
@@ -10,6 +10,7 @@ from covidactnow.datapublic.common_fields import CommonFields
 from typing_extensions import final
 
 from libs import pipeline
+from libs.datasets import AggregationLevel
 from libs.datasets.timeseries import MultiRegionDataset
 from libs.datasets.timeseries import OneRegionTimeseriesDataset
 from pyseir.icu import infer_icu
@@ -42,13 +43,15 @@ class OneRegionPipeline:
 
         icu_data = None
 
-        icu_input = infer_icu.RegionalInput.from_regional_data(input)
-        try:
-            icu_data = infer_icu.get_icu_timeseries_from_regional_input(
-                icu_input, weight_by=infer_icu.ICUWeightsPath.ONE_MONTH_TRAILING_CASES
-            )
-        except KeyError:
-            _log.exception(f"Failed to run icu data for {input.region}")
+        # TODO: Re-enable for CBSAs once typical utilization number aggregation fixed.
+        if input.region.level is not AggregationLevel.CBSA:
+            icu_input = infer_icu.RegionalInput.from_regional_data(input)
+            try:
+                icu_data = infer_icu.get_icu_timeseries_from_regional_input(
+                    icu_input, weight_by=infer_icu.ICUWeightsPath.ONE_MONTH_TRAILING_CASES
+                )
+            except KeyError:
+                _log.exception(f"Failed to run icu data for {input.region}")
 
         return OneRegionPipeline(
             region=input.region, infer_df=infer_df, icu_data=icu_data, _combined_data=input,


### PR DESCRIPTION
This fixes a couple issues with the aggregator:
1. I updated the column used for test positivity. It was simply summing the new test positivity columns, not good.
2. NYC CBSA was missing.  This is because the boroughs are aggregated, so the missing counties made all columns be null. this is very much a short lived fix, but in the email mentioning the NYC switch, we refer to the new CBSA, so I'd like this to be included before sending out and not have everyone query a missing CBSA.