### PR TITLE
Move annotations into MultiRegionDataset.tag

### DIFF
--- a/cli/data.py
+++ b/cli/data.py
@@ -146,7 +146,7 @@ def update(
         static_sorted.to_csv(path_prefix / wide_dates_filename.replace("wide-dates", "static"))
         # TODO(tom): When the output filename is disentangled from persist_dataset use it to
         #  store the annotations.
-        tail_filter.annotations_as_dataframe().to_csv(
+        multiregion_dataset.annotations_as_dataframe().to_csv(
             path_prefix / wide_dates_filename.replace("wide-dates", "annotations"), index=False,
         )
 
@@ -205,10 +205,10 @@ def run_bad_tails_filter(output_path: pathlib.Path):
     us_dataset = combined_datasets.load_us_timeseries_dataset()
     log = structlog.get_logger()
     log.info("Starting filter")
-    tail_filter, dataset_out = timeseries.TailFilter.run(us_dataset, CUMULATIVE_FIELDS_TO_FILTER,)
+    _, dataset_out = timeseries.TailFilter.run(us_dataset, CUMULATIVE_FIELDS_TO_FILTER,)
     log.info("Writing output")
     wide_dates_df.write_csv(dataset_out.timeseries_rows(), output_path)
-    tail_filter.annotations_as_dataframe().to_csv(
+    dataset_out.annotations_as_dataframe().to_csv(
         str(output_path).replace(".csv", "-annotations.csv"), index=False
     )
 

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -15,13 +15,14 @@ from libs.datasets import AggregationLevel
 from libs.datasets import combined_datasets
 
 from libs.datasets import timeseries
-from libs.datasets.timeseries import TagField
 from libs.datasets.timeseries import TagType
 from libs.datasets.timeseries import DatasetName
 from libs.pipeline import Region
 from test import test_helpers
 from test.dataset_utils_test import read_csv_and_index_fips
 from test.dataset_utils_test import read_csv_and_index_fips_date
+from test.test_helpers import TimeseriesLiteral
+
 
 # turns all warnings into errors for this module
 pytestmark = pytest.mark.filterwarnings("error", "ignore::libs.pipeline.BadFipsWarning")
@@ -644,6 +645,31 @@ def test_timeseries_drop_stale_timeseries_one_metric():
     assert_dataset_like(ds_out, ds_expected)
 
 
+def test_timeseries_drop_stale_timeseries_with_tag():
+    region = Region.from_state("TX")
+    values_recent = [100, 200, 300, 400]
+    values_stale = [100, 200, None, None]
+    ts_recent = TimeseriesLiteral(
+        values_recent, annotation=[(TagType.CUMULATIVE_TAIL_TRUNCATED, "2020-04-02", "taggy")]
+    )
+    ts_stale = TimeseriesLiteral(
+        values_stale, annotation=[(TagType.CUMULATIVE_TAIL_TRUNCATED, "2020-04-02", "taggy")]
+    )
+
+    dataset_in = test_helpers.build_dataset(
+        {region: {CommonFields.CASES: ts_recent, CommonFields.DEATHS: ts_stale}}
+    )
+
+    dataset_out = dataset_in.drop_stale_timeseries(pd.to_datetime("2020-04-03"))
+
+    assert len(dataset_out.tag) == 1
+    # drop_stale_timeseries preserves the empty DEATHS column so add it to dataset_expected
+    dataset_expected = test_helpers.build_dataset(
+        {region: {CommonFields.CASES: ts_recent}}, timeseries_columns=[CommonFields.DEATHS]
+    )
+    assert_dataset_like(dataset_out, dataset_expected)
+
+
 def test_timeseries_latest_values():
     dataset = timeseries.MultiRegionDataset.from_csv(
         io.StringIO(
@@ -901,6 +927,85 @@ def test_merge_provenance():
         )
 
 
+def test_append_tags():
+    region_sf = Region.from_fips("06075")
+    cases_values = [100, 200, 300, 400]
+    metrics_sf = {
+        CommonFields.POSITIVE_TESTS: TimeseriesLiteral([1, 2, 3, 4], provenance="pt_src2"),
+        CommonFields.CASES: cases_values,
+    }
+    dataset_in = test_helpers.build_dataset({region_sf: metrics_sf})
+    tag_sf_cases = test_helpers.TagLiteral(
+        region_sf, CommonFields.CASES, "2020-04-02", TagType.CUMULATIVE_TAIL_TRUNCATED, "Truncate"
+    )
+    tag_df = pd.DataFrame.from_records([tag_sf_cases.to_dict()])
+    dataset_out = dataset_in.append_tag_df(tag_df)
+    metrics_sf[CommonFields.CASES] = TimeseriesLiteral(
+        cases_values, annotation=[tag_sf_cases.to_annotation_tuple()]
+    )
+    dataset_expected = test_helpers.build_dataset({region_sf: metrics_sf})
+
+    assert_dataset_like(dataset_out, dataset_expected)
+
+
+def test_add_provenance_all_with_tags():
+    """Checks that add_provenance_all (and add_provenance_series that it calls) preserves tags."""
+    region = Region.from_state("TX")
+    cases_values = [100, 200, 300, 400]
+    cases_tag = test_helpers.TagLiteral(
+        region, CommonFields.CASES, "2020-04-02", TagType.CUMULATIVE_TAIL_TRUNCATED, "Truncate"
+    )
+    timeseries = TimeseriesLiteral(cases_values, annotation=[cases_tag.to_annotation_tuple()])
+    dataset_in = test_helpers.build_dataset({region: {CommonFields.CASES: timeseries}})
+
+    dataset_out = dataset_in.add_provenance_all("prov_prov")
+
+    timeseries.provenance = "prov_prov"
+    dataset_expected = test_helpers.build_dataset({region: {CommonFields.CASES: timeseries}})
+
+    assert_dataset_like(dataset_out, dataset_expected)
+
+
+def test_join_columns_with_tags():
+    """Checks that join_columns preserves tags."""
+    region = Region.from_state("TX")
+    cases_values = [100, 200, 300, 400]
+    ts_lit = TimeseriesLiteral(
+        cases_values, annotation=[(TagType.CUMULATIVE_TAIL_TRUNCATED, "2020-04-02", "taggy")]
+    )
+    dataset_cases = test_helpers.build_dataset({region: {CommonFields.CASES: ts_lit}})
+    dataset_deaths = test_helpers.build_dataset({region: {CommonFields.DEATHS: ts_lit}})
+
+    dataset_out = dataset_cases.join_columns(dataset_deaths)
+
+    assert len(dataset_out.tag) == 2
+    # The following checks that the tags in `ts_lit` have been preserved.
+    dataset_expected = test_helpers.build_dataset(
+        {region: {CommonFields.CASES: ts_lit, CommonFields.DEATHS: ts_lit}}
+    )
+
+    assert_dataset_like(dataset_out, dataset_expected)
+
+
+def test_drop_column_with_tags():
+    """Checks that join_columns preserves tags."""
+    region = Region.from_state("TX")
+    cases_values = [100, 200, 300, 400]
+    ts_lit = TimeseriesLiteral(
+        cases_values, annotation=[(TagType.CUMULATIVE_TAIL_TRUNCATED, "2020-04-02", "taggy")]
+    )
+
+    dataset_in = test_helpers.build_dataset(
+        {region: {CommonFields.CASES: ts_lit, CommonFields.DEATHS: ts_lit}}
+    )
+
+    dataset_out = dataset_in.drop_column_if_present(CommonFields.DEATHS)
+
+    assert len(dataset_out.tag) == 1
+    dataset_expected = test_helpers.build_dataset({region: {CommonFields.CASES: ts_lit}})
+    assert_dataset_like(dataset_out, dataset_expected)
+
+
 def test_remove_outliers():
     values = [10.0] * 7 + [1000.0]
     dataset = test_helpers.build_default_region_dataset({CommonFields.NEW_CASES: values})
@@ -964,26 +1069,23 @@ def test_tail_filter_stalled_timeseries():
     ds_in = test_helpers.build_default_region_dataset({CommonFields.NEW_CASES: values_stalled})
     tail_filter, ds_out = timeseries.TailFilter.run(ds_in, [CommonFields.NEW_CASES])
     _assert_tail_filter_counts(tail_filter, truncated=1)
-    assert tail_filter.annotations == [
-        {
-            TagField.TYPE: TagType.CUMULATIVE_TAIL_TRUNCATED,
-            TagField.VARIABLE: CommonFields.NEW_CASES,
-            TagField.LOCATION_ID: "iso1:us#fips:97222",
-            TagField.DATE: pd.to_datetime("2020-04-24"),
-            TagField.CONTENT: "Removed 4 observations that look suspicious compared to "
-            "mean diff of 1000.0 a few weeks ago.",
-        }
-    ]
-    ds_expected = test_helpers.build_default_region_dataset(
-        {CommonFields.NEW_CASES: values_increasing}
+    tag_content = (
+        "Removed 4 observations that look suspicious compared to mean diff of 1000.0 a few weeks "
+        "ago."
     )
-    assert_dataset_like(ds_out, ds_expected, compare_tags=False)
+    truncated_timeseries = test_helpers.TimeseriesLiteral(
+        values_increasing,
+        annotation=[(TagType.CUMULATIVE_TAIL_TRUNCATED, "2020-04-24", tag_content)],
+    )
+    ds_expected = test_helpers.build_default_region_dataset(
+        {CommonFields.NEW_CASES: truncated_timeseries}
+    )
+    assert_dataset_like(ds_out, ds_expected)
 
     # Try again with one day less, not enough for the filter so it returns the data unmodified.
     ds_in = test_helpers.build_default_region_dataset({CommonFields.NEW_CASES: values_stalled[:-1]})
     tail_filter, ds_out = timeseries.TailFilter.run(ds_in, [CommonFields.NEW_CASES])
     _assert_tail_filter_counts(tail_filter, skipped_too_short=1)
-    assert tail_filter.annotations == []
     assert_dataset_like(ds_out, ds_in)
 
 
@@ -996,7 +1098,6 @@ def test_tail_filter_mean_nan():
     ds_in = test_helpers.build_default_region_dataset({CommonFields.NEW_CASES: values})
     tail_filter, ds_out = timeseries.TailFilter.run(ds_in, [CommonFields.NEW_CASES])
     _assert_tail_filter_counts(tail_filter, skipped_na_mean=1)
-    assert tail_filter.annotations == []
     assert_dataset_like(ds_out, ds_in, drop_na_dates=True)
 
 
@@ -1046,7 +1147,6 @@ def test_tail_filter_zero_diff():
     tail_filter, ds_out = timeseries.TailFilter.run(ds_in, [CommonFields.CASES])
     _assert_tail_filter_counts(tail_filter, all_good=1)
     assert_dataset_like(ds_out, ds_in, drop_na_dates=True)
-    assert tail_filter.annotations == []
 
 
 @pytest.mark.parametrize("stall_count", [0, 1, 2, 4])
@@ -1059,7 +1159,6 @@ def test_tail_filter_small_diff(stall_count: int):
     tail_filter, ds_out = timeseries.TailFilter.run(ds_in, [CommonFields.CASES])
     _assert_tail_filter_counts(tail_filter, all_good=1)
     assert_dataset_like(ds_out, ds_in, drop_na_dates=True)
-    assert tail_filter.annotations == []
 
 
 @pytest.mark.parametrize(

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -298,6 +298,7 @@ def assert_dataset_like(
     drop_na_latest=False,
     drop_na_dates=False,
     check_less_precise=False,
+    compare_tags=True,
 ):
     """Asserts that two datasets contain similar date, ignoring order."""
     ts1 = _timeseries_sorted_by_location_date(
@@ -321,6 +322,11 @@ def assert_dataset_like(
         pd.testing.assert_series_equal(
             ds1.provenance, ds2.provenance, check_less_precise=check_less_precise
         )
+
+    if compare_tags:
+        tag1 = ds1.tag.astype("string")
+        tag2 = ds2.tag.astype("string")
+        pd.testing.assert_series_equal(tag1, tag2)
 
 
 def test_append_regions():
@@ -971,7 +977,7 @@ def test_tail_filter_stalled_timeseries():
     ds_expected = test_helpers.build_default_region_dataset(
         {CommonFields.NEW_CASES: values_increasing}
     )
-    assert_dataset_like(ds_out, ds_expected)
+    assert_dataset_like(ds_out, ds_expected, compare_tags=False)
 
     # Try again with one day less, not enough for the filter so it returns the data unmodified.
     ds_in = test_helpers.build_default_region_dataset({CommonFields.NEW_CASES: values_stalled[:-1]})
@@ -1016,8 +1022,7 @@ def test_tail_filter_two_series():
         {CommonFields.POSITIVE_TESTS: pos_tests, CommonFields.TOTAL_TESTS: tot_tests}
     )
     _assert_tail_filter_counts(tail_filter, truncated=2)
-    assert_dataset_like(ds_out, ds_expected, drop_na_dates=True)
-    # TODO(tom): check this... assert set(tail_filter.annotations) == { {} }
+    assert_dataset_like(ds_out, ds_expected, drop_na_dates=True, compare_tags=False)
 
 
 def test_tail_filter_diff_goes_negative():
@@ -1030,8 +1035,7 @@ def test_tail_filter_diff_goes_negative():
     tail_filter, ds_out = timeseries.TailFilter.run(ds_in, [CommonFields.CASES])
     ds_expected = test_helpers.build_default_region_dataset({CommonFields.CASES: values[:-1]})
     _assert_tail_filter_counts(tail_filter, truncated=1)
-    assert_dataset_like(ds_out, ds_expected, drop_na_dates=True)
-    # TODO(tom): check this... assert set(tail_filter.annotations) == { {} }
+    assert_dataset_like(ds_out, ds_expected, drop_na_dates=True, compare_tags=False)
 
 
 def test_tail_filter_zero_diff():
@@ -1087,8 +1091,7 @@ def test_tail_filter_long_stall(stall_count: int, annotation_type: TagType):
     elif annotation_type is TagType.CUMULATIVE_LONG_TAIL_TRUNCATED:
         _assert_tail_filter_counts(tail_filter, long_truncated=1)
 
-    assert_dataset_like(ds_out, ds_expected, drop_na_dates=True)
-    # TODO(tom): check this... assert set(tail_filter.annotations) == { {} }
+    assert_dataset_like(ds_out, ds_expected, drop_na_dates=True, compare_tags=False)
 
 
 def test_timeseries_empty_timeseries_and_static():


### PR DESCRIPTION
## This PR

This PR is part of https://trello.com/c/Cq2zNk2M/674-annotate-data-outliers-that-weve-flagged-in-the-ui

With this change annotations get all the way from the tail filter to the final combined data object. Next step will be writing and reading them and getting them to the API code.

* Adds method `MulitRegionDataset.append_tag_df`. 
* Tweaks `MulitRegionDataset.__post_init__` to explicitly check for dates instead of depending on `to_datetime` raising an exception. This catches places where a string representation of date gets into the index.
* Moves access to annotations from through `TailFilter.annotations_as_dataframe()` to `MulitRegionDataset.annotations_as_dataframe()`. 
* Adds test_helper code for tags/annotations

## Tested

Ran the following commands to check that annotations made their way to the final MulitRegionDataset.  The `csvcut` is there to make the column order consistent with the current output. The only diff is annotations for us-vi metrics were dropped because we don't have population data for VI.
```
./run.py data update
cp data/multiregion-annotations.csv data/multiregion-annotations.csv-as-written
csvcut -c location_id,variable,tag_type,content,date data/multiregion-annotations.csv-as-written > data/multiregion-annotations.csv
git difftool --no-prompt -t vimdiff main -- data/multiregion-annotations.csv
```
