### PR TITLE
Add filtering to current timeseries

### DIFF
--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -1246,8 +1246,8 @@ class AnnotationField(GetByValueMixin, ValueAsStrMixin, FieldName, enum.Enum):
 
 @enum.unique
 class AnnotationType(GetByValueMixin, ValueAsStrMixin, enum.Enum):
-    CUMULATIVE_TAIL_TRUNCATED = "cumulative_tail_truncated"
-    CUMULATIVE_LONG_TAIL_TRUNCATED = "cumulative_long_tail_truncated"
+    TAIL_TRUNCATED = "tail_truncated"
+    LONG_TAIL_TRUNCATED = "long_tail_truncated"
 
 
 @dataclass
@@ -1273,9 +1273,15 @@ class TailFilter:
 
     @staticmethod
     def run(
-        dataset: MultiRegionDataset, fields: List[FieldName]
+        dataset: MultiRegionDataset, fields: List[FieldName], is_cumulative: bool = True
     ) -> Tuple["TailFilter", MultiRegionDataset]:
-        """Returns a dataset with recent data that looks bad removed from cumulative fields."""
+        """Returns a dataset with recent data that looks bad removed from cumulative fields.
+
+        Args:
+            dataset: Input dataset
+            fields: List of fields, must be all either cumulative fields or all current fields.
+            is_cumulative: If True, fields are cumulative, if False, fields are current fields.
+        """
         timeseries_wide_dates = dataset.timeseries_wide_dates()
 
         fields_mask = timeseries_wide_dates.index.get_level_values(PdFields.VARIABLE).isin(fields)
@@ -1283,7 +1289,9 @@ class TailFilter:
         not_filtered = timeseries_wide_dates.loc[pd.IndexSlice[:, ~fields_mask], :]
 
         tail_filter = TailFilter()
-        filtered = to_filter.apply(tail_filter._filter_one_series, axis=1)
+        filtered = to_filter.apply(
+            lambda x: tail_filter._filter_one_series(x, is_cumulative=is_cumulative), axis=1
+        )
 
         merged = pd.concat([not_filtered, filtered])
         timeseries_wide_variables = merged.stack().unstack(PdFields.VARIABLE).sort_index()
@@ -1293,7 +1301,7 @@ class TailFilter:
     def annotations_as_dataframe(self):
         return pd.DataFrame(self.annotations)
 
-    def _filter_one_series(self, series_in: pd.Series) -> pd.Series:
+    def _filter_one_series(self, series_in: pd.Series, is_cumulative: bool = True) -> pd.Series:
         """Filters one timeseries of cumulative values. This is a method so self can be used to
         store side outputs.
 
@@ -1304,7 +1312,11 @@ class TailFilter:
             self.skipped_too_short += 1
             return series_in
 
-        diff = series_in.diff()
+        if is_cumulative:
+            diff = series_in.diff()
+        else:
+            diff = series_in
+
         mean = diff.iloc[
             TailFilter.TRUSTED_DATES_OLDEST : TailFilter.TRUSTED_DATES_NEWEST + 1
         ].mean()
@@ -1339,10 +1351,10 @@ class TailFilter:
             # series_in.iat[truncate_at] is the first value *not* returned
             assert TailFilter.FILTER_DATES_OLDEST <= truncate_at <= -1
             if count_observation_diff_under_threshold < TailFilter.COUNT_OBSERVATION_LONG:
-                annotation_type = AnnotationType.CUMULATIVE_TAIL_TRUNCATED
+                annotation_type = AnnotationType.TAIL_TRUNCATED
                 self.truncated += 1
             else:
-                annotation_type = AnnotationType.CUMULATIVE_LONG_TAIL_TRUNCATED
+                annotation_type = AnnotationType.LONG_TAIL_TRUNCATED
                 self.long_truncated += 1
             # Currently one annotation is created per series. Maybe it makes more sense to add
             # one for each dropped observation / real value?

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -1302,12 +1302,12 @@ class TailFilter:
         return pd.DataFrame(self.annotations)
 
     def _filter_one_series(self, series_in: pd.Series, is_cumulative: bool = True) -> pd.Series:
-        """Filters one timeseries of cumulative values. This is a method so self can be used to
+        """Filters one timeseries of values. This is a method so self can be used to
         store side outputs.
 
         Args:
             series_in: a timeseries of float values, with a sorted DatetimeIndex
-            """
+        """
         if len(series_in) < -TailFilter.TRUSTED_DATES_OLDEST:
             self.skipped_too_short += 1
             return series_in


### PR DESCRIPTION
This repurposes this existing cumulative tail series filter to filter both cumulative and current values.  I'm not sure I love calling it this way, but was the quickest way to repurpose the existing code to get both cumulative and current tail filters.  

I mostly went down this route because TN hospitalizations were cut off, this filter does end up removing those tail values.  Happy to take another approach or just disable TN for now.