### PR TITLE
Add vaccines to api

### DIFF
--- a/api/can_api_v2_definition.py
+++ b/api/can_api_v2_definition.py
@@ -113,6 +113,18 @@ Notable exceptions:
  2. Any days with negative new cases are removed.
 """,
     )
+    vaccinesDistributed: Optional[int] = pydantic.Field(
+        ..., description="Number of vaccine doses distributed."
+    )
+    vaccinationsInitiated: Optional[int] = pydantic.Field(
+        ...,
+        description="""
+Number of vaccinations initiated.
+
+This value may vary by type of vaccine, but for Moderna and Pfizer, this indicates
+number of people vaccinated with the first dose.
+""",
+    )
 
 
 class ActualsTimeseriesRow(Actuals):

--- a/api/can_api_v2_definition.py
+++ b/api/can_api_v2_definition.py
@@ -131,7 +131,7 @@ number of people vaccinated with the first dose.
 Number of vaccinations completed.
 
 This value may vary by type of vaccine, but for Moderna and Pfizer, this indicates
-number of people vaccinated with the both first and second dose.
+number of people vaccinated with both the first and second dose.
 """,
     )
 

--- a/api/can_api_v2_definition.py
+++ b/api/can_api_v2_definition.py
@@ -125,6 +125,15 @@ This value may vary by type of vaccine, but for Moderna and Pfizer, this indicat
 number of people vaccinated with the first dose.
 """,
     )
+    vaccinationsCompleted: Optional[int] = pydantic.Field(
+        None,
+        description="""
+Number of vaccinations completed.
+
+This value may vary by type of vaccine, but for Moderna and Pfizer, this indicates
+number of people vaccinated with the both first and second dose.
+""",
+    )
 
 
 class ActualsTimeseriesRow(Actuals):

--- a/api/can_api_v2_definition.py
+++ b/api/can_api_v2_definition.py
@@ -114,10 +114,10 @@ Notable exceptions:
 """,
     )
     vaccinesDistributed: Optional[int] = pydantic.Field(
-        ..., description="Number of vaccine doses distributed."
+        None, description="Number of vaccine doses distributed."
     )
     vaccinationsInitiated: Optional[int] = pydantic.Field(
-        ...,
+        None,
         description="""
 Number of vaccinations initiated.
 

--- a/api/docs/docs/updates.md
+++ b/api/docs/docs/updates.md
@@ -7,6 +7,22 @@ description: Updates to the Covid Act Now API.
 
 Updates to the API will be reflected here.
 
+### Vaccine data now available
+_Added on 2021-01-14_
+
+Vaccine data is now available within the Covid Act Now API.
+
+Currently the data is available for states only, but county-level vaccination data is coming soon.
+
+Fields added:
+ * `vaccinesDistributed`: Total number of vaccine doses distributed.
+ * `vaccinationsInitiated`: Total number of people initiating vaccination. For a vaccine with a
+   2-dose regimen, this represents the first dose.
+ * `vaccinationsCompleted`: Total number of people completing vaccination - currently those
+    completing their second shot. 
+
+You can access these fields in both the `actuals` field and `actualsTimeseries` fields.
+
 ### View entire timeseries of risk levels for all regions
 _Added on 2020-12-22_
 

--- a/api/docs/open_api_schema.json
+++ b/api/docs/open_api_schema.json
@@ -905,6 +905,21 @@
               }
             ],
             "description": "\nNew confirmed or suspected cases.\n\nNew cases are a processed timeseries of cases - summing new cases may not equal\nthe cumulative case count.\n\nNotable exceptions:\n 1. If a region does not report cases for a period of time, the first day\n    cases start reporting again will not be included. This day likely includes\n    multiple days worth of cases and can be misleading to the overall series.\n 2. Any days with negative new cases are removed.\n"
+          },
+          "vaccinesDistributed": {
+            "title": "Vaccinesdistributed",
+            "type": "integer",
+            "description": "Number of vaccine doses distributed."
+          },
+          "vaccinationsInitiated": {
+            "title": "Vaccinationsinitiated",
+            "type": "integer",
+            "description": "\nNumber of vaccinations initiated.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the first dose.\n"
+          },
+          "vaccinationsCompleted": {
+            "title": "Vaccinationscompleted",
+            "type": "integer",
+            "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the both first and second dose.\n"
           }
         },
         "description": "Known actuals data."
@@ -1676,6 +1691,21 @@
               }
             ],
             "description": "\nNew confirmed or suspected cases.\n\nNew cases are a processed timeseries of cases - summing new cases may not equal\nthe cumulative case count.\n\nNotable exceptions:\n 1. If a region does not report cases for a period of time, the first day\n    cases start reporting again will not be included. This day likely includes\n    multiple days worth of cases and can be misleading to the overall series.\n 2. Any days with negative new cases are removed.\n"
+          },
+          "vaccinesDistributed": {
+            "title": "Vaccinesdistributed",
+            "type": "integer",
+            "description": "Number of vaccine doses distributed."
+          },
+          "vaccinationsInitiated": {
+            "title": "Vaccinationsinitiated",
+            "type": "integer",
+            "description": "\nNumber of vaccinations initiated.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the first dose.\n"
+          },
+          "vaccinationsCompleted": {
+            "title": "Vaccinationscompleted",
+            "type": "integer",
+            "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the both first and second dose.\n"
           },
           "date": {
             "title": "Date",

--- a/api/schemas_v2/Actuals.json
+++ b/api/schemas_v2/Actuals.json
@@ -92,6 +92,21 @@
           "type": "null"
         }
       ]
+    },
+    "vaccinesDistributed": {
+      "title": "Vaccinesdistributed",
+      "description": "Number of vaccine doses distributed.",
+      "type": "integer"
+    },
+    "vaccinationsInitiated": {
+      "title": "Vaccinationsinitiated",
+      "description": "\nNumber of vaccinations initiated.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the first dose.\n",
+      "type": "integer"
+    },
+    "vaccinationsCompleted": {
+      "title": "Vaccinationscompleted",
+      "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the both first and second dose.\n",
+      "type": "integer"
     }
   },
   "required": [

--- a/api/schemas_v2/ActualsTimeseriesRow.json
+++ b/api/schemas_v2/ActualsTimeseriesRow.json
@@ -93,6 +93,21 @@
         }
       ]
     },
+    "vaccinesDistributed": {
+      "title": "Vaccinesdistributed",
+      "description": "Number of vaccine doses distributed.",
+      "type": "integer"
+    },
+    "vaccinationsInitiated": {
+      "title": "Vaccinationsinitiated",
+      "description": "\nNumber of vaccinations initiated.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the first dose.\n",
+      "type": "integer"
+    },
+    "vaccinationsCompleted": {
+      "title": "Vaccinationscompleted",
+      "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the both first and second dose.\n",
+      "type": "integer"
+    },
     "date": {
       "title": "Date",
       "description": "Date of timeseries data point",

--- a/api/schemas_v2/AggregateFlattenedTimeseries.json
+++ b/api/schemas_v2/AggregateFlattenedTimeseries.json
@@ -161,6 +161,21 @@
               "type": "null"
             }
           ]
+        },
+        "vaccinesDistributed": {
+          "title": "Vaccinesdistributed",
+          "description": "Number of vaccine doses distributed.",
+          "type": "integer"
+        },
+        "vaccinationsInitiated": {
+          "title": "Vaccinationsinitiated",
+          "description": "\nNumber of vaccinations initiated.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the first dose.\n",
+          "type": "integer"
+        },
+        "vaccinationsCompleted": {
+          "title": "Vaccinationscompleted",
+          "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the both first and second dose.\n",
+          "type": "integer"
         }
       },
       "required": [

--- a/api/schemas_v2/AggregateRegionSummary.json
+++ b/api/schemas_v2/AggregateRegionSummary.json
@@ -446,6 +446,21 @@
               "type": "null"
             }
           ]
+        },
+        "vaccinesDistributed": {
+          "title": "Vaccinesdistributed",
+          "description": "Number of vaccine doses distributed.",
+          "type": "integer"
+        },
+        "vaccinationsInitiated": {
+          "title": "Vaccinationsinitiated",
+          "description": "\nNumber of vaccinations initiated.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the first dose.\n",
+          "type": "integer"
+        },
+        "vaccinationsCompleted": {
+          "title": "Vaccinationscompleted",
+          "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the both first and second dose.\n",
+          "type": "integer"
         }
       },
       "required": [

--- a/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
@@ -446,6 +446,21 @@
               "type": "null"
             }
           ]
+        },
+        "vaccinesDistributed": {
+          "title": "Vaccinesdistributed",
+          "description": "Number of vaccine doses distributed.",
+          "type": "integer"
+        },
+        "vaccinationsInitiated": {
+          "title": "Vaccinationsinitiated",
+          "description": "\nNumber of vaccinations initiated.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the first dose.\n",
+          "type": "integer"
+        },
+        "vaccinationsCompleted": {
+          "title": "Vaccinationscompleted",
+          "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the both first and second dose.\n",
+          "type": "integer"
         }
       },
       "required": [
@@ -664,6 +679,21 @@
               "type": "null"
             }
           ]
+        },
+        "vaccinesDistributed": {
+          "title": "Vaccinesdistributed",
+          "description": "Number of vaccine doses distributed.",
+          "type": "integer"
+        },
+        "vaccinationsInitiated": {
+          "title": "Vaccinationsinitiated",
+          "description": "\nNumber of vaccinations initiated.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the first dose.\n",
+          "type": "integer"
+        },
+        "vaccinationsCompleted": {
+          "title": "Vaccinationscompleted",
+          "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the both first and second dose.\n",
+          "type": "integer"
         },
         "date": {
           "title": "Date",

--- a/api/schemas_v2/RegionSummary.json
+++ b/api/schemas_v2/RegionSummary.json
@@ -571,6 +571,21 @@
               "type": "null"
             }
           ]
+        },
+        "vaccinesDistributed": {
+          "title": "Vaccinesdistributed",
+          "description": "Number of vaccine doses distributed.",
+          "type": "integer"
+        },
+        "vaccinationsInitiated": {
+          "title": "Vaccinationsinitiated",
+          "description": "\nNumber of vaccinations initiated.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the first dose.\n",
+          "type": "integer"
+        },
+        "vaccinationsCompleted": {
+          "title": "Vaccinationscompleted",
+          "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the both first and second dose.\n",
+          "type": "integer"
         }
       },
       "required": [

--- a/api/schemas_v2/RegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/RegionSummaryWithTimeseries.json
@@ -594,6 +594,21 @@
               "type": "null"
             }
           ]
+        },
+        "vaccinesDistributed": {
+          "title": "Vaccinesdistributed",
+          "description": "Number of vaccine doses distributed.",
+          "type": "integer"
+        },
+        "vaccinationsInitiated": {
+          "title": "Vaccinationsinitiated",
+          "description": "\nNumber of vaccinations initiated.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the first dose.\n",
+          "type": "integer"
+        },
+        "vaccinationsCompleted": {
+          "title": "Vaccinationscompleted",
+          "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the both first and second dose.\n",
+          "type": "integer"
         }
       },
       "required": [
@@ -812,6 +827,21 @@
               "type": "null"
             }
           ]
+        },
+        "vaccinesDistributed": {
+          "title": "Vaccinesdistributed",
+          "description": "Number of vaccine doses distributed.",
+          "type": "integer"
+        },
+        "vaccinationsInitiated": {
+          "title": "Vaccinationsinitiated",
+          "description": "\nNumber of vaccinations initiated.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the first dose.\n",
+          "type": "integer"
+        },
+        "vaccinationsCompleted": {
+          "title": "Vaccinationscompleted",
+          "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the both first and second dose.\n",
+          "type": "integer"
         },
         "date": {
           "title": "Date",

--- a/api/schemas_v2/RegionTimeseriesRowWithHeader.json
+++ b/api/schemas_v2/RegionTimeseriesRowWithHeader.json
@@ -253,6 +253,21 @@
               "type": "null"
             }
           ]
+        },
+        "vaccinesDistributed": {
+          "title": "Vaccinesdistributed",
+          "description": "Number of vaccine doses distributed.",
+          "type": "integer"
+        },
+        "vaccinationsInitiated": {
+          "title": "Vaccinationsinitiated",
+          "description": "\nNumber of vaccinations initiated.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the first dose.\n",
+          "type": "integer"
+        },
+        "vaccinationsCompleted": {
+          "title": "Vaccinationscompleted",
+          "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the both first and second dose.\n",
+          "type": "integer"
         }
       },
       "required": [

--- a/libs/build_api_v2.py
+++ b/libs/build_api_v2.py
@@ -52,6 +52,9 @@ def _build_actuals(actual_data: dict) -> Actuals:
         newCases=actual_data[CommonFields.NEW_CASES],
         vaccinesDistributed=actual_data[CommonFields.VACCINES_DISTRIBUTED],
         vaccinationsInitiated=actual_data[CommonFields.VACCINATIONS_INITIATED],
+        # Vaccinations completed currently optional as data is not yet flowing through.
+        # This will allow us to include vaccines completed data as soon as its scraped.
+        vaccinationsCompleted=actual_data.get(CommonFields.VACCINATIONS_COMPLETED),
     )
 
 
@@ -97,9 +100,9 @@ def build_region_timeseries(
         # Don't include vaccinations in timeseries before first possible vaccination
         # date to not bloat timeseries.
         if row[CommonFields.DATE] < USA_VACCINATION_START_DATE:
-            print(f"deleting {row[CommonFields.DATE]}")
             del actual["vaccinesDistributed"]
             del actual["vaccinationsInitiated"]
+            del actual["vaccinationsCompleted"]
 
         timeseries_row = ActualsTimeseriesRow(**actual, date=row[CommonFields.DATE])
         actuals_timeseries.append(timeseries_row)

--- a/libs/build_api_v2.py
+++ b/libs/build_api_v2.py
@@ -47,8 +47,8 @@ def _build_actuals(actual_data: dict) -> Actuals:
             "typicalUsageRate": actual_data.get(CommonFields.ICU_TYPICAL_OCCUPANCY_RATE),
         },
         newCases=actual_data[CommonFields.NEW_CASES],
-        vaccinesDistributed=None,
-        vaccinationsInitiated=None,
+        vaccinesDistributed=actual_data[CommonFields.VACCINES_DISTRIBUTED],
+        vaccinationsInitiated=actual_data[CommonFields.VACCINATIONS_INITIATED],
     )
 
 

--- a/libs/build_api_v2.py
+++ b/libs/build_api_v2.py
@@ -47,6 +47,8 @@ def _build_actuals(actual_data: dict) -> Actuals:
             "typicalUsageRate": actual_data.get(CommonFields.ICU_TYPICAL_OCCUPANCY_RATE),
         },
         newCases=actual_data[CommonFields.NEW_CASES],
+        vaccinesDistributed=None,
+        vaccinationsInitiated=None,
     )
 
 

--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -108,6 +108,7 @@ ALL_TIMESERIES_FEATURE_DEFINITION: FeatureDataSourceMap = {
     CommonFields.TEST_POSITIVITY_7D: [CDCTestingDataset],
     CommonFields.VACCINES_DISTRIBUTED: [CDCVaccinesDataset],
     CommonFields.VACCINATIONS_INITIATED: [CDCVaccinesDataset],
+    CommonFields.VACCINATIONS_COMPLETED: [CDCVaccinesDataset],
 }
 
 ALL_FIELDS_FEATURE_DEFINITION: FeatureDataSourceMap = {

--- a/test/libs/generate_api_v2_test.py
+++ b/test/libs/generate_api_v2_test.py
@@ -69,7 +69,7 @@ def test_build_summary_for_fips(
             newCases=nyc_latest["new_cases"],
             vaccinesDistributed=nyc_latest["vaccines_distributed"],
             vaccinationsInitiated=nyc_latest["vaccinations_initiated"],
-            vaccinationsCompleted=nyc_latest["vaccinations_completed"],
+            vaccinationsCompleted=nyc_latest.get("vaccinations_completed"),
         ),
         lastUpdatedDate=datetime.datetime.utcnow(),
         url="https://covidactnow.org/us/new_york-ny/county/bronx_county",

--- a/test/libs/generate_api_v2_test.py
+++ b/test/libs/generate_api_v2_test.py
@@ -69,6 +69,7 @@ def test_build_summary_for_fips(
             newCases=nyc_latest["new_cases"],
             vaccinesDistributed=nyc_latest["vaccines_distributed"],
             vaccinationsInitiated=nyc_latest["vaccinations_initiated"],
+            vaccinationsCompleted=nyc_latest["vaccinations_completed"],
         ),
         lastUpdatedDate=datetime.datetime.utcnow(),
         url="https://covidactnow.org/us/new_york-ny/county/bronx_county",

--- a/test/libs/generate_api_v2_test.py
+++ b/test/libs/generate_api_v2_test.py
@@ -67,6 +67,8 @@ def test_build_summary_for_fips(
             },
             contactTracers=nyc_latest["contact_tracers_count"],
             newCases=nyc_latest["new_cases"],
+            vaccinesDistributed=nyc_latest["vaccines_distributed"],
+            vaccinationsInitiated=nyc_latest["vaccinations_initiated"],
         ),
         lastUpdatedDate=datetime.datetime.utcnow(),
         url="https://covidactnow.org/us/new_york-ny/county/bronx_county",

--- a/test/libs/generate_api_v2_test.py
+++ b/test/libs/generate_api_v2_test.py
@@ -95,6 +95,14 @@ def test_generate_timeseries_for_fips(nyc_region, nyc_rt_dataset, nyc_icu_datase
         region_summary, nyc_timeseries, metrics_series, risk_timeseries
     )
 
+    # Test vaccination fields aren't in before start date
+    for actuals_row in region_timeseries.actualsTimeseries:
+        row_data = actuals_row.dict(exclude_unset=True)
+        if actuals_row.date < build_api_v2.USA_VACCINATION_START_DATE.date():
+            assert "vaccinationsInitiated" not in row_data
+        else:
+            assert "vaccinationsInitiated" in row_data
+
     summary = build_api_v2.build_region_summary(nyc_latest, latest_metric, risk_levels, nyc_region)
 
     assert summary.dict() == region_timeseries.region_summary.dict()


### PR DESCRIPTION
This gets vaccination data flowing through to the API. Note that vaccinations completed won't have any data just yet, but now that the data is available, looks like it will sooon!

I also am filtering out including vaccination data before the date of first us vaccination.  

I confirmed that loading the timeseries in pandas works just fine with some records not having all of the fields.