### PR TITLE
Change references of covid data public master -> main

### DIFF
--- a/.github/workflows/CI_test_deploy_api.yml
+++ b/.github/workflows/CI_test_deploy_api.yml
@@ -22,7 +22,7 @@ env:
   COVID_DATA_MODEL_REF: 'master'
 
   # To pin to an old data sets, put the branch/tag/commit here:
-  COVID_DATA_PUBLIC_REF: 'master'
+  COVID_DATA_PUBLIC_REF: 'main'
 
   # S3 Bucket (used by s3-sync-action tasks) to store final API snapshot.
   AWS_S3_BUCKET: 'data.covidactnow.org'

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   # TODO: This may no longer be used for anything anymore. Remove?
-  COVID_DATA_PUBLIC_REF: 'master'
+  COVID_DATA_PUBLIC_REF: 'main'
 
   # S3 Bucket (used by s3-sync-action tasks) to store final API snapshot.
   AWS_S3_BUCKET: 'data.covidactnow.org'

--- a/.github/workflows/python_unit_tests.yml
+++ b/.github/workflows/python_unit_tests.yml
@@ -20,7 +20,7 @@ jobs:
 
   build:
     env:
-      COVID_DATA_PUBLIC_REF: 'master'
+      COVID_DATA_PUBLIC_REF: 'main'
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/update_api_usage.yml
+++ b/.github/workflows/update_api_usage.yml
@@ -10,7 +10,7 @@ env:
   COVID_DATA_MODEL_REF: 'master'
 
   # To pin to an old data sets, put the branch/tag/commit here:
-  COVID_DATA_PUBLIC_REF: 'master'
+  COVID_DATA_PUBLIC_REF: 'main'
 
   # Used by python code that reports errors to sentry.
   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}

--- a/.github/workflows/update_repo_datasets.yml
+++ b/.github/workflows/update_repo_datasets.yml
@@ -2,7 +2,7 @@ name: Update combined datasets
 
 on:
   # This workflow is automatically triggered by
-  # https://github.com/covid-projections/covid-data-public/blob/master/.github/workflows/update_data.yml
+  # https://github.com/covid-projections/covid-data-public/blob/main/.github/workflows/update_data.yml
   # after covid-data-public datasets have been updated.
   workflow_dispatch:
     inputs:
@@ -15,7 +15,7 @@ env:
   COVID_DATA_MODEL_REF: 'master'
 
   # To pin to an old data sets, put the branch/tag/commit here:
-  COVID_DATA_PUBLIC_REF: 'master'
+  COVID_DATA_PUBLIC_REF: 'main'
 
   # Used by python code that reports errors to sentry.
   SENTRY_DSN: ${{ secrets.SENTRY_DSN }}

--- a/api/README.md
+++ b/api/README.md
@@ -184,9 +184,9 @@ For `county_summaries/<state abreviation>.summary.json` files see the [JSON Sche
 For `county/counties_top_100.json` fields see the [JSON Schema](schema/CANPredictionAPI.json)
 
 ### For State/County Calculated Results
-For files like 
-- `us/counties/<fips>.<intervention>.json` 
-- `us/states/<state abbreviation>.<intervention>.json` 
+For files like
+- `us/counties/<fips>.<intervention>.json`
+- `us/states/<state abbreviation>.<intervention>.json`
 
 see the [JSON Schema](schema/CANPredictionAPIRow.json)
 
@@ -196,7 +196,7 @@ see the [JSON Schema](schema/CANPredictionAPIRow.json)
   * **version.json** - Metadata about how the API artifacts were generated.
     * *timestamp* (string) - an ISO 8601-formatted UTC timestamp.
     * *covid-data-public*
-      * *branch* (string) - Branch name (usually "master").
+      * *branch* (string) - Branch name (usually "main").
       * *hash* (string) - Commit hash that branch was synced to.
       * *dirty* (boolean) - Whether there were any uncommitted / untracked files
         in the repo (usually false).

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -39,7 +39,7 @@ structlog==20.1.0
 structlog-sentry==1.2.2
 more_itertools==8.3.0
 -e git://github.com/covid-projections/covid-data-public.git#egg=covidactnow
-# By default, installs from the latest master of covid-data-public.
+# By default, installs from the latest main of covid-data-public.
 # If you make changes in covid-data-public locally that you want to use,
 # comment the line above and uncomment the line below.
 # -e ../covid-data-public

--- a/libs/pipeline.py
+++ b/libs/pipeline.py
@@ -86,7 +86,7 @@ def cbsa_to_location_id(cbsa_code: str) -> str:
     """Turns a CBSA code into a location_id.
 
     For information about how these identifiers are brought into the CAN code see
-    https://github.com/covid-projections/covid-data-public/tree/master/data/census-msa
+    https://github.com/covid-projections/covid-data-public/tree/main/data/census-msa
     """
     return f"iso1:us#cbsa:{cbsa_code}"
 

--- a/raw_data_QA/check_raw_case_death_data.py
+++ b/raw_data_QA/check_raw_case_death_data.py
@@ -301,10 +301,10 @@ def check_new_data(df1, df2, args, var):
 
 def get_production_hash(json_path):
     prod_snapshot_version = requests.get(json_path).json()["data_url"].split("/")[-2]
-    master_hash = requests.get(
+    main_hash = requests.get(
         f"https://data.covidactnow.org/snapshot/{prod_snapshot_version}/version.json"
     ).json()["covid-data-public"]["hash"]
-    return master_hash
+    return main_hash
 
 
 def make_outputdirs(args):

--- a/tools/maybe-trigger-web-snapshot-update.sh
+++ b/tools/maybe-trigger-web-snapshot-update.sh
@@ -30,7 +30,7 @@ prepare () {
     exit_with_usage
   fi
 
-  if [[ $COVID_DATA_MODEL_REF != "master" ]] || [[ $COVID_DATA_PUBLIC_REF != "master" ]]; then
+  if [[ $COVID_DATA_MODEL_REF != "master" ]] || [[ $COVID_DATA_PUBLIC_REF != "main" ]]; then
     echo "Not triggering covid-projections update-snapshot since this isn't a 'master' branch run."
     exit 0
   fi
@@ -46,7 +46,7 @@ exit_with_usage () {
   echo "Usage: $CMD <snapshot-id> <covid-data-model-ref> <covid-data-public-ref>"
   echo
   echo "Examples:"
-  echo "$CMD 123 master master"
+  echo "$CMD 123 master main"
   exit 1
 }
 


### PR DESCRIPTION
Should not be merged until the main branch exists, but changes all covid-data-public master references to main