### PR TITLE
test_positivity_test TimeseriesLiteral

### DIFF
--- a/cli/api.py
+++ b/cli/api.py
@@ -5,7 +5,6 @@ from typing import Mapping
 from typing import Optional
 
 import click
-import structlog
 
 import us
 from covidactnow.datapublic.common_fields import CommonFields
@@ -19,7 +18,6 @@ from api import update_open_api_spec
 from libs.datasets import timeseries
 from libs.datasets.timeseries import MultiRegionDataset
 from libs.metrics import test_positivity
-from libs.metrics import top_level_metrics
 from libs.datasets import combined_datasets
 from libs.datasets.dataset_utils import REPO_ROOT
 from libs.datasets.dataset_utils import AggregationLevel

--- a/cli/api.py
+++ b/cli/api.py
@@ -112,11 +112,9 @@ def _write_dataset_map(
     output_path: pathlib.Path,
     all_methods_datasets: Mapping[timeseries.DatasetName, MultiRegionDataset],
 ):
-
-    # For debugging create a DataFrame with the calculated timeseries of all methods, including
-    # timeseries that are not recent.
+    """Writes a map from DatasetName to dataset, used for debugging test positivity."""
     all_datasets_df = pd.concat(
-        {name: ds.all_output.timeseries_rows() for name, ds in all_methods_datasets.items()},
+        {name: ds.timeseries_rows() for name, ds in all_methods_datasets.items()},
         names=[PdFields.DATASET, CommonFields.LOCATION_ID, PdFields.VARIABLE],
     )
     all_methods = (

--- a/libs/metrics/test_positivity.py
+++ b/libs/metrics/test_positivity.py
@@ -348,6 +348,7 @@ class AllMethods:
     def run(
         dataset_in: MultiRegionDataset,
         methods: Sequence[Method] = TEST_POSITIVITY_METHODS,
+        *,
         diff_days: int = 7,
     ) -> "AllMethods":
         """Runs `methods` on `dataset_in` and returns the results or raises a TestPositivityException."""

--- a/libs/metrics/test_positivity.py
+++ b/libs/metrics/test_positivity.py
@@ -378,11 +378,13 @@ class AllMethods:
         calculated_dataset_recent_map = {
             name: method_output.recent for name, method_output in calculated_dataset_map.items()
         }
-        # HACK: If SmoothedTests is in calculated_dataset_recent_map (that is the
-        # MethodOutput.recent returned by `calculate`) then add it again at the end of the map with
-        # the Method.all_output. Remember that dict entries remain in the order inserted. This makes
-        # SmoothedTests the final fallback for a location if no other Method has a timeseries for
-        # it.
+        calculated_dataset_all_map = {
+            name: method_output.all_output for name, method_output in calculated_dataset_map.items()
+        }
+        # HACK: If SmoothedTests is in calculated_dataset_map (that is the MethodOutput returned by
+        # `calculate`) then add it again at the end of the map with the Method.all_output. Remember
+        # that dict entries remain in the order inserted. This makes # SmoothedTests the final
+        # fallback for a location if no other Method has a timeseries for it.
         old_method_output: Optional[MethodOutput] = calculated_dataset_map.get(
             timeseries.DatasetName("SmoothedTests")
         )
@@ -399,7 +401,7 @@ class AllMethods:
             {},
         )
         return AllMethods(
-            all_methods_datasets=calculated_dataset_map, test_positivity=test_positivity
+            all_methods_datasets=calculated_dataset_all_map, test_positivity=test_positivity
         )
 
     @staticmethod

--- a/libs/metrics/test_positivity.py
+++ b/libs/metrics/test_positivity.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 import dataclasses
-import pathlib
 from itertools import chain
 from typing import Iterable
 from typing import List

--- a/test/libs/metrics/test_positivity_test.py
+++ b/test/libs/metrics/test_positivity_test.py
@@ -7,6 +7,7 @@ import pytest
 from covidactnow.datapublic import common_df
 
 from covidactnow.datapublic.common_fields import CommonFields
+from covidactnow.datapublic.common_fields import FieldName
 from freezegun import freeze_time
 
 from test import test_helpers
@@ -40,19 +41,20 @@ def _replace_methods_attribute(methods: List[Method], **kwargs) -> List[Method]:
 
 
 def test_basic():
-    ts = timeseries.MultiRegionDataset.from_csv(
-        io.StringIO(
-            "location_id,date,positive_tests,positive_tests_viral,total_tests,\n"
-            "iso1:us#iso2:as,2020-04-01,0,,100\n"
-            "iso1:us#iso2:as,2020-04-02,2,,200\n"
-            "iso1:us#iso2:as,2020-04-03,4,,300\n"
-            "iso1:us#iso2:as,2020-04-04,6,,400\n"
-            "iso1:us#iso2:tx,2020-04-01,1,10,100\n"
-            "iso1:us#iso2:tx,2020-04-02,2,20,200\n"
-            "iso1:us#iso2:tx,2020-04-03,3,30,300\n"
-            "iso1:us#iso2:tx,2020-04-04,4,40,400\n"
-        )
-    )
+    region_as = Region.from_state("AS")
+    region_tx = Region.from_state("TX")
+    metrics_as = {
+        CommonFields.POSITIVE_TESTS: TimeseriesLiteral([0, 2, 4, 6], provenance="pos"),
+        CommonFields.TOTAL_TESTS: TimeseriesLiteral([100, 200, 300, 400]),
+    }
+    metrics_tx = {
+        CommonFields.POSITIVE_TESTS: TimeseriesLiteral([1, 2, 3, 4], provenance="pos"),
+        CommonFields.POSITIVE_TESTS_VIRAL: TimeseriesLiteral(
+            [10, 20, 30, 40], provenance="pos_viral"
+        ),
+        CommonFields.TOTAL_TESTS: TimeseriesLiteral([100, 200, 300, 400]),
+    }
+    ds = test_helpers.build_dataset({region_as: metrics_as, region_tx: metrics_tx})
 
     methods = [
         DivisionMethod(
@@ -62,46 +64,48 @@ def test_basic():
             DatasetName("method2"), CommonFields.POSITIVE_TESTS, CommonFields.TOTAL_TESTS
         ),
     ]
-    all_methods = AllMethods.run(ts, methods, 3)
+    all_methods = AllMethods.run(ds, methods, diff_days=3)
 
     expected_df = _parse_wide_dates(
         "location_id,dataset,2020-04-01,2020-04-02,2020-04-03,2020-04-04\n"
-        "iso1:us#iso2:as,method2,,,,0.02\n"
-        "iso1:us#iso2:tx,method1,,,,0.1\n"
-        "iso1:us#iso2:tx,method2,,,,0.01\n"
+        "iso1:us#iso2:us-as,method2,,,,0.02\n"
+        "iso1:us#iso2:us-tx,method1,,,,0.1\n"
+        "iso1:us#iso2:us-tx,method2,,,,0.01\n"
     )
     pd.testing.assert_frame_equal(all_methods.all_methods_timeseries, expected_df, check_like=True)
 
-    expected_positivity = timeseries.MultiRegionDataset.from_csv(
-        io.StringIO(
-            "location_id,date,test_positivity\n"
-            "iso1:us#iso2:as,2020-04-04,0.02\n"
-            "iso1:us#iso2:tx,2020-04-04,0.1\n"
-        )
-    ).add_provenance_csv(
-        io.StringIO(
-            "location_id,variable,provenance\n"
-            "iso1:us#iso2:as,test_positivity,method2\n"
-            "iso1:us#iso2:tx,test_positivity,method1\n"
-        )
+    expected_positivity = test_helpers.build_dataset(
+        {
+            region_as: {
+                CommonFields.TEST_POSITIVITY: TimeseriesLiteral([0.02], provenance="method2")
+            },
+            region_tx: {
+                CommonFields.TEST_POSITIVITY: TimeseriesLiteral([0.1], provenance="method1")
+            },
+        },
+        start_date="2020-04-04",
     )
     test_helpers.assert_dataset_like(all_methods.test_positivity, expected_positivity)
 
 
 def test_recent_days():
-    ts = timeseries.MultiRegionDataset.from_csv(
-        io.StringIO(
-            "location_id,date,positive_tests,positive_tests_viral,total_tests,\n"
-            "iso1:us#iso2:us-as,2020-04-01,0,0,100\n"
-            "iso1:us#iso2:us-as,2020-04-02,2,20,200\n"
-            "iso1:us#iso2:us-as,2020-04-03,4,,300\n"
-            "iso1:us#iso2:us-as,2020-04-04,6,,400\n"
-            "iso1:us#iso2:us-tx,2020-04-01,1,10,100\n"
-            "iso1:us#iso2:us-tx,2020-04-02,2,20,200\n"
-            "iso1:us#iso2:us-tx,2020-04-03,3,30,300\n"
-            "iso1:us#iso2:us-tx,2020-04-04,4,40,400\n"
-        )
-    )
+    region_as = Region.from_state("AS")
+    region_tx = Region.from_state("TX")
+    metrics_as = {
+        CommonFields.POSITIVE_TESTS: TimeseriesLiteral([0, 2, 4, 6], provenance="pos"),
+        CommonFields.POSITIVE_TESTS_VIRAL: TimeseriesLiteral(
+            [0, 20, None, None], provenance="pos_viral"
+        ),
+        CommonFields.TOTAL_TESTS: TimeseriesLiteral([100, 200, 300, 400]),
+    }
+    metrics_tx = {
+        CommonFields.POSITIVE_TESTS: TimeseriesLiteral([1, 2, 3, 4], provenance="pos"),
+        CommonFields.POSITIVE_TESTS_VIRAL: TimeseriesLiteral(
+            [10, 20, 30, 40], provenance="pos_viral"
+        ),
+        CommonFields.TOTAL_TESTS: TimeseriesLiteral([100, 200, 300, 400]),
+    }
+    ds = test_helpers.build_dataset({region_as: metrics_as, region_tx: metrics_tx})
     methods = [
         DivisionMethod(
             DatasetName("method1"), CommonFields.POSITIVE_TESTS_VIRAL, CommonFields.TOTAL_TESTS
@@ -111,7 +115,7 @@ def test_recent_days():
         ),
     ]
     methods = _replace_methods_attribute(methods, recent_days=2)
-    all_methods = AllMethods.run(ts, methods, diff_days=1)
+    all_methods = AllMethods.run(ds, methods, diff_days=1)
 
     expected_all = _parse_wide_dates(
         "location_id,dataset,2020-04-01,2020-04-02,2020-04-03,2020-04-04\n"
@@ -121,33 +125,31 @@ def test_recent_days():
         "iso1:us#iso2:us-tx,method2,,0.01,0.01,0.01\n"
     )
     pd.testing.assert_frame_equal(all_methods.all_methods_timeseries, expected_all, check_like=True)
-    expected_positivity = timeseries.MultiRegionDataset.from_csv(
-        io.StringIO(
-            "location_id,date,test_positivity\n"
-            "iso1:us#iso2:us-as,2020-04-02,0.02\n"
-            "iso1:us#iso2:us-as,2020-04-03,0.02\n"
-            "iso1:us#iso2:us-as,2020-04-04,0.02\n"
-            "iso1:us#iso2:us-tx,2020-04-02,0.1\n"
-            "iso1:us#iso2:us-tx,2020-04-03,0.1\n"
-            "iso1:us#iso2:us-tx,2020-04-04,0.1\n"
-        )
-    ).add_provenance_csv(
-        io.StringIO(
-            "location_id,variable,provenance\n"
-            "iso1:us#iso2:us-as,test_positivity,method2\n"
-            "iso1:us#iso2:us-tx,test_positivity,method1\n"
-        )
+    expected_positivity = test_helpers.build_dataset(
+        {
+            region_as: {
+                CommonFields.TEST_POSITIVITY: TimeseriesLiteral(
+                    [0.02, 0.02, 0.02], provenance="method2"
+                )
+            },
+            region_tx: {
+                CommonFields.TEST_POSITIVITY: TimeseriesLiteral(
+                    [0.1, 0.1, 0.1], provenance="method1"
+                )
+            },
+        },
+        start_date="2020-04-02",
     )
     test_helpers.assert_dataset_like(all_methods.test_positivity, expected_positivity)
-    assert all_methods.test_positivity.get_one_region(Region.from_state("AS")).provenance == {
+    assert all_methods.test_positivity.get_one_region(region_as).provenance == {
         CommonFields.TEST_POSITIVITY: "method2"
     }
-    assert all_methods.test_positivity.get_one_region(Region.from_state("TX")).provenance == {
+    assert all_methods.test_positivity.get_one_region(region_tx).provenance == {
         CommonFields.TEST_POSITIVITY: "method1"
     }
 
     methods = _replace_methods_attribute(methods, recent_days=3)
-    all_methods = AllMethods.run(ts, methods, diff_days=1)
+    all_methods = AllMethods.run(ds, methods, diff_days=1)
     positivity_provenance = all_methods.test_positivity.provenance
     assert positivity_provenance.loc["iso1:us#iso2:us-as"].to_dict() == {
         CommonFields.TEST_POSITIVITY: "method1"
@@ -158,14 +160,12 @@ def test_recent_days():
 
 
 def test_missing_column_for_one_method():
-    ts = timeseries.MultiRegionDataset.from_csv(
-        io.StringIO(
-            "location_id,date,positive_tests,positive_tests_viral,total_tests\n"
-            "iso1:us#iso2:tx,2020-04-01,1,10,100\n"
-            "iso1:us#iso2:tx,2020-04-02,2,20,200\n"
-            "iso1:us#iso2:tx,2020-04-03,3,30,300\n"
-            "iso1:us#iso2:tx,2020-04-04,4,40,400\n"
-        )
+    ds = test_helpers.build_default_region_dataset(
+        {
+            CommonFields.POSITIVE_TESTS: [1, 2, 3, 4],
+            CommonFields.POSITIVE_TESTS_VIRAL: [10, 20, 30, 40],
+            CommonFields.TOTAL_TESTS: [100, 200, 300, 400],
+        }
     )
     methods = [
         DivisionMethod(
@@ -182,22 +182,16 @@ def test_missing_column_for_one_method():
     ]
     methods = _replace_methods_attribute(methods, recent_days=4)
     assert (
-        AllMethods.run(ts, methods, diff_days=1)
-        .test_positivity.provenance.loc["iso1:us#iso2:tx"]
+        AllMethods.run(ds, methods, diff_days=1)
+        .test_positivity.provenance.loc[test_helpers.DEFAULT_REGION.location_id]
         .at[CommonFields.TEST_POSITIVITY]
         == "method1"
     )
 
 
 def test_missing_columns_for_all_tests():
-    ts = timeseries.MultiRegionDataset.from_csv(
-        io.StringIO(
-            "location_id,date,m1,m2,m3\n"
-            "iso1:us#iso2:tx,2020-04-01,1,10,100\n"
-            "iso1:us#iso2:tx,2020-04-02,2,20,200\n"
-            "iso1:us#iso2:tx,2020-04-03,3,30,300\n"
-            "iso1:us#iso2:tx,2020-04-04,4,40,400\n"
-        )
+    ds = test_helpers.build_default_region_dataset(
+        {FieldName("m1"): [1, 2, 3, 4], FieldName("m2"): [10, 20, 30, 40]}
     )
     methods = [
         DivisionMethod(
@@ -214,7 +208,7 @@ def test_missing_columns_for_all_tests():
     ]
     methods = _replace_methods_attribute(methods, recent_days=4)
     with pytest.raises(test_positivity.NoMethodsWithRelevantColumns):
-        AllMethods.run(ts, methods, diff_days=1)
+        AllMethods.run(ds, methods, diff_days=1)
 
 
 def test_column_present_with_no_data():
@@ -281,7 +275,7 @@ def test_provenance():
             DatasetName("method2"), CommonFields.POSITIVE_TESTS, CommonFields.TOTAL_TESTS
         ),
     ]
-    all_methods = AllMethods.run(dataset_in, methods, 3)
+    all_methods = AllMethods.run(dataset_in, methods, diff_days=3)
 
     expected_df = _parse_wide_dates(
         "location_id,dataset,2020-04-01,2020-04-02,2020-04-03,2020-04-04\n"

--- a/test/libs/metrics/test_positivity_test.py
+++ b/test/libs/metrics/test_positivity_test.py
@@ -66,14 +66,6 @@ def test_basic():
     ]
     all_methods = AllMethods.run(ds, methods, diff_days=3)
 
-    expected_df = _parse_wide_dates(
-        "location_id,dataset,2020-04-01,2020-04-02,2020-04-03,2020-04-04\n"
-        "iso1:us#iso2:us-as,method2,,,,0.02\n"
-        "iso1:us#iso2:us-tx,method1,,,,0.1\n"
-        "iso1:us#iso2:us-tx,method2,,,,0.01\n"
-    )
-    pd.testing.assert_frame_equal(all_methods.all_methods_timeseries, expected_df, check_like=True)
-
     expected_positivity = test_helpers.build_dataset(
         {
             region_as: {
@@ -117,14 +109,6 @@ def test_recent_days():
     methods = _replace_methods_attribute(methods, recent_days=2)
     all_methods = AllMethods.run(ds, methods, diff_days=1)
 
-    expected_all = _parse_wide_dates(
-        "location_id,dataset,2020-04-01,2020-04-02,2020-04-03,2020-04-04\n"
-        "iso1:us#iso2:us-as,method1,,0.2,,\n"
-        "iso1:us#iso2:us-as,method2,,0.02,0.02,0.02\n"
-        "iso1:us#iso2:us-tx,method1,,0.1,0.1,0.1\n"
-        "iso1:us#iso2:us-tx,method2,,0.01,0.01,0.01\n"
-    )
-    pd.testing.assert_frame_equal(all_methods.all_methods_timeseries, expected_all, check_like=True)
     expected_positivity = test_helpers.build_dataset(
         {
             region_as: {
@@ -276,14 +260,6 @@ def test_provenance():
         ),
     ]
     all_methods = AllMethods.run(dataset_in, methods, diff_days=3)
-
-    expected_df = _parse_wide_dates(
-        "location_id,dataset,2020-04-01,2020-04-02,2020-04-03,2020-04-04\n"
-        "iso1:us#iso2:us-as,method2,,,,0.02\n"
-        "iso1:us#iso2:us-tx,method1,,,,0.1\n"
-        "iso1:us#iso2:us-tx,method2,,,,0.01\n"
-    )
-    pd.testing.assert_frame_equal(all_methods.all_methods_timeseries, expected_df, check_like=True)
 
     expected_as = {CommonFields.TEST_POSITIVITY: TimeseriesLiteral([0.02], provenance="method2")}
     expected_tx = {CommonFields.TEST_POSITIVITY: TimeseriesLiteral([0.1], provenance="method1")}


### PR DESCRIPTION
This PR cleans up some test positivity tests to simplify a future change which makes more use of the provenance tag. This changes how the output files are written, but they are only used for debugging.

* changes most test_positivity_test to use TimeseriesLiteral so it is easier to set the provenance
* writes test_positivity final_result using timeseries_rows() instead of custom code
* writes a Mapping[timeseries.DatasetName, MultiRegionDataset] instead of custom test_positivity write.
* removes all_methods.all_methods_timeseries checks in test_positivity_test. 

## Tested

In main ran `python ./run.py api generate-test-positivity --output-dir results/output-main/` and in this branch `python ./run.py api generate-test-positivity --output-dir results/output-tgb-positivity-test-cleanup` then compared the outputs. This branch adds a column `provenance` in test-positivity-all.csv and stops writing timeseries without real values in `test-positivity-output.csv`.
