### PR TITLE
Test positivity calculate takes dataset

### DIFF
--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -292,6 +292,7 @@ class MultiRegionDataset(SaveableDatasetInterface):
             .sort_index()
         )
 
+    @lru_cache(maxsize=None)
     def timeseries_wide_dates(self) -> pd.DataFrame:
         """Returns the timeseries in a DataFrame with LOCATION_ID, VARIABLE index and DATE columns."""
         if self.timeseries.empty:
@@ -309,6 +310,18 @@ class MultiRegionDataset(SaveableDatasetInterface):
             .rename_axis(columns=CommonFields.DATE)
         )
         return timeseries_wide
+
+    @lru_cache(maxsize=None)
+    def timeseries_wide_dates_variable_first(self) -> pd.DataFrame:
+        return self.timeseries_wide_dates().reorder_levels(
+            [PdFields.VARIABLE, CommonFields.LOCATION_ID]
+        )
+
+    @lru_cache(maxsize=None)
+    def timeseries_wide_dates_variable_first_diff(self, *, periods: int) -> pd.DataFrame:
+        # This calculates the difference only when the cumulative value is a real value `diff_days` apart.
+        # This only works on input data that has few or no holes.
+        return self.timeseries_wide_dates_variable_first().diff(periods=periods, axis=1)
 
     def _timeseries_latest_values(self) -> pd.DataFrame:
         """Returns the latest value for every region and metric, derived from timeseries."""

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -311,16 +311,6 @@ class MultiRegionDataset(SaveableDatasetInterface):
         )
         return timeseries_wide
 
-    def timeseries_wide_dates_variable_first(self) -> pd.DataFrame:
-        return self.timeseries_wide_dates().reorder_levels(
-            [PdFields.VARIABLE, CommonFields.LOCATION_ID]
-        )
-
-    def timeseries_wide_dates_variable_first_diff(self, *, periods: int) -> pd.DataFrame:
-        # This calculates the difference only when the cumulative value is a real value `diff_days` apart.
-        # This only works on input data that has few or no holes.
-        return self.timeseries_wide_dates_variable_first().diff(periods=periods, axis=1)
-
     def _timeseries_latest_values(self) -> pd.DataFrame:
         """Returns the latest value for every region and metric, derived from timeseries."""
         if self.timeseries.columns.empty:

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -311,13 +311,11 @@ class MultiRegionDataset(SaveableDatasetInterface):
         )
         return timeseries_wide
 
-    @lru_cache(maxsize=None)
     def timeseries_wide_dates_variable_first(self) -> pd.DataFrame:
         return self.timeseries_wide_dates().reorder_levels(
             [PdFields.VARIABLE, CommonFields.LOCATION_ID]
         )
 
-    @lru_cache(maxsize=None)
     def timeseries_wide_dates_variable_first_diff(self, *, periods: int) -> pd.DataFrame:
         # This calculates the difference only when the cumulative value is a real value `diff_days` apart.
         # This only works on input data that has few or no holes.

--- a/libs/metrics/test_positivity.py
+++ b/libs/metrics/test_positivity.py
@@ -132,16 +132,16 @@ class PassThruMethod(Method):
         wide_date_df = df.loc[self._column, :]
         # Optional optimization: The following likely adds the variable/field/column name back in
         # to the index which was just taken out. Consider skipping reindexing.
+        assert wide_date_df.index.names == [CommonFields.LOCATION_ID]
         _append_variable_index_level(wide_date_df, CommonFields.TEST_POSITIVITY)
 
-        assert wide_date_df.index.names == [CommonFields.LOCATION_ID]
-        assert dataset.provenance.index.names == [CommonFields.LOCATION_ID, PdFields.VARIABLE]
-        provenance = dataset.provenance.loc[
-            wide_date_df.get_level_values(CommonFields.LOCATION_ID), self._column
-        ]
+        # assert dataset.provenance.index.names == [CommonFields.LOCATION_ID, PdFields.VARIABLE]
+        # provenance = dataset.provenance.loc[
+        #     wide_date_df.index.get_level_values(CommonFields.LOCATION_ID), self._column
+        # ]
 
-        return MultiRegionDataset.from_timeseries_wide_dates_df(wide_date_df).add_provenance_series(
-            provenance
+        return MultiRegionDataset.from_timeseries_wide_dates_df(wide_date_df).add_provenance_all(
+            self.name
         )
 
 

--- a/libs/metrics/top_level_metrics.py
+++ b/libs/metrics/top_level_metrics.py
@@ -155,7 +155,8 @@ def calculate_or_copy_test_positivity(
         provenance = dataset_in.provenance.get(CommonFields.TEST_POSITIVITY)
         method = TestPositivityRatioMethod.get(provenance)
         if method is None:
-            log.warning("Unable to find TestPositivityRatioMethod", provenance=provenance)
+            if provenance is not None:
+                log.warning("Unable to find TestPositivityRatioMethod", provenance=provenance)
             method = TestPositivityRatioMethod.OTHER
     return test_positivity, TestPositivityRatioDetails(source=method)
 

--- a/test/libs/metrics/test_positivity_test.py
+++ b/test/libs/metrics/test_positivity_test.py
@@ -12,6 +12,9 @@ from libs.metrics.test_positivity import DivisionMethod
 from libs.metrics import test_positivity
 from test.libs.datasets.timeseries_test import assert_dataset_like
 
+# turns all warnings into errors for this module
+pytestmark = pytest.mark.filterwarnings("error", "ignore::libs.pipeline.BadFipsWarning")
+
 
 def _parse_wide_dates(csv_str: str) -> pd.DataFrame:
     """Parses a string with columns for region, variable/provenance followed by dates."""
@@ -59,8 +62,8 @@ def test_basic():
     ).add_provenance_csv(
         io.StringIO(
             "location_id,variable,provenance\n"
-            "iso1:us#iso2:as,test_positivity,method2\n"
-            "iso1:us#iso2:tx,test_positivity,method1\n"
+            "iso1:us#iso2:as,test_positivity,method2()\n"
+            "iso1:us#iso2:tx,test_positivity,method1()\n"
         )
     )
     assert_dataset_like(all_methods.test_positivity, expected_positivity)
@@ -68,10 +71,10 @@ def test_basic():
     positivity_provenance = all_methods.test_positivity.provenance
     # Use loc[...].at[...] as work-around for https://github.com/pandas-dev/pandas/issues/26989
     assert positivity_provenance.loc["iso1:us#iso2:as"].to_dict() == {
-        CommonFields.TEST_POSITIVITY: "method2"
+        CommonFields.TEST_POSITIVITY: "method2()"
     }
     assert positivity_provenance.loc["iso1:us#iso2:tx"].to_dict() == {
-        CommonFields.TEST_POSITIVITY: "method1"
+        CommonFields.TEST_POSITIVITY: "method1()"
     }
 
 
@@ -116,25 +119,25 @@ def test_recent_days():
     ).add_provenance_csv(
         io.StringIO(
             "location_id,variable,provenance\n"
-            "iso1:us#iso2:us-as,test_positivity,method2\n"
-            "iso1:us#iso2:us-tx,test_positivity,method1\n"
+            "iso1:us#iso2:us-as,test_positivity,method2()\n"
+            "iso1:us#iso2:us-tx,test_positivity,method1()\n"
         )
     )
     assert_dataset_like(all_methods.test_positivity, expected_positivity)
     assert all_methods.test_positivity.get_one_region(Region.from_state("AS")).provenance == {
-        CommonFields.TEST_POSITIVITY: "method2"
+        CommonFields.TEST_POSITIVITY: "method2()"
     }
     assert all_methods.test_positivity.get_one_region(Region.from_state("TX")).provenance == {
-        CommonFields.TEST_POSITIVITY: "method1"
+        CommonFields.TEST_POSITIVITY: "method1()"
     }
 
     all_methods = AllMethods.run(ts, methods, diff_days=1, recent_days=3)
     positivity_provenance = all_methods.test_positivity.provenance
     assert positivity_provenance.loc["iso1:us#iso2:us-as"].to_dict() == {
-        CommonFields.TEST_POSITIVITY: "method1"
+        CommonFields.TEST_POSITIVITY: "method1()"
     }
     assert positivity_provenance.loc["iso1:us#iso2:us-tx"].to_dict() == {
-        CommonFields.TEST_POSITIVITY: "method1"
+        CommonFields.TEST_POSITIVITY: "method1()"
     }
 
 
@@ -159,7 +162,7 @@ def test_missing_column_for_one_method():
         AllMethods.run(ts, methods, diff_days=1, recent_days=4)
         .test_positivity.provenance.loc["iso1:us#iso2:tx"]
         .at[CommonFields.TEST_POSITIVITY]
-        == "method1"
+        == "method1()"
     )
 
 
@@ -270,8 +273,8 @@ def test_provenance():
     ).add_provenance_csv(
         io.StringIO(
             "location_id,variable,provenance\n"
-            "iso1:us#iso2:as,test_positivity,method2\n"
-            "iso1:us#iso2:tx,test_positivity,method1\n"
+            "iso1:us#iso2:as,test_positivity,method2()\n"
+            "iso1:us#iso2:tx,test_positivity,method1()\n"
         )
     )
     assert_dataset_like(all_methods.test_positivity, expected_positivity)
@@ -279,8 +282,8 @@ def test_provenance():
     positivity_provenance = all_methods.test_positivity.provenance
     # Use loc[...].at[...] as work-around for https://github.com/pandas-dev/pandas/issues/26989
     assert positivity_provenance.loc["iso1:us#iso2:as"].to_dict() == {
-        CommonFields.TEST_POSITIVITY: "method2"
+        CommonFields.TEST_POSITIVITY: "method2()"
     }
     assert positivity_provenance.loc["iso1:us#iso2:tx"].to_dict() == {
-        CommonFields.TEST_POSITIVITY: "method1"
+        CommonFields.TEST_POSITIVITY: "method1()"
     }

--- a/test/libs/metrics/test_positivity_test.py
+++ b/test/libs/metrics/test_positivity_test.py
@@ -13,7 +13,7 @@ from libs.metrics.test_positivity import DivisionMethod
 from libs.metrics import test_positivity
 from test.libs.datasets.timeseries_test import assert_dataset_like
 from test.libs.metrics import top_level_metrics_test
-from test.libs.metrics.top_level_metrics_test import TimeseriesLit
+from test.libs.metrics.top_level_metrics_test import TimeseriesLiteral
 
 
 # turns all warnings into errors for this module
@@ -230,11 +230,11 @@ def test_provenance():
     region_as = Region.from_state("AS")
     region_tx = Region.from_state("TX")
     metrics_as = {
-        CommonFields.POSITIVE_TESTS: TimeseriesLit([0, 2, 4, 6], provenance="pt_src1"),
+        CommonFields.POSITIVE_TESTS: TimeseriesLiteral([0, 2, 4, 6], provenance="pt_src1"),
         CommonFields.TOTAL_TESTS: [100, 200, 300, 400],
     }
     metrics_tx = {
-        CommonFields.POSITIVE_TESTS: TimeseriesLit([1, 2, 3, 4], provenance="pt_src2"),
+        CommonFields.POSITIVE_TESTS: TimeseriesLiteral([1, 2, 3, 4], provenance="pt_src2"),
         CommonFields.POSITIVE_TESTS_VIRAL: [10, 20, 30, 40],
         CommonFields.TOTAL_TESTS: [100, 200, 300, 400],
     }
@@ -256,11 +256,9 @@ def test_provenance():
     )
     pd.testing.assert_frame_equal(all_methods.all_methods_timeseries, expected_df, check_like=True)
 
+    expected_as = {CommonFields.TEST_POSITIVITY: TimeseriesLiteral([0.02], provenance="method2")}
+    expected_tx = {CommonFields.TEST_POSITIVITY: TimeseriesLiteral([0.1], provenance="method1")}
     expected_positivity = top_level_metrics_test.build_dataset(
-        {
-            region_as: {CommonFields.TEST_POSITIVITY: TimeseriesLit([0.02], provenance="method2")},
-            region_tx: {CommonFields.TEST_POSITIVITY: TimeseriesLit([0.1], provenance="method1")},
-        },
-        start_date="2020-04-04",
+        {region_as: expected_as, region_tx: expected_tx}, start_date="2020-04-04",
     )
     assert_dataset_like(all_methods.test_positivity, expected_positivity)

--- a/test/libs/metrics/test_positivity_test.py
+++ b/test/libs/metrics/test_positivity_test.py
@@ -229,18 +229,17 @@ def test_all_columns_na():
 def test_provenance():
     region_as = Region.from_state("AS")
     region_tx = Region.from_state("TX")
+    metrics_as = {
+        CommonFields.POSITIVE_TESTS: TimeseriesLit([0, 2, 4, 6], provenance="pt_src1"),
+        CommonFields.TOTAL_TESTS: [100, 200, 300, 400],
+    }
+    metrics_tx = {
+        CommonFields.POSITIVE_TESTS: TimeseriesLit([1, 2, 3, 4], provenance="pt_src2"),
+        CommonFields.POSITIVE_TESTS_VIRAL: [10, 20, 30, 40],
+        CommonFields.TOTAL_TESTS: [100, 200, 300, 400],
+    }
     dataset_in = top_level_metrics_test.build_dataset(
-        {
-            region_as: {
-                CommonFields.POSITIVE_TESTS: TimeseriesLit([0, 2, 4, 6], provenance="pt_src1"),
-                CommonFields.TOTAL_TESTS: [100, 200, 300, 400],
-            },
-            region_tx: {
-                CommonFields.POSITIVE_TESTS: TimeseriesLit([1, 2, 3, 4], provenance="pt_src2"),
-                CommonFields.POSITIVE_TESTS_VIRAL: [10, 20, 30, 40],
-                CommonFields.TOTAL_TESTS: [100, 200, 300, 400],
-            },
-        }
+        {region_as: metrics_as, region_tx: metrics_tx}
     )
 
     methods = [

--- a/test/libs/metrics/test_positivity_test.py
+++ b/test/libs/metrics/test_positivity_test.py
@@ -62,8 +62,8 @@ def test_basic():
     ).add_provenance_csv(
         io.StringIO(
             "location_id,variable,provenance\n"
-            "iso1:us#iso2:as,test_positivity,method2()\n"
-            "iso1:us#iso2:tx,test_positivity,method1()\n"
+            "iso1:us#iso2:as,test_positivity,method2\n"
+            "iso1:us#iso2:tx,test_positivity,method1\n"
         )
     )
     assert_dataset_like(all_methods.test_positivity, expected_positivity)
@@ -71,10 +71,10 @@ def test_basic():
     positivity_provenance = all_methods.test_positivity.provenance
     # Use loc[...].at[...] as work-around for https://github.com/pandas-dev/pandas/issues/26989
     assert positivity_provenance.loc["iso1:us#iso2:as"].to_dict() == {
-        CommonFields.TEST_POSITIVITY: "method2()"
+        CommonFields.TEST_POSITIVITY: "method2"
     }
     assert positivity_provenance.loc["iso1:us#iso2:tx"].to_dict() == {
-        CommonFields.TEST_POSITIVITY: "method1()"
+        CommonFields.TEST_POSITIVITY: "method1"
     }
 
 
@@ -119,25 +119,25 @@ def test_recent_days():
     ).add_provenance_csv(
         io.StringIO(
             "location_id,variable,provenance\n"
-            "iso1:us#iso2:us-as,test_positivity,method2()\n"
-            "iso1:us#iso2:us-tx,test_positivity,method1()\n"
+            "iso1:us#iso2:us-as,test_positivity,method2\n"
+            "iso1:us#iso2:us-tx,test_positivity,method1\n"
         )
     )
     assert_dataset_like(all_methods.test_positivity, expected_positivity)
     assert all_methods.test_positivity.get_one_region(Region.from_state("AS")).provenance == {
-        CommonFields.TEST_POSITIVITY: "method2()"
+        CommonFields.TEST_POSITIVITY: "method2"
     }
     assert all_methods.test_positivity.get_one_region(Region.from_state("TX")).provenance == {
-        CommonFields.TEST_POSITIVITY: "method1()"
+        CommonFields.TEST_POSITIVITY: "method1"
     }
 
     all_methods = AllMethods.run(ts, methods, diff_days=1, recent_days=3)
     positivity_provenance = all_methods.test_positivity.provenance
     assert positivity_provenance.loc["iso1:us#iso2:us-as"].to_dict() == {
-        CommonFields.TEST_POSITIVITY: "method1()"
+        CommonFields.TEST_POSITIVITY: "method1"
     }
     assert positivity_provenance.loc["iso1:us#iso2:us-tx"].to_dict() == {
-        CommonFields.TEST_POSITIVITY: "method1()"
+        CommonFields.TEST_POSITIVITY: "method1"
     }
 
 
@@ -162,7 +162,7 @@ def test_missing_column_for_one_method():
         AllMethods.run(ts, methods, diff_days=1, recent_days=4)
         .test_positivity.provenance.loc["iso1:us#iso2:tx"]
         .at[CommonFields.TEST_POSITIVITY]
-        == "method1()"
+        == "method1"
     )
 
 
@@ -273,8 +273,8 @@ def test_provenance():
     ).add_provenance_csv(
         io.StringIO(
             "location_id,variable,provenance\n"
-            "iso1:us#iso2:as,test_positivity,method2()\n"
-            "iso1:us#iso2:tx,test_positivity,method1()\n"
+            "iso1:us#iso2:as,test_positivity,method2\n"
+            "iso1:us#iso2:tx,test_positivity,method1\n"
         )
     )
     assert_dataset_like(all_methods.test_positivity, expected_positivity)
@@ -282,8 +282,8 @@ def test_provenance():
     positivity_provenance = all_methods.test_positivity.provenance
     # Use loc[...].at[...] as work-around for https://github.com/pandas-dev/pandas/issues/26989
     assert positivity_provenance.loc["iso1:us#iso2:as"].to_dict() == {
-        CommonFields.TEST_POSITIVITY: "method2()"
+        CommonFields.TEST_POSITIVITY: "method2"
     }
     assert positivity_provenance.loc["iso1:us#iso2:tx"].to_dict() == {
-        CommonFields.TEST_POSITIVITY: "method1()"
+        CommonFields.TEST_POSITIVITY: "method1"
     }

--- a/test/libs/metrics/test_positivity_test.py
+++ b/test/libs/metrics/test_positivity_test.py
@@ -74,15 +74,6 @@ def test_basic():
     )
     assert_dataset_like(all_methods.test_positivity, expected_positivity)
 
-    positivity_provenance = all_methods.test_positivity.provenance
-    # Use loc[...].at[...] as work-around for https://github.com/pandas-dev/pandas/issues/26989
-    assert positivity_provenance.loc["iso1:us#iso2:as"].to_dict() == {
-        CommonFields.TEST_POSITIVITY: "method2"
-    }
-    assert positivity_provenance.loc["iso1:us#iso2:tx"].to_dict() == {
-        CommonFields.TEST_POSITIVITY: "method1"
-    }
-
 
 def test_recent_days():
     ts = timeseries.MultiRegionDataset.from_csv(
@@ -274,12 +265,3 @@ def test_provenance():
         start_date="2020-04-04",
     )
     assert_dataset_like(all_methods.test_positivity, expected_positivity)
-
-    positivity_provenance = all_methods.test_positivity.provenance
-    # Use loc[...].at[...] as work-around for https://github.com/pandas-dev/pandas/issues/26989
-    assert positivity_provenance.loc["iso1:us#iso2:us-as"].to_dict() == {
-        CommonFields.TEST_POSITIVITY: "method2"
-    }
-    assert positivity_provenance.loc["iso1:us#iso2:us-tx"].to_dict() == {
-        CommonFields.TEST_POSITIVITY: "method1"
-    }

--- a/test/libs/metrics/top_level_metrics_test.py
+++ b/test/libs/metrics/top_level_metrics_test.py
@@ -43,7 +43,7 @@ INPUT_COLUMNS = [
 ]
 
 
-class TimeseriesLit(UserList):
+class TimeseriesLiteral(UserList):
     """Represents a timeseries literal, a sequence of floats and provenance string."""
 
     def __init__(self, ts_list, *, provenance=""):
@@ -52,13 +52,13 @@ class TimeseriesLit(UserList):
 
 
 def build_dataset(
-    metrics: Mapping[Region, Mapping[FieldName, Union[Sequence[float], TimeseriesLit]]],
+    metrics: Mapping[Region, Mapping[FieldName, Union[Sequence[float], TimeseriesLiteral]]],
     *,
     start_date="2020-04-01",
 ) -> timeseries.MultiRegionDataset:
     """Returns a dataset for multiple regions and metrics. Each sequence of values represents a
     timeseries metric with identical length. provenance information can be set for a metric by
-    using a TimeseriesLit. Timeseries without any real values are dropped.
+    using a TimeseriesLiteral. Timeseries without any real values are dropped.
     """
     # From https://stackoverflow.com/a/47416248. Make a dictionary listing all the timeseries
     # sequences in metrics.
@@ -84,7 +84,7 @@ def build_dataset(
     loc_var_provenance = {
         key: ts_lit.provenance
         for key, ts_lit in loc_var_seq.items()
-        if isinstance(ts_lit, TimeseriesLit)
+        if isinstance(ts_lit, TimeseriesLiteral)
     }
     if loc_var_provenance:
         provenance_index = pd.MultiIndex.from_tuples(

--- a/test/libs/metrics/top_level_metrics_test.py
+++ b/test/libs/metrics/top_level_metrics_test.py
@@ -1,9 +1,11 @@
+from collections import UserList
 from typing import Any
 from typing import List
 import dataclasses
 from typing import Mapping
 from typing import Optional
 from typing import Sequence
+from typing import Union
 
 import more_itertools
 import numpy as np
@@ -41,11 +43,22 @@ INPUT_COLUMNS = [
 ]
 
 
+class TimeseriesLit(UserList):
+    """Represents a timeseries literal, a sequence of floats and provenance string."""
+
+    def __init__(self, ts_list, *, provenance=""):
+        super().__init__(ts_list)
+        self.provenance = provenance
+
+
 def build_dataset(
-    metrics: Mapping[Region, Mapping[FieldName, Sequence[float]]], *, start_date="2020-04-01",
+    metrics: Mapping[Region, Mapping[FieldName, Union[Sequence[float], TimeseriesLit]]],
+    *,
+    start_date="2020-04-01",
 ) -> timeseries.MultiRegionDataset:
     """Returns a dataset for multiple regions and metrics. Each sequence of values represents a
-    timeseries metric with identical length. Timeseries without any real values are dropped.
+    timeseries metric with identical length. provenance information can be set for a metric by
+    using a TimeseriesLit. Timeseries without any real values are dropped.
     """
     # From https://stackoverflow.com/a/47416248. Make a dictionary listing all the timeseries
     # sequences in metrics.
@@ -66,7 +79,26 @@ def build_dataset(
 
     df = pd.DataFrame(list(loc_var_seq.values()), index=index, columns=dates)
 
-    return timeseries.MultiRegionDataset.from_timeseries_wide_dates_df(df)
+    dataset = timeseries.MultiRegionDataset.from_timeseries_wide_dates_df(df)
+
+    loc_var_provenance = {
+        key: ts_lit.provenance
+        for key, ts_lit in loc_var_seq.items()
+        if isinstance(ts_lit, TimeseriesLit)
+    }
+    if loc_var_provenance:
+        provenance_index = pd.MultiIndex.from_tuples(
+            loc_var_provenance.keys(), names=[CommonFields.LOCATION_ID, PdFields.VARIABLE]
+        )
+        provenance_series = pd.Series(
+            list(loc_var_provenance.values()),
+            dtype="str",
+            index=provenance_index,
+            name=PdFields.PROVENANCE,
+        )
+        dataset = dataset.add_provenance_series(provenance_series)
+
+    return dataset
 
 
 def build_one_region_dataset(


### PR DESCRIPTION
## This PR

This PR is part of https://trello.com/c/6ZPv7k9T/477-clean-up-redundant-test-positivity-calculation-code-api-vs-combined-dataset

* Changes the test_positivity `calculate` methods to read from a dataset class instead of raw DataFrame
* Adds cached data access methods in `MultiRegionDataset` to replace calculations that were done in `AllMethods.run`
* Adds `_make_result_dataset` which builds a Series used by add_provenance_series, replacing the call to `add_provenance_all`. This is a step towards copying provenance per location which will replace the hack of having a CommonField per source. 
* Extends `build_dataset` to use a new timeseries literal class to optionally set provenance info.

## Tested

```
git checkout master
./run.py api generate-test-positivity --output-dir results/output-master/
git checkout tgb-test-pos-df-arg
./run.py api generate-test-positivity
```
Then compared output to find no diff.

