### PR TITLE
Update pydantic + Exclude unset fields in json serialization

### DIFF
--- a/api/can_api_v2_definition.py
+++ b/api/can_api_v2_definition.py
@@ -152,7 +152,7 @@ class Metrics(base_model.APIBaseModel):
         description="90th percentile confidence interval upper endpoint of the infection rate.",
     )
     icuHeadroomRatio: Optional[float] = pydantic.Field(...)
-    icuHeadroomDetails: ICUHeadroomMetricDetails = pydantic.Field(None)
+    icuHeadroomDetails: Optional[ICUHeadroomMetricDetails] = pydantic.Field(None)
     icuCapacityRatio: Optional[float] = pydantic.Field(...)
 
     @staticmethod

--- a/api/docs/open_api_schema.json
+++ b/api/docs/open_api_schema.json
@@ -1084,6 +1084,31 @@
         },
         "description": "Calculated metrics data based on known actuals."
       },
+      "RiskLevel": {
+        "title": "RiskLevel",
+        "enum": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5
+        ],
+        "description": "COVID Risk Level.\n\n## Risk Level Definitions\n *Low* - On track to contain COVID\n *Medium* - Slow disease growth\n *High* - At risk of outbreak\n *Critical* - Active or imminent outbreak\n *Unknown* - Risk unknown\n *Extreme* - Severe outbreak"
+      },
+      "RiskLevelsRow": {
+        "title": "RiskLevelsRow",
+        "required": [
+          "overall"
+        ],
+        "type": "object",
+        "properties": {
+          "overall": {
+            "$ref": "#/components/schemas/RiskLevel"
+          }
+        },
+        "description": "Base model for API output."
+      },
       "RegionTimeseriesRowWithHeader": {
         "title": "RegionTimeseriesRowWithHeader",
         "required": [
@@ -1094,7 +1119,8 @@
           "fips",
           "locationId",
           "actuals",
-          "metrics"
+          "metrics",
+          "riskLevels"
         ],
         "type": "object",
         "properties": {
@@ -1170,6 +1196,15 @@
               }
             ],
             "description": "Metrics for given day"
+          },
+          "riskLevels": {
+            "title": "Risklevels",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RiskLevelsRow"
+              }
+            ],
+            "description": "Risk Levels for given day"
           }
         },
         "description": "Prediction timeseries row with location information."
@@ -1192,18 +1227,6 @@
           "place"
         ],
         "description": "An enumeration."
-      },
-      "RiskLevel": {
-        "title": "RiskLevel",
-        "enum": [
-          0,
-          1,
-          2,
-          3,
-          4,
-          5
-        ],
-        "description": "COVID Risk Level.\n\n## Risk Level Definitions\n *Low* - On track to contain COVID\n *Medium* - Slow disease growth\n *High* - At risk of outbreak\n *Critical* - Active or imminent outbreak\n *Unknown* - Risk unknown\n *Extreme* - Severe outbreak"
       },
       "RiskLevels": {
         "title": "RiskLevels",
@@ -1606,19 +1629,19 @@
       "RiskLevelTimeseriesRow": {
         "title": "RiskLevelTimeseriesRow",
         "required": [
-          "date",
-          "overall"
+          "overall",
+          "date"
         ],
         "type": "object",
         "properties": {
+          "overall": {
+            "$ref": "#/components/schemas/RiskLevel"
+          },
           "date": {
             "title": "Date",
             "type": "string",
             "description": "Date of timeseries data point",
             "format": "date"
-          },
-          "overall": {
-            "$ref": "#/components/schemas/RiskLevel"
           }
         },
         "description": "Timeseries data for risk levels. Currently only surfacing overall risk level for region."

--- a/api/docs/open_api_schema.json
+++ b/api/docs/open_api_schema.json
@@ -929,7 +929,12 @@
         "type": "object",
         "properties": {
           "source": {
-            "$ref": "#/components/schemas/TestPositivityRatioMethod"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TestPositivityRatioMethod"
+              }
+            ],
+            "description": "Source data for test positivity ratio."
           }
         },
         "description": "Details about how the test positivity ratio was calculated."
@@ -967,7 +972,12 @@
             "description": "Current number of covid patients in icu."
           },
           "currentIcuCovidMethod": {
-            "$ref": "#/components/schemas/CovidPatientsMethod"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CovidPatientsMethod"
+              }
+            ],
+            "description": "Method used to determine number of current ICU patients with covid."
           },
           "currentIcuNonCovid": {
             "title": "Currenticunoncovid",
@@ -975,7 +985,12 @@
             "description": "Current number of covid patients in icu."
           },
           "currentIcuNonCovidMethod": {
-            "$ref": "#/components/schemas/NonCovidPatientsMethod"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/NonCovidPatientsMethod"
+              }
+            ],
+            "description": "Method used to determine number of current ICU patients without covid."
           }
         },
         "description": "Details about how the ICU Headroom Metric was calculated."
@@ -1104,7 +1119,12 @@
         "type": "object",
         "properties": {
           "overall": {
-            "$ref": "#/components/schemas/RiskLevel"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RiskLevel"
+              }
+            ],
+            "description": "Overall risk level for region."
           }
         },
         "description": "Base model for API output."
@@ -1242,25 +1262,60 @@
         "type": "object",
         "properties": {
           "overall": {
-            "$ref": "#/components/schemas/RiskLevel"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RiskLevel"
+              }
+            ],
+            "description": "Overall risk level for region."
           },
           "testPositivityRatio": {
-            "$ref": "#/components/schemas/RiskLevel"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RiskLevel"
+              }
+            ],
+            "description": "Test positivity ratio risk level."
           },
           "caseDensity": {
-            "$ref": "#/components/schemas/RiskLevel"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RiskLevel"
+              }
+            ],
+            "description": "Case density risk level."
           },
           "contactTracerCapacityRatio": {
-            "$ref": "#/components/schemas/RiskLevel"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RiskLevel"
+              }
+            ],
+            "description": "Contact tracer capacity ratio risk level."
           },
           "infectionRate": {
-            "$ref": "#/components/schemas/RiskLevel"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RiskLevel"
+              }
+            ],
+            "description": "Infection rate risk level."
           },
           "icuHeadroomRatio": {
-            "$ref": "#/components/schemas/RiskLevel"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RiskLevel"
+              }
+            ],
+            "description": "ICU headroom ratio risk level."
           },
           "icuCapacityRatio": {
-            "$ref": "#/components/schemas/RiskLevel"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RiskLevel"
+              }
+            ],
+            "description": "ICU capacity ratio risk level."
           }
         },
         "description": "COVID risk levels for a region."
@@ -1320,7 +1375,12 @@
             "description": "County name"
           },
           "level": {
-            "$ref": "#/components/schemas/AggregationLevel"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AggregationLevel"
+              }
+            ],
+            "description": "Level of region."
           },
           "lat": {
             "title": "Lat",
@@ -1635,7 +1695,12 @@
         "type": "object",
         "properties": {
           "overall": {
-            "$ref": "#/components/schemas/RiskLevel"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RiskLevel"
+              }
+            ],
+            "description": "Overall risk level for region."
           },
           "date": {
             "title": "Date",
@@ -1703,7 +1768,12 @@
             "description": "County name"
           },
           "level": {
-            "$ref": "#/components/schemas/AggregationLevel"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AggregationLevel"
+              }
+            ],
+            "description": "Level of region."
           },
           "lat": {
             "title": "Lat",

--- a/api/schemas_v2/AggregateFlattenedTimeseries.json
+++ b/api/schemas_v2/AggregateFlattenedTimeseries.json
@@ -192,7 +192,12 @@
       "type": "object",
       "properties": {
         "source": {
-          "$ref": "#/definitions/TestPositivityRatioMethod"
+          "description": "Source data for test positivity ratio.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TestPositivityRatioMethod"
+            }
+          ]
         }
       },
       "required": [
@@ -227,7 +232,12 @@
           "type": "integer"
         },
         "currentIcuCovidMethod": {
-          "$ref": "#/definitions/CovidPatientsMethod"
+          "description": "Method used to determine number of current ICU patients with covid.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CovidPatientsMethod"
+            }
+          ]
         },
         "currentIcuNonCovid": {
           "title": "Currenticunoncovid",
@@ -235,7 +245,12 @@
           "type": "integer"
         },
         "currentIcuNonCovidMethod": {
-          "$ref": "#/definitions/NonCovidPatientsMethod"
+          "description": "Method used to determine number of current ICU patients without covid.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NonCovidPatientsMethod"
+            }
+          ]
         }
       },
       "required": [
@@ -367,7 +382,12 @@
       "type": "object",
       "properties": {
         "overall": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "Overall risk level for region.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         }
       },
       "required": [

--- a/api/schemas_v2/AggregateFlattenedTimeseries.json
+++ b/api/schemas_v2/AggregateFlattenedTimeseries.json
@@ -349,6 +349,31 @@
         "icuCapacityRatio"
       ]
     },
+    "RiskLevel": {
+      "title": "RiskLevel",
+      "description": "COVID Risk Level.\n\n## Risk Level Definitions\n *Low* - On track to contain COVID\n *Medium* - Slow disease growth\n *High* - At risk of outbreak\n *Critical* - Active or imminent outbreak\n *Unknown* - Risk unknown\n *Extreme* - Severe outbreak",
+      "enum": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ]
+    },
+    "RiskLevelsRow": {
+      "title": "RiskLevelsRow",
+      "description": "Base model for API output.",
+      "type": "object",
+      "properties": {
+        "overall": {
+          "$ref": "#/definitions/RiskLevel"
+        }
+      },
+      "required": [
+        "overall"
+      ]
+    },
     "RegionTimeseriesRowWithHeader": {
       "title": "RegionTimeseriesRowWithHeader",
       "description": "Prediction timeseries row with location information.",
@@ -426,6 +451,15 @@
               "$ref": "#/definitions/Metrics"
             }
           ]
+        },
+        "riskLevels": {
+          "title": "Risklevels",
+          "description": "Risk Levels for given day",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevelsRow"
+            }
+          ]
         }
       },
       "required": [
@@ -436,7 +470,8 @@
         "fips",
         "locationId",
         "actuals",
-        "metrics"
+        "metrics",
+        "riskLevels"
       ]
     }
   }

--- a/api/schemas_v2/AggregateRegionSummary.json
+++ b/api/schemas_v2/AggregateRegionSummary.json
@@ -35,7 +35,12 @@
       "type": "object",
       "properties": {
         "source": {
-          "$ref": "#/definitions/TestPositivityRatioMethod"
+          "description": "Source data for test positivity ratio.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TestPositivityRatioMethod"
+            }
+          ]
         }
       },
       "required": [
@@ -70,7 +75,12 @@
           "type": "integer"
         },
         "currentIcuCovidMethod": {
-          "$ref": "#/definitions/CovidPatientsMethod"
+          "description": "Method used to determine number of current ICU patients with covid.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CovidPatientsMethod"
+            }
+          ]
         },
         "currentIcuNonCovid": {
           "title": "Currenticunoncovid",
@@ -78,7 +88,12 @@
           "type": "integer"
         },
         "currentIcuNonCovidMethod": {
-          "$ref": "#/definitions/NonCovidPatientsMethod"
+          "description": "Method used to determine number of current ICU patients without covid.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NonCovidPatientsMethod"
+            }
+          ]
         }
       },
       "required": [
@@ -210,25 +225,60 @@
       "type": "object",
       "properties": {
         "overall": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "Overall risk level for region.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         },
         "testPositivityRatio": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "Test positivity ratio risk level.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         },
         "caseDensity": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "Case density risk level.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         },
         "contactTracerCapacityRatio": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "Contact tracer capacity ratio risk level.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         },
         "infectionRate": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "Infection rate risk level.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         },
         "icuHeadroomRatio": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "ICU headroom ratio risk level.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         },
         "icuCapacityRatio": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "ICU capacity ratio risk level.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         }
       },
       "required": [
@@ -449,7 +499,12 @@
           ]
         },
         "level": {
-          "$ref": "#/definitions/AggregationLevel"
+          "description": "Level of region.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AggregationLevel"
+            }
+          ]
         },
         "lat": {
           "title": "Lat",

--- a/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
@@ -639,19 +639,19 @@
       "description": "Timeseries data for risk levels. Currently only surfacing overall risk level for region.",
       "type": "object",
       "properties": {
+        "overall": {
+          "$ref": "#/definitions/RiskLevel"
+        },
         "date": {
           "title": "Date",
           "description": "Date of timeseries data point",
           "type": "string",
           "format": "date"
-        },
-        "overall": {
-          "$ref": "#/definitions/RiskLevel"
         }
       },
       "required": [
-        "date",
-        "overall"
+        "overall",
+        "date"
       ]
     },
     "RegionSummaryWithTimeseries": {

--- a/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
@@ -35,7 +35,12 @@
       "type": "object",
       "properties": {
         "source": {
-          "$ref": "#/definitions/TestPositivityRatioMethod"
+          "description": "Source data for test positivity ratio.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TestPositivityRatioMethod"
+            }
+          ]
         }
       },
       "required": [
@@ -70,7 +75,12 @@
           "type": "integer"
         },
         "currentIcuCovidMethod": {
-          "$ref": "#/definitions/CovidPatientsMethod"
+          "description": "Method used to determine number of current ICU patients with covid.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CovidPatientsMethod"
+            }
+          ]
         },
         "currentIcuNonCovid": {
           "title": "Currenticunoncovid",
@@ -78,7 +88,12 @@
           "type": "integer"
         },
         "currentIcuNonCovidMethod": {
-          "$ref": "#/definitions/NonCovidPatientsMethod"
+          "description": "Method used to determine number of current ICU patients without covid.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NonCovidPatientsMethod"
+            }
+          ]
         }
       },
       "required": [
@@ -210,25 +225,60 @@
       "type": "object",
       "properties": {
         "overall": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "Overall risk level for region.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         },
         "testPositivityRatio": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "Test positivity ratio risk level.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         },
         "caseDensity": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "Case density risk level.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         },
         "contactTracerCapacityRatio": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "Contact tracer capacity ratio risk level.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         },
         "infectionRate": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "Infection rate risk level.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         },
         "icuHeadroomRatio": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "ICU headroom ratio risk level.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         },
         "icuCapacityRatio": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "ICU capacity ratio risk level.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         }
       },
       "required": [
@@ -640,7 +690,12 @@
       "type": "object",
       "properties": {
         "overall": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "Overall risk level for region.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         },
         "date": {
           "title": "Date",
@@ -694,7 +749,12 @@
           ]
         },
         "level": {
-          "$ref": "#/definitions/AggregationLevel"
+          "description": "Level of region.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/AggregationLevel"
+            }
+          ]
         },
         "lat": {
           "title": "Lat",

--- a/api/schemas_v2/ICUHeadroomMetricDetails.json
+++ b/api/schemas_v2/ICUHeadroomMetricDetails.json
@@ -9,7 +9,12 @@
       "type": "integer"
     },
     "currentIcuCovidMethod": {
-      "$ref": "#/definitions/CovidPatientsMethod"
+      "description": "Method used to determine number of current ICU patients with covid.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CovidPatientsMethod"
+        }
+      ]
     },
     "currentIcuNonCovid": {
       "title": "Currenticunoncovid",
@@ -17,7 +22,12 @@
       "type": "integer"
     },
     "currentIcuNonCovidMethod": {
-      "$ref": "#/definitions/NonCovidPatientsMethod"
+      "description": "Method used to determine number of current ICU patients without covid.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/NonCovidPatientsMethod"
+        }
+      ]
     }
   },
   "required": [

--- a/api/schemas_v2/Metrics.json
+++ b/api/schemas_v2/Metrics.json
@@ -120,7 +120,12 @@
       "type": "object",
       "properties": {
         "source": {
-          "$ref": "#/definitions/TestPositivityRatioMethod"
+          "description": "Source data for test positivity ratio.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TestPositivityRatioMethod"
+            }
+          ]
         }
       },
       "required": [
@@ -155,7 +160,12 @@
           "type": "integer"
         },
         "currentIcuCovidMethod": {
-          "$ref": "#/definitions/CovidPatientsMethod"
+          "description": "Method used to determine number of current ICU patients with covid.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CovidPatientsMethod"
+            }
+          ]
         },
         "currentIcuNonCovid": {
           "title": "Currenticunoncovid",
@@ -163,7 +173,12 @@
           "type": "integer"
         },
         "currentIcuNonCovidMethod": {
-          "$ref": "#/definitions/NonCovidPatientsMethod"
+          "description": "Method used to determine number of current ICU patients without covid.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NonCovidPatientsMethod"
+            }
+          ]
         }
       },
       "required": [

--- a/api/schemas_v2/MetricsTimeseriesRow.json
+++ b/api/schemas_v2/MetricsTimeseriesRow.json
@@ -127,7 +127,12 @@
       "type": "object",
       "properties": {
         "source": {
-          "$ref": "#/definitions/TestPositivityRatioMethod"
+          "description": "Source data for test positivity ratio.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TestPositivityRatioMethod"
+            }
+          ]
         }
       },
       "required": [
@@ -162,7 +167,12 @@
           "type": "integer"
         },
         "currentIcuCovidMethod": {
-          "$ref": "#/definitions/CovidPatientsMethod"
+          "description": "Method used to determine number of current ICU patients with covid.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CovidPatientsMethod"
+            }
+          ]
         },
         "currentIcuNonCovid": {
           "title": "Currenticunoncovid",
@@ -170,7 +180,12 @@
           "type": "integer"
         },
         "currentIcuNonCovidMethod": {
-          "$ref": "#/definitions/NonCovidPatientsMethod"
+          "description": "Method used to determine number of current ICU patients without covid.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NonCovidPatientsMethod"
+            }
+          ]
         }
       },
       "required": [

--- a/api/schemas_v2/RegionSummary.json
+++ b/api/schemas_v2/RegionSummary.json
@@ -38,7 +38,12 @@
       ]
     },
     "level": {
-      "$ref": "#/definitions/AggregationLevel"
+      "description": "Level of region.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AggregationLevel"
+        }
+      ]
     },
     "lat": {
       "title": "Lat",
@@ -155,7 +160,12 @@
       "type": "object",
       "properties": {
         "source": {
-          "$ref": "#/definitions/TestPositivityRatioMethod"
+          "description": "Source data for test positivity ratio.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TestPositivityRatioMethod"
+            }
+          ]
         }
       },
       "required": [
@@ -190,7 +200,12 @@
           "type": "integer"
         },
         "currentIcuCovidMethod": {
-          "$ref": "#/definitions/CovidPatientsMethod"
+          "description": "Method used to determine number of current ICU patients with covid.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CovidPatientsMethod"
+            }
+          ]
         },
         "currentIcuNonCovid": {
           "title": "Currenticunoncovid",
@@ -198,7 +213,12 @@
           "type": "integer"
         },
         "currentIcuNonCovidMethod": {
-          "$ref": "#/definitions/NonCovidPatientsMethod"
+          "description": "Method used to determine number of current ICU patients without covid.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NonCovidPatientsMethod"
+            }
+          ]
         }
       },
       "required": [
@@ -330,25 +350,60 @@
       "type": "object",
       "properties": {
         "overall": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "Overall risk level for region.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         },
         "testPositivityRatio": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "Test positivity ratio risk level.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         },
         "caseDensity": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "Case density risk level.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         },
         "contactTracerCapacityRatio": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "Contact tracer capacity ratio risk level.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         },
         "infectionRate": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "Infection rate risk level.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         },
         "icuHeadroomRatio": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "ICU headroom ratio risk level.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         },
         "icuCapacityRatio": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "ICU capacity ratio risk level.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         }
       },
       "required": [

--- a/api/schemas_v2/RegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/RegionSummaryWithTimeseries.json
@@ -782,19 +782,19 @@
       "description": "Timeseries data for risk levels. Currently only surfacing overall risk level for region.",
       "type": "object",
       "properties": {
+        "overall": {
+          "$ref": "#/definitions/RiskLevel"
+        },
         "date": {
           "title": "Date",
           "description": "Date of timeseries data point",
           "type": "string",
           "format": "date"
-        },
-        "overall": {
-          "$ref": "#/definitions/RiskLevel"
         }
       },
       "required": [
-        "date",
-        "overall"
+        "overall",
+        "date"
       ]
     }
   }

--- a/api/schemas_v2/RegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/RegionSummaryWithTimeseries.json
@@ -38,7 +38,12 @@
       ]
     },
     "level": {
-      "$ref": "#/definitions/AggregationLevel"
+      "description": "Level of region.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AggregationLevel"
+        }
+      ]
     },
     "lat": {
       "title": "Lat",
@@ -178,7 +183,12 @@
       "type": "object",
       "properties": {
         "source": {
-          "$ref": "#/definitions/TestPositivityRatioMethod"
+          "description": "Source data for test positivity ratio.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TestPositivityRatioMethod"
+            }
+          ]
         }
       },
       "required": [
@@ -213,7 +223,12 @@
           "type": "integer"
         },
         "currentIcuCovidMethod": {
-          "$ref": "#/definitions/CovidPatientsMethod"
+          "description": "Method used to determine number of current ICU patients with covid.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CovidPatientsMethod"
+            }
+          ]
         },
         "currentIcuNonCovid": {
           "title": "Currenticunoncovid",
@@ -221,7 +236,12 @@
           "type": "integer"
         },
         "currentIcuNonCovidMethod": {
-          "$ref": "#/definitions/NonCovidPatientsMethod"
+          "description": "Method used to determine number of current ICU patients without covid.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NonCovidPatientsMethod"
+            }
+          ]
         }
       },
       "required": [
@@ -353,25 +373,60 @@
       "type": "object",
       "properties": {
         "overall": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "Overall risk level for region.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         },
         "testPositivityRatio": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "Test positivity ratio risk level.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         },
         "caseDensity": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "Case density risk level.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         },
         "contactTracerCapacityRatio": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "Contact tracer capacity ratio risk level.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         },
         "infectionRate": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "Infection rate risk level.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         },
         "icuHeadroomRatio": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "ICU headroom ratio risk level.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         },
         "icuCapacityRatio": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "ICU capacity ratio risk level.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         }
       },
       "required": [
@@ -783,7 +838,12 @@
       "type": "object",
       "properties": {
         "overall": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "Overall risk level for region.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         },
         "date": {
           "title": "Date",

--- a/api/schemas_v2/RegionTimeseriesRowWithHeader.json
+++ b/api/schemas_v2/RegionTimeseriesRowWithHeader.json
@@ -75,6 +75,15 @@
           "$ref": "#/definitions/Metrics"
         }
       ]
+    },
+    "riskLevels": {
+      "title": "Risklevels",
+      "description": "Risk Levels for given day",
+      "allOf": [
+        {
+          "$ref": "#/definitions/RiskLevelsRow"
+        }
+      ]
     }
   },
   "required": [
@@ -85,7 +94,8 @@
     "fips",
     "locationId",
     "actuals",
-    "metrics"
+    "metrics",
+    "riskLevels"
   ],
   "definitions": {
     "HospitalResourceUtilization": {
@@ -429,6 +439,31 @@
         "infectionRateCI90",
         "icuHeadroomRatio",
         "icuCapacityRatio"
+      ]
+    },
+    "RiskLevel": {
+      "title": "RiskLevel",
+      "description": "COVID Risk Level.\n\n## Risk Level Definitions\n *Low* - On track to contain COVID\n *Medium* - Slow disease growth\n *High* - At risk of outbreak\n *Critical* - Active or imminent outbreak\n *Unknown* - Risk unknown\n *Extreme* - Severe outbreak",
+      "enum": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ]
+    },
+    "RiskLevelsRow": {
+      "title": "RiskLevelsRow",
+      "description": "Base model for API output.",
+      "type": "object",
+      "properties": {
+        "overall": {
+          "$ref": "#/definitions/RiskLevel"
+        }
+      },
+      "required": [
+        "overall"
       ]
     }
   }

--- a/api/schemas_v2/RegionTimeseriesRowWithHeader.json
+++ b/api/schemas_v2/RegionTimeseriesRowWithHeader.json
@@ -284,7 +284,12 @@
       "type": "object",
       "properties": {
         "source": {
-          "$ref": "#/definitions/TestPositivityRatioMethod"
+          "description": "Source data for test positivity ratio.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TestPositivityRatioMethod"
+            }
+          ]
         }
       },
       "required": [
@@ -319,7 +324,12 @@
           "type": "integer"
         },
         "currentIcuCovidMethod": {
-          "$ref": "#/definitions/CovidPatientsMethod"
+          "description": "Method used to determine number of current ICU patients with covid.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CovidPatientsMethod"
+            }
+          ]
         },
         "currentIcuNonCovid": {
           "title": "Currenticunoncovid",
@@ -327,7 +337,12 @@
           "type": "integer"
         },
         "currentIcuNonCovidMethod": {
-          "$ref": "#/definitions/NonCovidPatientsMethod"
+          "description": "Method used to determine number of current ICU patients without covid.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NonCovidPatientsMethod"
+            }
+          ]
         }
       },
       "required": [
@@ -459,7 +474,12 @@
       "type": "object",
       "properties": {
         "overall": {
-          "$ref": "#/definitions/RiskLevel"
+          "description": "Overall risk level for region.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RiskLevel"
+            }
+          ]
         }
       },
       "required": [

--- a/api/schemas_v2/RiskLevelTimeseriesRow.json
+++ b/api/schemas_v2/RiskLevelTimeseriesRow.json
@@ -3,19 +3,19 @@
   "description": "Timeseries data for risk levels. Currently only surfacing overall risk level for region.",
   "type": "object",
   "properties": {
+    "overall": {
+      "$ref": "#/definitions/RiskLevel"
+    },
     "date": {
       "title": "Date",
       "description": "Date of timeseries data point",
       "type": "string",
       "format": "date"
-    },
-    "overall": {
-      "$ref": "#/definitions/RiskLevel"
     }
   },
   "required": [
-    "date",
-    "overall"
+    "overall",
+    "date"
   ],
   "definitions": {
     "RiskLevel": {

--- a/api/schemas_v2/RiskLevels.json
+++ b/api/schemas_v2/RiskLevels.json
@@ -4,25 +4,60 @@
   "type": "object",
   "properties": {
     "overall": {
-      "$ref": "#/definitions/RiskLevel"
+      "description": "Overall risk level for region.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/RiskLevel"
+        }
+      ]
     },
     "testPositivityRatio": {
-      "$ref": "#/definitions/RiskLevel"
+      "description": "Test positivity ratio risk level.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/RiskLevel"
+        }
+      ]
     },
     "caseDensity": {
-      "$ref": "#/definitions/RiskLevel"
+      "description": "Case density risk level.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/RiskLevel"
+        }
+      ]
     },
     "contactTracerCapacityRatio": {
-      "$ref": "#/definitions/RiskLevel"
+      "description": "Contact tracer capacity ratio risk level.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/RiskLevel"
+        }
+      ]
     },
     "infectionRate": {
-      "$ref": "#/definitions/RiskLevel"
+      "description": "Infection rate risk level.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/RiskLevel"
+        }
+      ]
     },
     "icuHeadroomRatio": {
-      "$ref": "#/definitions/RiskLevel"
+      "description": "ICU headroom ratio risk level.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/RiskLevel"
+        }
+      ]
     },
     "icuCapacityRatio": {
-      "$ref": "#/definitions/RiskLevel"
+      "description": "ICU capacity ratio risk level.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/RiskLevel"
+        }
+      ]
     }
   },
   "required": [

--- a/api/schemas_v2/RiskLevelsRow.json
+++ b/api/schemas_v2/RiskLevelsRow.json
@@ -1,6 +1,6 @@
 {
-  "title": "RiskLevelTimeseriesRow",
-  "description": "Timeseries data for risk levels. Currently only surfacing overall risk level for region.",
+  "title": "RiskLevelsRow",
+  "description": "Base model for API output.",
   "type": "object",
   "properties": {
     "overall": {
@@ -10,17 +10,10 @@
           "$ref": "#/definitions/RiskLevel"
         }
       ]
-    },
-    "date": {
-      "title": "Date",
-      "description": "Date of timeseries data point",
-      "type": "string",
-      "format": "date"
     }
   },
   "required": [
-    "overall",
-    "date"
+    "overall"
   ],
   "definitions": {
     "RiskLevel": {

--- a/api/schemas_v2/TestPositivityRatioDetails.json
+++ b/api/schemas_v2/TestPositivityRatioDetails.json
@@ -4,7 +4,12 @@
   "type": "object",
   "properties": {
     "source": {
-      "$ref": "#/definitions/TestPositivityRatioMethod"
+      "description": "Source data for test positivity ratio.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TestPositivityRatioMethod"
+        }
+      ]
     }
   },
   "required": [

--- a/libs/pipelines/api_v2_pipeline.py
+++ b/libs/pipelines/api_v2_pipeline.py
@@ -228,8 +228,12 @@ def deploy_single_level(
     deploy_csv_api_output(bulk_summaries, output_path)
 
 
-def deploy_json_api_output(region_result: pydantic.BaseModel, output_path: pathlib.Path,) -> None:
-    output_path.write_text(region_result.json(exclude_unset=True))
+def deploy_json_api_output(region_result: pydantic.BaseModel, output_path: pathlib.Path) -> None:
+    # Excluding fields that are not specifically included in a model.
+    # This lets a field be undefined and not included in the actual json.
+    serialized_result = region_result.json(exclude_unset=True)
+
+    output_path.write_text(serialized_result)
 
 
 def deploy_csv_api_output(

--- a/libs/pipelines/api_v2_pipeline.py
+++ b/libs/pipelines/api_v2_pipeline.py
@@ -229,7 +229,7 @@ def deploy_single_level(
 
 
 def deploy_json_api_output(region_result: pydantic.BaseModel, output_path: pathlib.Path,) -> None:
-    output_path.write_text(region_result.json())
+    output_path.write_text(region_result.json(exclude_unset=True))
 
 
 def deploy_csv_api_output(

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ fastparquet==0.3.3
 us==1.0.0
 adtk==0.6.0
 -e .
-pydantic==1.6.1
+pydantic==1.7.3
 dill
 dictdiffer==0.8.1
 structlog==20.1.0


### PR DESCRIPTION
This updates the version of pydantic (seems to shave 1 min of api build) + excluding unset fields, this primarily lets us remove `icuHeadroomDetails` and `testPositivityRatioDetails` from the json output, which shaves about 75MB off of the counties.timeseries.json file. 

Any field that is included but null (which is most fields) will be included in the output