### PR TITLE
in wide-dates csv put most recent data on left, truncate decimals and extra commas. update pytest

### DIFF
--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -838,8 +838,8 @@ class MultiRegionDataset:
         """Writes `self` to files referenced by `pointer`."""
         wide_df = self.timeseries_rows()
 
-        # 6 significant digits of precision seems like enough.
-        csv_buf = wide_df.to_csv(index=True, float_format="%.6g")
+        # 7 significant digits of precision seems like enough.
+        csv_buf = wide_df.to_csv(index=True, float_format="%.7g")
         # Most timeseries don't go back to the oldest dates in the CSV so they are represented by
         # a row ending in lots of commas. Remove these because CSV readers seem to handle rows
         # with missing commas correctly.

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -769,9 +769,7 @@ class MultiRegionDataset:
         wide_dates.columns = wide_dates.columns.strftime("%Y-%m-%d")
         # When I look at the CSV I'm usually looking for the most recent values so reverse the
         # dates to put the most recent on the left.
-        # TODO(tom): When new code seems stable uncomment the following line. For now leave dates
-        #  with most recent on right to reduce diff from what is is currently written.
-        # wide_dates = wide_dates.loc[:, wide_dates.columns[-1::-1]]
+        wide_dates = wide_dates.loc[:, wide_dates.columns[-1::-1]]
         wide_dates = wide_dates.rename_axis(None, axis="columns")
 
         if not self.provenance.empty:
@@ -838,9 +836,7 @@ class MultiRegionDataset:
     def write_to_dataset_pointer(self, pointer: dataset_pointer.DatasetPointer):
         """Writes `self` to files referenced by `pointer`."""
         wide_df = self.timeseries_rows()
-        # TODO(tom): Change to %.5g after new code seems stable. For now leaving .12g to reduce
-        #  diff from what is currently written.
-        wide_df.to_csv(pointer.path_wide_dates(), index=True, float_format="%.12g")
+        wide_df.to_csv(pointer.path_wide_dates(), index=True, float_format="%.5g")
 
         self.annotations_as_dataframe().to_csv(pointer.path_annotation(), index=False)
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,7 @@
 # Requirements file containing packages needed for testing.
 # These should *not* be installed in non-test environments.
 
-pytest==5.4.2
+pytest==6.2.1
 pytest-pylint==0.17.0
 pytest-xdist==1.34.0
 pytest-mock >= 1.10.4

--- a/test/libs/datasets/combined_dataset_utils_test.py
+++ b/test/libs/datasets/combined_dataset_utils_test.py
@@ -1,5 +1,6 @@
 import pathlib
 
+import pytest
 from covidactnow.datapublic.common_fields import CommonFields
 
 from libs.datasets import combined_dataset_utils
@@ -40,7 +41,7 @@ def test_update_and_load(tmp_path: pathlib.Path, nyc_fips, nyc_region):
 
     timeseries_loaded = combined_datasets.load_us_timeseries_dataset(pointer_directory=tmp_path)
     one_region_loaded = timeseries_loaded.get_one_region(nyc_region)
-    assert one_region_nyc.latest == one_region_loaded.latest
+    assert one_region_nyc.latest == pytest.approx(one_region_loaded.latest)
     test_helpers.assert_dataset_like(
         timeseries_loaded, multiregion_timeseries_nyc, drop_na_timeseries=True
     )

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -518,11 +518,11 @@ def test_write_read_wide_dates_csv_compare_literal(tmpdir):
     # Compare written file with a string literal so a test fails if something changes in how the
     # file is written. The literal contains spaces to align the columns in the source.
     assert pointer.path_wide_dates().read_text() == (
-        "                  location_id,variable,provenance,2020-04-01,2020-04-02,2020-04-03\n"
-        "           iso1:us#iso2:us-as,   cases,          ,       100,       200,       300\n"
-        "           iso1:us#iso2:us-as,icu_beds,   pt_src1,         0,         2,         4\n"
-        "iso1:us#iso2:us-ca#fips:06075,   cases,          ,          ,       210,       310\n"
-        "iso1:us#iso2:us-ca#fips:06075,  deaths,   pt_src2,         1,         2,          \n"
+        "                  location_id,variable,provenance,2020-04-03,2020-04-02,2020-04-01\n"
+        "           iso1:us#iso2:us-as,   cases,          ,       300,       200,       100\n"
+        "           iso1:us#iso2:us-as,icu_beds,   pt_src1,         4,         2,         0\n"
+        "iso1:us#iso2:us-ca#fips:06075,   cases,          ,       310,       210\n"
+        "iso1:us#iso2:us-ca#fips:06075,  deaths,   pt_src2,          ,         2,         1\n"
     ).replace(" ", "")
 
     dataset_read = timeseries.MultiRegionDataset.read_from_pointer(pointer)
@@ -1353,11 +1353,11 @@ def test_timeseries_rows():
     rows = ts.timeseries_rows()
     expected = pd.read_csv(
         io.StringIO(
-            "       location_id,variable,2020-04-01,2020-04-02\n"
-            "iso1:us#iso2:us-az,      m1,         8,        12\n"
-            "iso1:us#iso2:us-az,      m2,        20,        40\n"
+            "       location_id,variable,2020-04-02,2020-04-01\n"
+            "iso1:us#iso2:us-az,      m1,        12,         8\n"
+            "iso1:us#iso2:us-az,      m2,        40,        20\n"
             "iso1:us#iso2:us-tx,      m1,         4,         4\n"
-            "iso1:us#iso2:us-tx,      m2,         2,         4\n".replace(" ", "")
+            "iso1:us#iso2:us-tx,      m2,         4,         2\n".replace(" ", "")
         )
     ).set_index([CommonFields.LOCATION_ID, PdFields.VARIABLE])
     pd.testing.assert_frame_equal(rows, expected, check_dtype=False, check_exact=False)


### PR DESCRIPTION
This PR makes the wide-dates files a little smaller and easier to read, as the last part of https://trello.com/c/6W0oakD2/711-github-usage-investigate-low-hanging-fruits

I'm also upgrading to the newest pytest to get the latest pytest.approx