### PR TITLE
Change tag content to JSON

### DIFF
--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -103,10 +103,7 @@ class TagType(GetByValueMixin, ValueAsStrMixin, str, enum.Enum):
 class TagInTimeseries(ABC):
     """Represents a tag in the context of a particular timeseries"""
 
-    # TODO(tom): Retire date as an attribute of TagInTimeseries because it is now optional and in
-    #  content.
-    date: pd.Timestamp
-
+    # TAG_TYPE must be set by subclasses.
     TAG_TYPE: ClassVar[TagType]
 
     @property
@@ -121,7 +118,7 @@ class TagInTimeseries(ABC):
     @staticmethod
     def make(tag_type: TagType, content: str) -> "TagInTimeseries":
         if tag_type == TagType.PROVENANCE:
-            return ProvenanceTag(date=pd.NaT, source=content)
+            return ProvenanceTag(source=content)
 
         if tag_type == TagType.CUMULATIVE_TAIL_TRUNCATED:
             return CumulativeTailTruncated.make_with_content(content)
@@ -153,6 +150,7 @@ class ProvenanceTag(TagInTimeseries):
 @dataclass(frozen=True)
 class AnnotationWithDate(TagInTimeseries, ABC):
     original_observation: float
+    date: pd.Timestamp
 
     @classmethod
     def make_with_content(cls, content: str) -> "AnnotationWithDate":

--- a/libs/metrics/test_positivity.py
+++ b/libs/metrics/test_positivity.py
@@ -127,7 +127,6 @@ def _make_output_dataset(
         TagField.LOCATION_ID,
         TagField.VARIABLE,
         TagField.TYPE,
-        TagField.DATE,
     ]
     dataset_out = MultiRegionDataset.from_timeseries_wide_dates_df(wide_date_df)
     if source_columns:
@@ -136,18 +135,6 @@ def _make_output_dataset(
         # When there are two source_columns they usually contain the same provenance content.
         # Only keep one copy of it.
         output_tags = source_tags.drop_duplicates(ignore_index=True)
-        # I expect the DATE datetime level in dataset_in.tag to be a Timestamp column in
-        # source_tags but somehow it is sometimes changed to floats. This seems to happen when
-        # all the dates for `locations` and `source_columns` are NaT. Maybe it is a variation of
-        # https://github.com/pandas-dev/pandas/issues/12941 but I haven't found a simple way to
-        # reproduce the issue. To reproduce remove the patch below and wait for the
-        # is_all_dates check in MultiRegionDataset.__post_init__ to fail.
-        if output_tags[TagField.DATE].dtype == "float":
-            # For mysterious reasons output_tags._is_copy is sometimes a weakref to source_tags
-            # which causes the following assignment to trip a SettingWithCopy. Make a copy to
-            # work-around the problem.
-            output_tags = output_tags.copy()
-            output_tags.loc[:, TagField.DATE] = pd.to_datetime(output_tags.loc[:, TagField.DATE])
         dataset_out = dataset_out.append_tag_df(output_tags)
 
     return dataset_out

--- a/test/libs/datasets/taglib_test.py
+++ b/test/libs/datasets/taglib_test.py
@@ -1,0 +1,40 @@
+import abc
+import inspect
+from typing import Iterable
+from typing import Type
+
+from libs.datasets import timeseries
+
+
+def _get_subclasses(cls) -> Iterable[Type]:
+    """Yields all subclasses of `cls`."""
+    # From https://stackoverflow.com/a/33607093
+    for subclass in cls.__subclasses__():
+        yield from _get_subclasses(subclass)
+        yield subclass
+
+
+def _get_subclass_tag_types(cls):
+    """Returns a list of all TAG_TYPE subclasses of concrete subclasses of cls. By concrete I
+    mean no abstract methods and not directly subclassing abc.ABC."""
+    not_abstract_subclasses = [k for k in _get_subclasses(cls) if not inspect.isabstract(k)]
+    not_abc = [k for k in not_abstract_subclasses if abc.ABC not in k.__bases__]
+    return [k.TAG_TYPE for k in not_abc]
+
+
+def test_all_tag_subclasses_accounted_for():
+    """Checks that every subclass of TagInTimeseries has exactly one TagType enum value."""
+    subclass_tag_types = _get_subclass_tag_types(timeseries.TagInTimeseries)
+    assert set(timeseries.TagType) == set(subclass_tag_types)
+    assert len(list(timeseries.TagType)) == len(subclass_tag_types)
+
+
+def test_annotation_tag_types():
+    annotation_tag_types = _get_subclass_tag_types(timeseries.AnnotationWithDate)
+    assert sorted(annotation_tag_types) == sorted(timeseries.ANNOTATION_TAG_TYPES)
+
+
+def test_tag_type_to_class():
+    assert set(timeseries.TAG_TYPE_TO_CLASS.keys()) == set(timeseries.TagType)
+    for tag_type, tag_type_class in timeseries.TAG_TYPE_TO_CLASS.items():
+        assert tag_type_class.TAG_TYPE is tag_type

--- a/test/libs/datasets/tail_filter_test.py
+++ b/test/libs/datasets/tail_filter_test.py
@@ -42,7 +42,9 @@ def test_tail_filter_stalled_timeseries():
     truncated_timeseries = test_helpers.TimeseriesLiteral(
         values_increasing,
         annotation=[
-            test_helpers.make_tag(TagType.CUMULATIVE_TAIL_TRUNCATED, "2020-04-24", tag_content)
+            test_helpers.make_tag(
+                TagType.CUMULATIVE_TAIL_TRUNCATED, "2020-04-24", original_observation=123_000.0
+            )
         ],
     )
     ds_expected = test_helpers.build_default_region_dataset(

--- a/test/libs/datasets/tail_filter_test.py
+++ b/test/libs/datasets/tail_filter_test.py
@@ -43,7 +43,7 @@ def test_tail_filter_stalled_timeseries():
         values_increasing,
         annotation=[
             test_helpers.make_tag(
-                TagType.CUMULATIVE_TAIL_TRUNCATED, "2020-04-24", original_observation=123_000.0
+                TagType.CUMULATIVE_TAIL_TRUNCATED, date="2020-04-24", original_observation=123_000.0
             )
         ],
     )

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -538,8 +538,8 @@ def test_write_read_wide_dates_csv_with_annotation(tmpdir):
         CommonFields.ICU_BEDS: TimeseriesLiteral(
             [0, 2, 4],
             annotation=[
-                test_helpers.make_tag(date="2020-04-01", content="tag1"),
-                test_helpers.make_tag(date="2020-04-02", content="tag2"),
+                test_helpers.make_tag(date="2020-04-01"),
+                test_helpers.make_tag(type=TagType.ZSCORE_OUTLIER, date="2020-04-02"),
             ],
         ),
         CommonFields.CASES: [100, 200, 300],
@@ -560,8 +560,8 @@ def test_write_read_dataset_pointer_with_provenance_list(tmpdir):
             CommonFields.ICU_BEDS: TimeseriesLiteral(
                 [0, 2, 4],
                 annotation=[
-                    test_helpers.make_tag(date="2020-04-01", content="tag1"),
-                    test_helpers.make_tag(date="2020-04-02", content="tag2"),
+                    test_helpers.make_tag(date="2020-04-01"),
+                    test_helpers.make_tag(date="2020-04-02"),
                 ],
                 provenance=["prov1", "prov2"],
             ),
@@ -685,9 +685,9 @@ def test_one_region_annotations():
     region_tx = Region.from_state("TX")
     region_sf = Region.from_fips("06075")
     values = [100, 200, 300, 400]
-    tag1 = test_helpers.make_tag(content="tag1")
-    tag2a = test_helpers.make_tag(content="tag2a")
-    tag2b = test_helpers.make_tag(content="tag2b")
+    tag1 = test_helpers.make_tag(date="2020-04-01")
+    tag2a = test_helpers.make_tag(date="2020-04-02")
+    tag2b = test_helpers.make_tag(date="2020-04-03")
 
     dataset_tx_and_sf = test_helpers.build_dataset(
         {
@@ -974,9 +974,7 @@ def test_append_tags():
         CommonFields.CASES: cases_values,
     }
     dataset_in = test_helpers.build_dataset({region_sf: metrics_sf})
-    tag_sf_cases = test_helpers.make_tag(
-        TagType.CUMULATIVE_TAIL_TRUNCATED, "2020-04-02", "Truncate"
-    )
+    tag_sf_cases = test_helpers.make_tag(TagType.CUMULATIVE_TAIL_TRUNCATED, "2020-04-02")
     tag_df = test_helpers.make_tag_df(region_sf, CommonFields.CASES, [tag_sf_cases])
     dataset_out = dataset_in.append_tag_df(tag_df)
     metrics_sf[CommonFields.CASES] = TimeseriesLiteral(cases_values, annotation=[tag_sf_cases])
@@ -1043,7 +1041,7 @@ def test_remove_outliers():
 
     # Expected result is the same series with the last value removed
     expected_tag = test_helpers.make_tag(
-        TagType.ZSCORE_OUTLIER, "2020-04-08", "Removed outlier 1000"
+        TagType.ZSCORE_OUTLIER, "2020-04-08", original_observation=1000.0,
     )
     expected_ts = TimeseriesLiteral([10.0] * 7, annotation=[expected_tag])
     expected = test_helpers.build_default_region_dataset({CommonFields.NEW_CASES: expected_ts})
@@ -1061,7 +1059,9 @@ def test_remove_outliers_threshold():
     result = timeseries.drop_new_case_outliers(dataset, case_threshold=29)
 
     # Expected result is the same series with the last value removed
-    expected_tag = test_helpers.make_tag(TagType.ZSCORE_OUTLIER, "2020-04-08", "Removed outlier 30")
+    expected_tag = test_helpers.make_tag(
+        TagType.ZSCORE_OUTLIER, "2020-04-08", original_observation=30.0
+    )
     expected_ts = TimeseriesLiteral([1.0] * 7, annotation=[expected_tag])
     expected = test_helpers.build_default_region_dataset({CommonFields.NEW_CASES: expected_ts})
     test_helpers.assert_dataset_like(result, expected, drop_na_dates=True)
@@ -1181,17 +1181,15 @@ def test_combined_annotation():
     ts1a = TimeseriesLiteral(
         [0, 2, 4],
         annotation=[
-            test_helpers.make_tag(date="2020-04-01", content="ds1_a"),
-            test_helpers.make_tag(date="2020-04-02", content="ds1_b"),
+            test_helpers.make_tag(date="2020-04-01"),
+            test_helpers.make_tag(date="2020-04-02"),
         ],
     )
     ts1b = [100, 200, 300]
     ds1 = test_helpers.build_default_region_dataset(
         {CommonFields.ICU_BEDS: ts1a, CommonFields.CASES: ts1b}
     )
-    ts2a = TimeseriesLiteral(
-        [1, 3, 5], annotation=[test_helpers.make_tag(date="2020-04-01", content="ds2_a")],
-    )
+    ts2a = TimeseriesLiteral([1, 3, 5], annotation=[test_helpers.make_tag(date="2020-04-01")],)
     ts2b = [150, 250, 350]
     ds2 = test_helpers.build_default_region_dataset(
         {CommonFields.ICU_BEDS: ts2a, CommonFields.CASES: ts2b}

--- a/test/libs/datasets/timeseries_test.py
+++ b/test/libs/datasets/timeseries_test.py
@@ -974,7 +974,7 @@ def test_append_tags():
         CommonFields.CASES: cases_values,
     }
     dataset_in = test_helpers.build_dataset({region_sf: metrics_sf})
-    tag_sf_cases = test_helpers.make_tag(TagType.CUMULATIVE_TAIL_TRUNCATED, "2020-04-02")
+    tag_sf_cases = test_helpers.make_tag(TagType.CUMULATIVE_TAIL_TRUNCATED, date="2020-04-02")
     tag_df = test_helpers.make_tag_df(region_sf, CommonFields.CASES, [tag_sf_cases])
     dataset_out = dataset_in.append_tag_df(tag_df)
     metrics_sf[CommonFields.CASES] = TimeseriesLiteral(cases_values, annotation=[tag_sf_cases])
@@ -1041,7 +1041,7 @@ def test_remove_outliers():
 
     # Expected result is the same series with the last value removed
     expected_tag = test_helpers.make_tag(
-        TagType.ZSCORE_OUTLIER, "2020-04-08", original_observation=1000.0,
+        TagType.ZSCORE_OUTLIER, date="2020-04-08", original_observation=1000.0,
     )
     expected_ts = TimeseriesLiteral([10.0] * 7, annotation=[expected_tag])
     expected = test_helpers.build_default_region_dataset({CommonFields.NEW_CASES: expected_ts})
@@ -1060,7 +1060,7 @@ def test_remove_outliers_threshold():
 
     # Expected result is the same series with the last value removed
     expected_tag = test_helpers.make_tag(
-        TagType.ZSCORE_OUTLIER, "2020-04-08", original_observation=30.0
+        TagType.ZSCORE_OUTLIER, date="2020-04-08", original_observation=30.0
     )
     expected_ts = TimeseriesLiteral([1.0] * 7, annotation=[expected_tag])
     expected = test_helpers.build_default_region_dataset({CommonFields.NEW_CASES: expected_ts})

--- a/test/libs/metrics/test_positivity_test.py
+++ b/test/libs/metrics/test_positivity_test.py
@@ -10,6 +10,7 @@ from covidactnow.datapublic.common_fields import CommonFields
 from covidactnow.datapublic.common_fields import FieldName
 from freezegun import freeze_time
 
+from libs.datasets.tail_filter import TagType
 from test import test_helpers
 from libs.datasets import timeseries
 from libs.datasets.timeseries import DatasetName
@@ -274,11 +275,11 @@ def test_provenance():
 def test_preserve_tags():
     region_as = Region.from_state("AS")
     region_tx = Region.from_state("TX")
-    tag1 = test_helpers.make_tag(date="2020-04-04", content="tag1")
-    tag2 = test_helpers.make_tag(date="2020-04-04", content="tag2")
-    tag_drop = test_helpers.make_tag(date="2020-04-04", content="expect-to-drop")
-    tag3 = test_helpers.make_tag(date="2020-04-04", content="tag3")
-    tag4 = test_helpers.make_tag(date="2020-04-04", content="tag4")
+    tag1 = test_helpers.make_tag(type=TagType.CUMULATIVE_LONG_TAIL_TRUNCATED, date="2020-04-04")
+    tag2 = test_helpers.make_tag(type=TagType.CUMULATIVE_TAIL_TRUNCATED, date="2020-04-04")
+    tag_drop = test_helpers.make_tag(type=TagType.ZSCORE_OUTLIER, date="2020-04-01")
+    tag3 = test_helpers.make_tag(type=TagType.ZSCORE_OUTLIER, date="2020-04-04")
+    tag4 = test_helpers.make_tag(type=TagType.ZSCORE_OUTLIER, date="2020-04-03")
     metrics_as = {
         CommonFields.POSITIVE_TESTS: TimeseriesLiteral(
             [1, 2, 3, 4], annotation=[tag1], provenance="pos"

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -61,7 +61,7 @@ def make_tag(
     date: pd.Timestamp = pd.to_datetime(date)
     if type == TagType.PROVENANCE:
         assert content != "taggy"
-        return timeseries.ProvenanceTag(date=pd.NaT, source=content)
+        return timeseries.ProvenanceTag(source=content)
     elif type == TagType.CUMULATIVE_TAIL_TRUNCATED:
         assert content == "taggy"
         if "original_observation" not in kwargs:


### PR DESCRIPTION
This PR builds towards https://trello.com/c/Cq2zNk2M/674-annotate-data-outliers-that-weve-flagged-in-the-ui

* Moves `date` from a field in the tag/annotation CSV and DataFrame to a field in the JSON content of annotations. This replaces the human readable strings buried in our data pipeline with flexible JSON content. The downside is processing the JSON in pandas is harder. The upside is this makes adding new attributes per annotation *much* easier. Removing the date will also make it easier to include all the annotations in the wide-dates CSV so we can later remove multiregion-annotations.csv.