### PR TITLE
calculate_test_positivity takes Dataset

### DIFF
--- a/libs/metrics/top_level_metrics.py
+++ b/libs/metrics/top_level_metrics.py
@@ -196,17 +196,9 @@ def calculate_case_density(
 
 
 def calculate_test_positivity(
-    region_dataset: OneRegionTimeseriesDataset, smooth: int = 7, lag_lookback: int = 7
+    region_dataset: OneRegionTimeseriesDataset, lag_lookback: int = 7
 ) -> pd.Series:
-    """Calculates positive test rate.
-
-    Args:
-        positive_tests: Number of cumulative positive tests.
-        negative_tests: Number of cumulative negative tests.
-
-    Returns:
-        Positive test rate.
-    """
+    """Calculates positive test rate from combined data."""
     data = region_dataset.date_indexed
     positive_tests = series_utils.interpolate_stalled_and_missing_values(
         data[CommonFields.POSITIVE_TESTS]

--- a/libs/metrics/top_level_metrics.py
+++ b/libs/metrics/top_level_metrics.py
@@ -133,11 +133,11 @@ def _lookup_test_positivity_method(
 
 
 def calculate_or_copy_test_positivity(
-    ts: OneRegionTimeseriesDataset, log,
+    dataset_in: OneRegionTimeseriesDataset, log,
 ) -> Tuple[pd.Series, TestPositivityRatioDetails]:
-    # TODO(tom): Move all these calculations to test_positivity.AllMethods or something applied to each
-    # datasource with test metrics.
-    data = ts.date_indexed
+    # TODO(tom): Move all these calculations to test_positivity.AllMethods or something applied to
+    #  each datasource with test metrics.
+    data = dataset_in.date_indexed
     # Use POSITIVE_TESTS and NEGATIVE_TEST if they are recent or TEST_POSITIVITY is not available
     # for this region.
     positive_negative_recent = has_data_in_past_10_days(
@@ -146,13 +146,13 @@ def calculate_or_copy_test_positivity(
     test_positivity = common_df.get_timeseries(data, CommonFields.TEST_POSITIVITY, EMPTY_TS)
     if positive_negative_recent or not test_positivity.notna().any():
         method = _lookup_test_positivity_method(
-            ts.provenance.get(CommonFields.POSITIVE_TESTS),
-            ts.provenance.get(CommonFields.NEGATIVE_TESTS),
+            dataset_in.provenance.get(CommonFields.POSITIVE_TESTS),
+            dataset_in.provenance.get(CommonFields.NEGATIVE_TESTS),
             log,
         )
-        test_positivity = calculate_test_positivity(ts)
+        test_positivity = calculate_test_positivity(dataset_in)
     else:
-        provenance = ts.provenance.get(CommonFields.TEST_POSITIVITY)
+        provenance = dataset_in.provenance.get(CommonFields.TEST_POSITIVITY)
         method = TestPositivityRatioMethod.get(provenance)
         if method is None:
             log.warning("Unable to find TestPositivityRatioMethod", provenance=provenance)

--- a/libs/metrics/top_level_metrics.py
+++ b/libs/metrics/top_level_metrics.py
@@ -145,20 +145,12 @@ def calculate_or_copy_test_positivity(
     ) and has_data_in_past_10_days(data[CommonFields.NEGATIVE_TESTS])
     test_positivity = common_df.get_timeseries(data, CommonFields.TEST_POSITIVITY, EMPTY_TS)
     if positive_negative_recent or not test_positivity.notna().any():
-        cumulative_positive_tests = series_utils.interpolate_stalled_and_missing_values(
-            data[CommonFields.POSITIVE_TESTS]
-        )
-        cumulative_negative_tests = series_utils.interpolate_stalled_and_missing_values(
-            data[CommonFields.NEGATIVE_TESTS]
-        )
         method = _lookup_test_positivity_method(
             ts.provenance.get(CommonFields.POSITIVE_TESTS),
             ts.provenance.get(CommonFields.NEGATIVE_TESTS),
             log,
         )
-        test_positivity = calculate_test_positivity(
-            cumulative_positive_tests, cumulative_negative_tests
-        )
+        test_positivity = calculate_test_positivity(ts)
     else:
         provenance = ts.provenance.get(CommonFields.TEST_POSITIVITY)
         method = TestPositivityRatioMethod.get(provenance)
@@ -204,7 +196,7 @@ def calculate_case_density(
 
 
 def calculate_test_positivity(
-    positive_tests: pd.Series, negative_tests: pd.Series, smooth: int = 7, lag_lookback: int = 7
+    region_dataset: OneRegionTimeseriesDataset, smooth: int = 7, lag_lookback: int = 7
 ) -> pd.Series:
     """Calculates positive test rate.
 
@@ -215,6 +207,14 @@ def calculate_test_positivity(
     Returns:
         Positive test rate.
     """
+    data = region_dataset.date_indexed
+    positive_tests = series_utils.interpolate_stalled_and_missing_values(
+        data[CommonFields.POSITIVE_TESTS]
+    )
+    negative_tests = series_utils.interpolate_stalled_and_missing_values(
+        data[CommonFields.NEGATIVE_TESTS]
+    )
+
     daily_negative_tests = negative_tests.diff()
     daily_positive_tests = positive_tests.diff()
     positive_smoothed = series_utils.smooth_with_rolling_average(daily_positive_tests)

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -29,6 +29,12 @@ from test.dataset_utils_test import read_csv_and_index_fips_date
 pytestmark = pytest.mark.filterwarnings("error", "ignore::libs.pipeline.BadFipsWarning")
 
 
+DEFAULT_FIPS = "97222"
+
+
+DEFAULT_REGION = Region.from_fips(DEFAULT_FIPS)
+
+
 @pytest.mark.parametrize("include_na_at_end", [False, True])
 def test_remove_padded_nans(include_na_at_end):
     rows = [
@@ -893,7 +899,7 @@ def test_merge_provenance():
 def _build_one_column_dataset(
     column,
     values: Union[Sequence[float], Mapping[Region, Sequence[float]]],
-    location_id="iso1:us#fips:97222",
+    location_id=DEFAULT_REGION.location_id,
     start_date="2020-08-25",
 ) -> timeseries.MultiRegionDataset:
     if isinstance(values, Mapping):

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -29,9 +29,9 @@ from test.dataset_utils_test import read_csv_and_index_fips_date
 pytestmark = pytest.mark.filterwarnings("error", "ignore::libs.pipeline.BadFipsWarning")
 
 
+# This is a totally bogus fips/region/location that we've been using as a default in some test
+# cases. It is factored out here in an attempt to reduce how much it is hard-coded into our source.
 DEFAULT_FIPS = "97222"
-
-
 DEFAULT_REGION = Region.from_fips(DEFAULT_FIPS)
 
 

--- a/test/libs/metrics/top_level_metrics_test.py
+++ b/test/libs/metrics/top_level_metrics_test.py
@@ -44,16 +44,17 @@ def build_dataset(
 ) -> timeseries.MultiRegionDataset:
     """Returns a dataset for multiple regions and metrics. Each sequence of values represents a
     timeseries metric with identical length."""
+    # From https://stackoverflow.com/a/47416248. Make a dictionary listing all the timeseries
+    # sequences in metrics.
     d = {
-        (region.location_id, var): metrics[region][var]
+        (region.location_id, variable): metrics[region][variable]
         for region in metrics.keys()
-        for var in metrics[region].keys()
+        for variable in metrics[region].keys()
     }
 
-    lengths = set(len(seq) for seq in d.values())
-    dates = pd.date_range(
-        start_date, periods=more_itertools.one(lengths), freq="D", name=CommonFields.DATE
-    )
+    # Make sure there is only one len among all of d.values()
+    sequence_lengths = more_itertools.one(len(seq) for seq in d.values())
+    dates = pd.date_range(start_date, periods=sequence_lengths, freq="D", name=CommonFields.DATE)
 
     index = pd.MultiIndex.from_tuples(
         d.keys(), names=[CommonFields.LOCATION_ID, PdFields.VARIABLE],

--- a/test/libs/metrics/top_level_metrics_test.py
+++ b/test/libs/metrics/top_level_metrics_test.py
@@ -53,7 +53,7 @@ def build_dataset(
     }
 
     # Make sure there is only one len among all of d.values()
-    sequence_lengths = more_itertools.one(len(seq) for seq in d.values())
+    sequence_lengths = more_itertools.one(set(len(seq) for seq in d.values()))
     dates = pd.date_range(start_date, periods=sequence_lengths, freq="D", name=CommonFields.DATE)
 
     index = pd.MultiIndex.from_tuples(


### PR DESCRIPTION
## This PR

This PR is part of https://trello.com/c/6ZPv7k9T/477-clean-up-redundant-test-positivity-calculation-code-api-vs-combined-dataset

* Changes `calculate_test_positivity` to run the smoothing itself and take a `OneRegionTimeseriesDataset` instead of raw DataFrame.
* Adds test helpers build_dataset and build_one_region_dataset to simplify making test data

## Tested

Ran `python ./run.py api generate-test-positivity` in master and this branch. Compared results/output/test-positivity-all.csv and results/output/test-positivity-output.csv from each. They were identical.