### PR TITLE
fix Annotations in test_build_summary_for_fips

### DIFF
--- a/api/can_api_v2_definition.py
+++ b/api/can_api_v2_definition.py
@@ -27,8 +27,10 @@ class FieldSource(GetByValueMixin, enum.Enum):
     CMSTesting = "CMSTesting"
     CDCTesting = "CDCTesting"
     HHSTesting = "HHSTesting"
+    HHSHospital = "HHSHospital"
     VALORUM = "Valorum"
     COVID_TRACKING = "covid_tracking"
+    USA_FACTS = "USAFacts"
     OTHER = "other"
 
 

--- a/test/libs/generate_api_v2_test.py
+++ b/test/libs/generate_api_v2_test.py
@@ -76,12 +76,12 @@ def test_build_summary_for_fips(
             vaccinationsCompleted=nyc_latest.get("vaccinations_completed"),
         ),
         annotations=Annotations(
-            cases=FieldAnnotations(sources=[FieldSource.OTHER], anomalies=[]),
-            deaths=FieldAnnotations(sources=[FieldSource.OTHER], anomalies=[]),
-            positiveTests=FieldAnnotations(sources=[FieldSource.VALORUM], anomalies=[]),
-            negativeTests=FieldAnnotations(sources=[FieldSource.VALORUM], anomalies=[]),
-            hospitalBeds=FieldAnnotations(sources=[FieldSource.OTHER], anomalies=[]),
-            icuBeds=FieldAnnotations(sources=[FieldSource.OTHER], anomalies=[]),
+            cases=FieldAnnotations(sources=[FieldSource.USA_FACTS], anomalies=[]),
+            deaths=FieldAnnotations(sources=[FieldSource.USA_FACTS], anomalies=[]),
+            positiveTests=None,
+            negativeTests=None,
+            hospitalBeds=FieldAnnotations(sources=[FieldSource.HHSHospital], anomalies=[]),
+            icuBeds=FieldAnnotations(sources=[FieldSource.HHSHospital], anomalies=[]),
             contactTracers=None,
             newCases=FieldAnnotations(
                 sources=[],


### PR DESCRIPTION
This PR builds towards https://trello.com/c/Cq2zNk2M/674-annotate-data-outliers-that-weve-flagged-in-the-ui

Follow up to https://github.com/covid-projections/covid-data-model/pull/889