### PR TITLE
Update log and API schemas

### DIFF
--- a/api/can_api_v2_definition.py
+++ b/api/can_api_v2_definition.py
@@ -159,7 +159,7 @@ class ActualsTimeseriesRow(Actuals):
 class AnomalyAnnotation(base_model.APIBaseModel):
     date: datetime.date = pydantic.Field(..., description="Date of anomaly")
     original_observation: float = pydantic.Field(
-        ..., description="Original value on this date " "detected as anomalious."
+        ..., description="Original value on this date detected as anomalous."
     )
 
 

--- a/api/docs/docs/updates.md
+++ b/api/docs/docs/updates.md
@@ -7,6 +7,14 @@ description: Updates to the Covid Act Now API.
 
 Updates to the API will be reflected here.
 
+### Field level annotations
+_Added on 2021-01-19_
+
+The Annotations field has a FieldAnnotations for each field in `Actuals`. You can now access the
+data source(s) used to produce a field and list of dates where an anomalous observation was removed.
+The exact structure of the `AnomalyAnnotation` may be modified in the future.
+
+
 ### Vaccine data now available
 _Added on 2021-01-14_
 

--- a/api/docs/open_api_schema.json
+++ b/api/docs/open_api_schema.json
@@ -1335,6 +1335,171 @@
         },
         "description": "COVID risk levels for a region."
       },
+      "FieldSource": {
+        "title": "FieldSource",
+        "enum": [
+          "NYTimes",
+          "CMSTesting",
+          "CDCTesting",
+          "HHSTesting",
+          "Valorum",
+          "covid_tracking",
+          "other"
+        ],
+        "description": "The data source of a field (metric or actual). This enumeration lists the places from which\nCAN fetches data. The source is tracked on a per field and region timeseries basis."
+      },
+      "AnomalyAnnotation": {
+        "title": "AnomalyAnnotation",
+        "required": [
+          "date",
+          "original_observation"
+        ],
+        "type": "object",
+        "properties": {
+          "date": {
+            "title": "Date",
+            "type": "string",
+            "description": "Date of anomaly",
+            "format": "date"
+          },
+          "original_observation": {
+            "title": "Original Observation",
+            "type": "number",
+            "description": "Original value on this date detected as anomalous."
+          }
+        },
+        "description": "Base model for API output."
+      },
+      "FieldAnnotations": {
+        "title": "FieldAnnotations",
+        "required": [
+          "sources",
+          "anomalies"
+        ],
+        "type": "object",
+        "properties": {
+          "sources": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FieldSource"
+            }
+          },
+          "anomalies": {
+            "title": "Anomalies",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AnomalyAnnotation"
+            }
+          }
+        },
+        "description": "Annotations associated with one field."
+      },
+      "Annotations": {
+        "title": "Annotations",
+        "type": "object",
+        "properties": {
+          "cases": {
+            "title": "Cases",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FieldAnnotations"
+              }
+            ],
+            "description": "Annotations for cases"
+          },
+          "deaths": {
+            "title": "Deaths",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FieldAnnotations"
+              }
+            ],
+            "description": "Annotations for deaths"
+          },
+          "positiveTests": {
+            "title": "Positivetests",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FieldAnnotations"
+              }
+            ],
+            "description": "Annotations for positiveTests"
+          },
+          "negativeTests": {
+            "title": "Negativetests",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FieldAnnotations"
+              }
+            ],
+            "description": "Annotations for negativeTests"
+          },
+          "contactTracers": {
+            "title": "Contacttracers",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FieldAnnotations"
+              }
+            ],
+            "description": "Annotations for contactTracers"
+          },
+          "hospitalBeds": {
+            "title": "Hospitalbeds",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FieldAnnotations"
+              }
+            ],
+            "description": "Annotations for hospitalBeds"
+          },
+          "icuBeds": {
+            "title": "Icubeds",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FieldAnnotations"
+              }
+            ],
+            "description": "Annotations for icuBeds"
+          },
+          "newCases": {
+            "title": "Newcases",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FieldAnnotations"
+              }
+            ],
+            "description": "Annotations for newCases"
+          },
+          "vaccinesDistributed": {
+            "title": "Vaccinesdistributed",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FieldAnnotations"
+              }
+            ],
+            "description": "Annotations for vaccinesDistributed"
+          },
+          "vaccinationsInitiated": {
+            "title": "Vaccinationsinitiated",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FieldAnnotations"
+              }
+            ],
+            "description": "Annotations for vaccinationsInitiated"
+          },
+          "vaccinationsCompleted": {
+            "title": "Vaccinationscompleted",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FieldAnnotations"
+              }
+            ],
+            "description": "Annotations for vaccinationsCompleted"
+          }
+        },
+        "description": "Annotations for each field."
+      },
       "RegionSummary": {
         "title": "RegionSummary",
         "required": [
@@ -1350,6 +1515,7 @@
           "metrics",
           "riskLevels",
           "actuals",
+          "annotations",
           "lastUpdatedDate",
           "url"
         ],
@@ -1446,6 +1612,9 @@
           },
           "actuals": {
             "$ref": "#/components/schemas/Actuals"
+          },
+          "annotations": {
+            "$ref": "#/components/schemas/Annotations"
           },
           "lastUpdatedDate": {
             "title": "Lastupdateddate",
@@ -1756,6 +1925,7 @@
           "metrics",
           "riskLevels",
           "actuals",
+          "annotations",
           "lastUpdatedDate",
           "url",
           "actualsTimeseries",
@@ -1854,6 +2024,9 @@
           },
           "actuals": {
             "$ref": "#/components/schemas/Actuals"
+          },
+          "annotations": {
+            "$ref": "#/components/schemas/Annotations"
           },
           "lastUpdatedDate": {
             "title": "Lastupdateddate",

--- a/api/schemas_v2/Actuals.json
+++ b/api/schemas_v2/Actuals.json
@@ -105,7 +105,7 @@
     },
     "vaccinationsCompleted": {
       "title": "Vaccinationscompleted",
-      "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the both first and second dose.\n",
+      "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with both the first and second dose.\n",
       "type": "integer"
     }
   },

--- a/api/schemas_v2/ActualsTimeseriesRow.json
+++ b/api/schemas_v2/ActualsTimeseriesRow.json
@@ -105,7 +105,7 @@
     },
     "vaccinationsCompleted": {
       "title": "Vaccinationscompleted",
-      "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the both first and second dose.\n",
+      "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with both the first and second dose.\n",
       "type": "integer"
     },
     "date": {

--- a/api/schemas_v2/AggregateFlattenedTimeseries.json
+++ b/api/schemas_v2/AggregateFlattenedTimeseries.json
@@ -174,7 +174,7 @@
         },
         "vaccinationsCompleted": {
           "title": "Vaccinationscompleted",
-          "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the both first and second dose.\n",
+          "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with both the first and second dose.\n",
           "type": "integer"
         }
       },

--- a/api/schemas_v2/AggregateRegionSummary.json
+++ b/api/schemas_v2/AggregateRegionSummary.json
@@ -459,7 +459,7 @@
         },
         "vaccinationsCompleted": {
           "title": "Vaccinationscompleted",
-          "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the both first and second dose.\n",
+          "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with both the first and second dose.\n",
           "type": "integer"
         }
       },
@@ -473,6 +473,171 @@
         "icuBeds",
         "newCases"
       ]
+    },
+    "FieldSource": {
+      "title": "FieldSource",
+      "description": "The data source of a field (metric or actual). This enumeration lists the places from which\nCAN fetches data. The source is tracked on a per field and region timeseries basis.",
+      "enum": [
+        "NYTimes",
+        "CMSTesting",
+        "CDCTesting",
+        "HHSTesting",
+        "Valorum",
+        "covid_tracking",
+        "other"
+      ]
+    },
+    "AnomalyAnnotation": {
+      "title": "AnomalyAnnotation",
+      "description": "Base model for API output.",
+      "type": "object",
+      "properties": {
+        "date": {
+          "title": "Date",
+          "description": "Date of anomaly",
+          "type": "string",
+          "format": "date"
+        },
+        "original_observation": {
+          "title": "Original Observation",
+          "description": "Original value on this date detected as anomalous.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "date",
+        "original_observation"
+      ]
+    },
+    "FieldAnnotations": {
+      "title": "FieldAnnotations",
+      "description": "Annotations associated with one field.",
+      "type": "object",
+      "properties": {
+        "sources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FieldSource"
+          }
+        },
+        "anomalies": {
+          "title": "Anomalies",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AnomalyAnnotation"
+          }
+        }
+      },
+      "required": [
+        "sources",
+        "anomalies"
+      ]
+    },
+    "Annotations": {
+      "title": "Annotations",
+      "description": "Annotations for each field.",
+      "type": "object",
+      "properties": {
+        "cases": {
+          "title": "Cases",
+          "description": "Annotations for cases",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "deaths": {
+          "title": "Deaths",
+          "description": "Annotations for deaths",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "positiveTests": {
+          "title": "Positivetests",
+          "description": "Annotations for positiveTests",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "negativeTests": {
+          "title": "Negativetests",
+          "description": "Annotations for negativeTests",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "contactTracers": {
+          "title": "Contacttracers",
+          "description": "Annotations for contactTracers",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "hospitalBeds": {
+          "title": "Hospitalbeds",
+          "description": "Annotations for hospitalBeds",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "icuBeds": {
+          "title": "Icubeds",
+          "description": "Annotations for icuBeds",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "newCases": {
+          "title": "Newcases",
+          "description": "Annotations for newCases",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "vaccinesDistributed": {
+          "title": "Vaccinesdistributed",
+          "description": "Annotations for vaccinesDistributed",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "vaccinationsInitiated": {
+          "title": "Vaccinationsinitiated",
+          "description": "Annotations for vaccinationsInitiated",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "vaccinationsCompleted": {
+          "title": "Vaccinationscompleted",
+          "description": "Annotations for vaccinationsCompleted",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        }
+      }
     },
     "RegionSummary": {
       "title": "RegionSummary",
@@ -571,6 +736,9 @@
         "actuals": {
           "$ref": "#/definitions/Actuals"
         },
+        "annotations": {
+          "$ref": "#/definitions/Annotations"
+        },
         "lastUpdatedDate": {
           "title": "Lastupdateddate",
           "description": "Date of latest data",
@@ -603,6 +771,7 @@
         "metrics",
         "riskLevels",
         "actuals",
+        "annotations",
         "lastUpdatedDate",
         "url"
       ]

--- a/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
@@ -459,7 +459,7 @@
         },
         "vaccinationsCompleted": {
           "title": "Vaccinationscompleted",
-          "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the both first and second dose.\n",
+          "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with both the first and second dose.\n",
           "type": "integer"
         }
       },
@@ -473,6 +473,171 @@
         "icuBeds",
         "newCases"
       ]
+    },
+    "FieldSource": {
+      "title": "FieldSource",
+      "description": "The data source of a field (metric or actual). This enumeration lists the places from which\nCAN fetches data. The source is tracked on a per field and region timeseries basis.",
+      "enum": [
+        "NYTimes",
+        "CMSTesting",
+        "CDCTesting",
+        "HHSTesting",
+        "Valorum",
+        "covid_tracking",
+        "other"
+      ]
+    },
+    "AnomalyAnnotation": {
+      "title": "AnomalyAnnotation",
+      "description": "Base model for API output.",
+      "type": "object",
+      "properties": {
+        "date": {
+          "title": "Date",
+          "description": "Date of anomaly",
+          "type": "string",
+          "format": "date"
+        },
+        "original_observation": {
+          "title": "Original Observation",
+          "description": "Original value on this date detected as anomalous.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "date",
+        "original_observation"
+      ]
+    },
+    "FieldAnnotations": {
+      "title": "FieldAnnotations",
+      "description": "Annotations associated with one field.",
+      "type": "object",
+      "properties": {
+        "sources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FieldSource"
+          }
+        },
+        "anomalies": {
+          "title": "Anomalies",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AnomalyAnnotation"
+          }
+        }
+      },
+      "required": [
+        "sources",
+        "anomalies"
+      ]
+    },
+    "Annotations": {
+      "title": "Annotations",
+      "description": "Annotations for each field.",
+      "type": "object",
+      "properties": {
+        "cases": {
+          "title": "Cases",
+          "description": "Annotations for cases",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "deaths": {
+          "title": "Deaths",
+          "description": "Annotations for deaths",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "positiveTests": {
+          "title": "Positivetests",
+          "description": "Annotations for positiveTests",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "negativeTests": {
+          "title": "Negativetests",
+          "description": "Annotations for negativeTests",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "contactTracers": {
+          "title": "Contacttracers",
+          "description": "Annotations for contactTracers",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "hospitalBeds": {
+          "title": "Hospitalbeds",
+          "description": "Annotations for hospitalBeds",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "icuBeds": {
+          "title": "Icubeds",
+          "description": "Annotations for icuBeds",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "newCases": {
+          "title": "Newcases",
+          "description": "Annotations for newCases",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "vaccinesDistributed": {
+          "title": "Vaccinesdistributed",
+          "description": "Annotations for vaccinesDistributed",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "vaccinationsInitiated": {
+          "title": "Vaccinationsinitiated",
+          "description": "Annotations for vaccinationsInitiated",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "vaccinationsCompleted": {
+          "title": "Vaccinationscompleted",
+          "description": "Annotations for vaccinationsCompleted",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        }
+      }
     },
     "MetricsTimeseriesRow": {
       "title": "MetricsTimeseriesRow",
@@ -692,7 +857,7 @@
         },
         "vaccinationsCompleted": {
           "title": "Vaccinationscompleted",
-          "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the both first and second dose.\n",
+          "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with both the first and second dose.\n",
           "type": "integer"
         },
         "date": {
@@ -836,6 +1001,9 @@
         "actuals": {
           "$ref": "#/definitions/Actuals"
         },
+        "annotations": {
+          "$ref": "#/definitions/Annotations"
+        },
         "lastUpdatedDate": {
           "title": "Lastupdateddate",
           "description": "Date of latest data",
@@ -889,6 +1057,7 @@
         "metrics",
         "riskLevels",
         "actuals",
+        "annotations",
         "lastUpdatedDate",
         "url",
         "actualsTimeseries",

--- a/api/schemas_v2/RegionSummary.json
+++ b/api/schemas_v2/RegionSummary.json
@@ -95,6 +95,9 @@
     "actuals": {
       "$ref": "#/definitions/Actuals"
     },
+    "annotations": {
+      "$ref": "#/definitions/Annotations"
+    },
     "lastUpdatedDate": {
       "title": "Lastupdateddate",
       "description": "Date of latest data",
@@ -127,6 +130,7 @@
     "metrics",
     "riskLevels",
     "actuals",
+    "annotations",
     "lastUpdatedDate",
     "url"
   ],
@@ -584,7 +588,7 @@
         },
         "vaccinationsCompleted": {
           "title": "Vaccinationscompleted",
-          "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the both first and second dose.\n",
+          "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with both the first and second dose.\n",
           "type": "integer"
         }
       },
@@ -598,6 +602,171 @@
         "icuBeds",
         "newCases"
       ]
+    },
+    "FieldSource": {
+      "title": "FieldSource",
+      "description": "The data source of a field (metric or actual). This enumeration lists the places from which\nCAN fetches data. The source is tracked on a per field and region timeseries basis.",
+      "enum": [
+        "NYTimes",
+        "CMSTesting",
+        "CDCTesting",
+        "HHSTesting",
+        "Valorum",
+        "covid_tracking",
+        "other"
+      ]
+    },
+    "AnomalyAnnotation": {
+      "title": "AnomalyAnnotation",
+      "description": "Base model for API output.",
+      "type": "object",
+      "properties": {
+        "date": {
+          "title": "Date",
+          "description": "Date of anomaly",
+          "type": "string",
+          "format": "date"
+        },
+        "original_observation": {
+          "title": "Original Observation",
+          "description": "Original value on this date detected as anomalous.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "date",
+        "original_observation"
+      ]
+    },
+    "FieldAnnotations": {
+      "title": "FieldAnnotations",
+      "description": "Annotations associated with one field.",
+      "type": "object",
+      "properties": {
+        "sources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FieldSource"
+          }
+        },
+        "anomalies": {
+          "title": "Anomalies",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AnomalyAnnotation"
+          }
+        }
+      },
+      "required": [
+        "sources",
+        "anomalies"
+      ]
+    },
+    "Annotations": {
+      "title": "Annotations",
+      "description": "Annotations for each field.",
+      "type": "object",
+      "properties": {
+        "cases": {
+          "title": "Cases",
+          "description": "Annotations for cases",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "deaths": {
+          "title": "Deaths",
+          "description": "Annotations for deaths",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "positiveTests": {
+          "title": "Positivetests",
+          "description": "Annotations for positiveTests",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "negativeTests": {
+          "title": "Negativetests",
+          "description": "Annotations for negativeTests",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "contactTracers": {
+          "title": "Contacttracers",
+          "description": "Annotations for contactTracers",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "hospitalBeds": {
+          "title": "Hospitalbeds",
+          "description": "Annotations for hospitalBeds",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "icuBeds": {
+          "title": "Icubeds",
+          "description": "Annotations for icuBeds",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "newCases": {
+          "title": "Newcases",
+          "description": "Annotations for newCases",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "vaccinesDistributed": {
+          "title": "Vaccinesdistributed",
+          "description": "Annotations for vaccinesDistributed",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "vaccinationsInitiated": {
+          "title": "Vaccinationsinitiated",
+          "description": "Annotations for vaccinationsInitiated",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "vaccinationsCompleted": {
+          "title": "Vaccinationscompleted",
+          "description": "Annotations for vaccinationsCompleted",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/api/schemas_v2/RegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/RegionSummaryWithTimeseries.json
@@ -95,6 +95,9 @@
     "actuals": {
       "$ref": "#/definitions/Actuals"
     },
+    "annotations": {
+      "$ref": "#/definitions/Annotations"
+    },
     "lastUpdatedDate": {
       "title": "Lastupdateddate",
       "description": "Date of latest data",
@@ -148,6 +151,7 @@
     "metrics",
     "riskLevels",
     "actuals",
+    "annotations",
     "lastUpdatedDate",
     "url",
     "actualsTimeseries",
@@ -607,7 +611,7 @@
         },
         "vaccinationsCompleted": {
           "title": "Vaccinationscompleted",
-          "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the both first and second dose.\n",
+          "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with both the first and second dose.\n",
           "type": "integer"
         }
       },
@@ -621,6 +625,171 @@
         "icuBeds",
         "newCases"
       ]
+    },
+    "FieldSource": {
+      "title": "FieldSource",
+      "description": "The data source of a field (metric or actual). This enumeration lists the places from which\nCAN fetches data. The source is tracked on a per field and region timeseries basis.",
+      "enum": [
+        "NYTimes",
+        "CMSTesting",
+        "CDCTesting",
+        "HHSTesting",
+        "Valorum",
+        "covid_tracking",
+        "other"
+      ]
+    },
+    "AnomalyAnnotation": {
+      "title": "AnomalyAnnotation",
+      "description": "Base model for API output.",
+      "type": "object",
+      "properties": {
+        "date": {
+          "title": "Date",
+          "description": "Date of anomaly",
+          "type": "string",
+          "format": "date"
+        },
+        "original_observation": {
+          "title": "Original Observation",
+          "description": "Original value on this date detected as anomalous.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "date",
+        "original_observation"
+      ]
+    },
+    "FieldAnnotations": {
+      "title": "FieldAnnotations",
+      "description": "Annotations associated with one field.",
+      "type": "object",
+      "properties": {
+        "sources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FieldSource"
+          }
+        },
+        "anomalies": {
+          "title": "Anomalies",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AnomalyAnnotation"
+          }
+        }
+      },
+      "required": [
+        "sources",
+        "anomalies"
+      ]
+    },
+    "Annotations": {
+      "title": "Annotations",
+      "description": "Annotations for each field.",
+      "type": "object",
+      "properties": {
+        "cases": {
+          "title": "Cases",
+          "description": "Annotations for cases",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "deaths": {
+          "title": "Deaths",
+          "description": "Annotations for deaths",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "positiveTests": {
+          "title": "Positivetests",
+          "description": "Annotations for positiveTests",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "negativeTests": {
+          "title": "Negativetests",
+          "description": "Annotations for negativeTests",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "contactTracers": {
+          "title": "Contacttracers",
+          "description": "Annotations for contactTracers",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "hospitalBeds": {
+          "title": "Hospitalbeds",
+          "description": "Annotations for hospitalBeds",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "icuBeds": {
+          "title": "Icubeds",
+          "description": "Annotations for icuBeds",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "newCases": {
+          "title": "Newcases",
+          "description": "Annotations for newCases",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "vaccinesDistributed": {
+          "title": "Vaccinesdistributed",
+          "description": "Annotations for vaccinesDistributed",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "vaccinationsInitiated": {
+          "title": "Vaccinationsinitiated",
+          "description": "Annotations for vaccinationsInitiated",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        },
+        "vaccinationsCompleted": {
+          "title": "Vaccinationscompleted",
+          "description": "Annotations for vaccinationsCompleted",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FieldAnnotations"
+            }
+          ]
+        }
+      }
     },
     "MetricsTimeseriesRow": {
       "title": "MetricsTimeseriesRow",
@@ -840,7 +1009,7 @@
         },
         "vaccinationsCompleted": {
           "title": "Vaccinationscompleted",
-          "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the both first and second dose.\n",
+          "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with both the first and second dose.\n",
           "type": "integer"
         },
         "date": {

--- a/api/schemas_v2/RegionTimeseriesRowWithHeader.json
+++ b/api/schemas_v2/RegionTimeseriesRowWithHeader.json
@@ -266,7 +266,7 @@
         },
         "vaccinationsCompleted": {
           "title": "Vaccinationscompleted",
-          "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with the both first and second dose.\n",
+          "description": "\nNumber of vaccinations completed.\n\nThis value may vary by type of vaccine, but for Moderna and Pfizer, this indicates\nnumber of people vaccinated with both the first and second dose.\n",
           "type": "integer"
         }
       },


### PR DESCRIPTION
This PR builds towards https://trello.com/c/Cq2zNk2M/674-annotate-data-outliers-that-weve-flagged-in-the-ui

Follow up to https://github.com/covid-projections/covid-data-model/pull/889

## This PR
* update updates log
* `./run.py api update-v2-schemas`