### PR TITLE
Add annotations in drop_new_case_outliers

### DIFF
--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -999,9 +999,12 @@ def drop_new_case_outliers(
     grouped_df = timeseries.groupby_region()
 
     zscores = grouped_df[CommonFields.NEW_CASES].apply(_calculate_modified_zscore)
+    to_exclude = (zscores > zscore_threshold) & (df_copy[CommonFields.NEW_CASES] > case_threshold)
 
     new_tags = []
-    to_exclude = (zscores > zscore_threshold) & (df_copy[CommonFields.NEW_CASES] > case_threshold)
+    # to_exclude is a Series of bools with the same index as df_copy. Iterate through the index
+    # rows where to_exclude is True.
+    assert to_exclude.index.names == [CommonFields.LOCATION_ID, CommonFields.DATE]
     for idx, _ in to_exclude[to_exclude].iteritems():
         new_tags.append(
             {

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -1010,7 +1010,7 @@ def drop_new_case_outliers(
                 TagField.TYPE: TagType.ZSCORE_OUTLIER,
                 # TODO(tom): Having a formatted string deep in our pipeline is ugly. See TODO
                 #  in the TagField class.
-                TagField.CONTENT: f"Removed outlier {df_copy.at[idx, CommonFields.NEW_CASES]:.3g}",
+                TagField.CONTENT: f"Removed outlier {df_copy.at[idx, CommonFields.NEW_CASES]:.6g}",
                 TagField.DATE: idx[1],
             }
         )

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -1042,8 +1042,11 @@ def test_remove_outliers():
     dataset = timeseries.drop_new_case_outliers(dataset)
 
     # Expected result is the same series with the last value removed
-    values = [10.0] * 7
-    expected = test_helpers.build_default_region_dataset({CommonFields.NEW_CASES: values})
+    expected_tag = test_helpers.make_tag(
+        TagType.ZSCORE_OUTLIER, "2020-04-08", "Removed outlier 1000"
+    )
+    expected_ts = TimeseriesLiteral([10.0] * 7, annotation=[expected_tag])
+    expected = test_helpers.build_default_region_dataset({CommonFields.NEW_CASES: expected_ts})
     test_helpers.assert_dataset_like(dataset, expected, drop_na_dates=True)
 
 
@@ -1058,19 +1061,9 @@ def test_remove_outliers_threshold():
     result = timeseries.drop_new_case_outliers(dataset, case_threshold=29)
 
     # Expected result is the same series with the last value removed
-    values = [1.0] * 7
-    expected = test_helpers.build_default_region_dataset(
-        {
-            CommonFields.NEW_CASES: TimeseriesLiteral(
-                values,
-                annotation=[
-                    test_helpers.make_tag(
-                        TagType.ZSCORE_OUTLIER, "2020-04-08", "Removed outlier 30"
-                    )
-                ],
-            )
-        }
-    )
+    expected_tag = test_helpers.make_tag(TagType.ZSCORE_OUTLIER, "2020-04-08", "Removed outlier 30")
+    expected_ts = TimeseriesLiteral([1.0] * 7, annotation=[expected_tag])
+    expected = test_helpers.build_default_region_dataset({CommonFields.NEW_CASES: expected_ts})
     test_helpers.assert_dataset_like(result, expected, drop_na_dates=True)
 
 

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -1059,7 +1059,18 @@ def test_remove_outliers_threshold():
 
     # Expected result is the same series with the last value removed
     values = [1.0] * 7
-    expected = test_helpers.build_default_region_dataset({CommonFields.NEW_CASES: values})
+    expected = test_helpers.build_default_region_dataset(
+        {
+            CommonFields.NEW_CASES: TimeseriesLiteral(
+                values,
+                annotation=[
+                    test_helpers.make_tag(
+                        TagType.ZSCORE_OUTLIER, "2020-04-08", "Removed outlier 30"
+                    )
+                ],
+            )
+        }
+    )
     test_helpers.assert_dataset_like(result, expected, drop_na_dates=True)
 
 


### PR DESCRIPTION
This PR is part of https://trello.com/c/Cq2zNk2M/674-annotate-data-outliers-that-weve-flagged-in-the-ui

* in drop_new_case_outliers add an annotation for each removed value

## Tested

Ran `./run.py data update` which produced a 199k data/multiregion-annotations.csv up from 26k. Looking at `git difftool -t vimdiff --no-prompt main -- data/multiregion-annotations.csv` the diffs look as expected, adding a bunch of zscore_outlier in states and counties. A few regions have multiple outliers removed.