### PR TITLE
Snapshot with truncated bulk histories

### DIFF
--- a/api/can_api_v2_definition.py
+++ b/api/can_api_v2_definition.py
@@ -391,6 +391,7 @@ class RegionSummaryWithTimeseries(RegionSummary):
 
         Returns: RegionSummaryWithTimeseries
         """
+        start_date = start_date.date()
         metrics_timeseries = [row for row in self.metricsTimeseries if row.date >= start_date]
         actuals_timeseries = [row for row in self.actualsTimeseries if row.date >= start_date]
         risk_levels_timeseries = [

--- a/api/can_api_v2_definition.py
+++ b/api/can_api_v2_definition.py
@@ -383,6 +383,26 @@ class RegionSummaryWithTimeseries(RegionSummary):
 
         return RegionSummary(**data)
 
+    def drop_dates_before(self, start_date: datetime.datetime) -> "RegionSummaryWithTimeseries":
+        """Returns a new instance with dates truncated before `start_date`.
+
+        Args:
+            start_date: Date that new timeseries should start on
+
+        Returns: RegionSummaryWithTimeseries
+        """
+        metrics_timeseries = [row for row in self.metricsTimeseries if row.date >= start_date]
+        actuals_timeseries = [row for row in self.actualsTimeseries if row.date >= start_date]
+        risk_levels_timeseries = [
+            row for row in self.riskLevelsTimeseries if row.date >= start_date
+        ]
+        updates = {
+            "metricsTimeseries": metrics_timeseries,
+            "actualsTimeseries": actuals_timeseries,
+            "riskLevelsTimeseries": risk_levels_timeseries,
+        }
+        return self.copy(update=updates)
+
 
 class AggregateRegionSummary(base_model.APIBaseModel):
     """Summary data for multiple regions."""

--- a/api/docs/open_api_schema.json
+++ b/api/docs/open_api_schema.json
@@ -35,9 +35,8 @@
       },
       "parameters": [
         {
-          "name": "fips",
-          "in": "path",
-          "description": "5 Letter County FIPS code",
+          "name": "apiKey",
+          "in": "query",
           "required": true,
           "deprecated": false,
           "allowEmptyValue": false,
@@ -48,8 +47,9 @@
           }
         },
         {
-          "name": "apiKey",
-          "in": "query",
+          "name": "fips",
+          "in": "path",
+          "description": "5 Letter County FIPS code",
           "required": true,
           "deprecated": false,
           "allowEmptyValue": false,
@@ -84,9 +84,8 @@
       },
       "parameters": [
         {
-          "name": "fips",
-          "in": "path",
-          "description": "5 Letter County FIPS code",
+          "name": "apiKey",
+          "in": "query",
           "required": true,
           "deprecated": false,
           "allowEmptyValue": false,
@@ -97,8 +96,9 @@
           }
         },
         {
-          "name": "apiKey",
-          "in": "query",
+          "name": "fips",
+          "in": "path",
+          "description": "5 Letter County FIPS code",
           "required": true,
           "deprecated": false,
           "allowEmptyValue": false,
@@ -133,9 +133,8 @@
       },
       "parameters": [
         {
-          "name": "state",
-          "in": "path",
-          "description": "2 Letter State Cocde",
+          "name": "apiKey",
+          "in": "query",
           "required": true,
           "deprecated": false,
           "allowEmptyValue": false,
@@ -146,8 +145,9 @@
           }
         },
         {
-          "name": "apiKey",
-          "in": "query",
+          "name": "state",
+          "in": "path",
+          "description": "2 Letter State Cocde",
           "required": true,
           "deprecated": false,
           "allowEmptyValue": false,
@@ -182,9 +182,8 @@
       },
       "parameters": [
         {
-          "name": "state",
-          "in": "path",
-          "description": "2 Letter State Cocde",
+          "name": "apiKey",
+          "in": "query",
           "required": true,
           "deprecated": false,
           "allowEmptyValue": false,
@@ -195,8 +194,9 @@
           }
         },
         {
-          "name": "apiKey",
-          "in": "query",
+          "name": "state",
+          "in": "path",
+          "description": "2 Letter State Cocde",
           "required": true,
           "deprecated": false,
           "allowEmptyValue": false,
@@ -231,9 +231,8 @@
       },
       "parameters": [
         {
-          "name": "cbsa_code",
-          "in": "path",
-          "description": "\n5 Letter core-based statistical area (CBSA) Code.\n\nFor a list of all CBSA codes, refer to the\n[Spreadsheet of CBSA Codes](https://github.com/covid-projections/covid-data-public/raw/main/data/census-msa/list1_2020.xls). This list includes a CBSA code to County mapping.\n",
+          "name": "apiKey",
+          "in": "query",
           "required": true,
           "deprecated": false,
           "allowEmptyValue": false,
@@ -244,8 +243,9 @@
           }
         },
         {
-          "name": "apiKey",
-          "in": "query",
+          "name": "cbsa_code",
+          "in": "path",
+          "description": "\n5 Letter core-based statistical area (CBSA) Code.\n\nFor a list of all CBSA codes, refer to the\n[Spreadsheet of CBSA Codes](https://github.com/covid-projections/covid-data-public/raw/main/data/census-msa/list1_2020.xls). This list includes a CBSA code to County mapping.\n",
           "required": true,
           "deprecated": false,
           "allowEmptyValue": false,
@@ -280,9 +280,8 @@
       },
       "parameters": [
         {
-          "name": "cbsa_code",
-          "in": "path",
-          "description": "\n5 Letter core-based statistical area (CBSA) Code.\n\nFor a list of all CBSA codes, refer to the\n[Spreadsheet of CBSA Codes](https://github.com/covid-projections/covid-data-public/raw/main/data/census-msa/list1_2020.xls). This list includes a CBSA code to County mapping.\n",
+          "name": "apiKey",
+          "in": "query",
           "required": true,
           "deprecated": false,
           "allowEmptyValue": false,
@@ -293,8 +292,9 @@
           }
         },
         {
-          "name": "apiKey",
-          "in": "query",
+          "name": "cbsa_code",
+          "in": "path",
+          "description": "\n5 Letter core-based statistical area (CBSA) Code.\n\nFor a list of all CBSA codes, refer to the\n[Spreadsheet of CBSA Codes](https://github.com/covid-projections/covid-data-public/raw/main/data/census-msa/list1_2020.xls). This list includes a CBSA code to County mapping.\n",
           "required": true,
           "deprecated": false,
           "allowEmptyValue": false,
@@ -409,6 +409,23 @@
           "explode": false,
           "allowReserved": false,
           "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "daysBack",
+          "in": "query",
+          "description": "\nNumber of days back to include in timeseries.\n\nIf not specified includes all history. Currently limited to 30 or 90 days.\n",
+          "required": false,
+          "deprecated": false,
+          "allowEmptyValue": false,
+          "explode": false,
+          "allowReserved": false,
+          "schema": {
+            "enum": [
+              "30",
+              "90"
+            ],
             "type": "string"
           }
         }
@@ -555,6 +572,23 @@
           "schema": {
             "type": "string"
           }
+        },
+        {
+          "name": "daysBack",
+          "in": "query",
+          "description": "\nNumber of days back to include in timeseries.\n\nIf not specified includes all history. Currently limited to 30 or 90 days.\n",
+          "required": false,
+          "deprecated": false,
+          "allowEmptyValue": false,
+          "explode": false,
+          "allowReserved": false,
+          "schema": {
+            "enum": [
+              "30",
+              "90"
+            ],
+            "type": "string"
+          }
         }
       ]
     },
@@ -697,6 +731,23 @@
           "explode": false,
           "allowReserved": false,
           "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "daysBack",
+          "in": "query",
+          "description": "\nNumber of days back to include in timeseries.\n\nIf not specified includes all history. Currently limited to 30 or 90 days.\n",
+          "required": false,
+          "deprecated": false,
+          "allowEmptyValue": false,
+          "explode": false,
+          "allowReserved": false,
+          "schema": {
+            "enum": [
+              "30",
+              "90"
+            ],
             "type": "string"
           }
         }

--- a/api/update_open_api_spec.py
+++ b/api/update_open_api_spec.py
@@ -40,6 +40,17 @@ state_parameter = {
     "description": "2 Letter State Cocde",
     "schema": {"type": "string"},
 }
+days_back_parameter = {
+    "name": "daysBack",
+    "in": "query",
+    "required": False,
+    "description": """
+Number of days back to include in timeseries.
+
+If not specified includes all history. Currently limited to 30 or 90 days.
+""",
+    "schema": {"type": "string", "enum": ["30", "90"]},
+}
 
 
 @dataclasses.dataclass
@@ -65,7 +76,7 @@ class APIEndpoint:
             "required": True,
             "schema": {"type": "string"},
         }
-        parameters = self.parameters + [security]
+        parameters = [security] + self.parameters
         content_type = "application/csv" if self.endpoint.endswith(".csv") else "application/json"
         return {
             "parameters": parameters,
@@ -121,7 +132,7 @@ ALL_COUNTY_SUMMARY_CSV = APIEndpoint(
 )
 ALL_COUNTY_TIMESERIES = APIEndpoint(
     endpoint="/counties.timeseries.json",
-    parameters=[],
+    parameters=[days_back_parameter],
     tags=[COUNTY_TAG],
     description="Region summaries with timeseries for all counties",
     summary="All counties timeseries",
@@ -171,7 +182,7 @@ ALL_STATE_SUMMARY_CSV = APIEndpoint(
 )
 ALL_STATE_TIMESERIES = APIEndpoint(
     endpoint="/states.timeseries.json",
-    parameters=[],
+    parameters=[days_back_parameter],
     tags=[STATE_TAG],
     description="Region summaries with timeseries for all states",
     summary="All states timeseries",
@@ -220,7 +231,7 @@ ALL_CBSA_SUMMARY_CSV = APIEndpoint(
 )
 ALL_CBSA_TIMESERIES = APIEndpoint(
     endpoint="/cbsas.timeseries.json",
-    parameters=[],
+    parameters=[days_back_parameter],
     tags=[CBSA_TAG],
     description="Region summaries with timeseries for all CBSAs",
     summary="All CBSAs timeseries",

--- a/libs/pipelines/api_v2_paths.py
+++ b/libs/pipelines/api_v2_paths.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import enum
 import dataclasses
 import pathlib
@@ -56,8 +57,14 @@ class APIOutputPathBuilder:
         self,
         aggregate_timeseries_summary: can_api_v2_definition.AggregateRegionSummaryWithTimeseries,
         file_type: FileType,
+        days_back: Optional[int] = None,
     ) -> str:
         assert file_type is FileType.JSON
+
+        if days_back:
+            # Including number of days that this file includes
+            return self.root / f"{self.region_key}.timeseries.{days_back}d.{file_type.suffix}"
+
         return self.root / f"{self.region_key}.timeseries.{file_type.suffix}"
 
     def bulk_summary(

--- a/test/libs/api_v2_pipeline_test.py
+++ b/test/libs/api_v2_pipeline_test.py
@@ -85,6 +85,8 @@ def test_build_api_output_for_intervention(nyc_regional_input, tmp_path):
     api_v2_pipeline.deploy_single_level(all_timeseries_api, AggregationLevel.COUNTY, county_output)
     expected_outputs = [
         "counties.timeseries.json",
+        "counties.timeseries.30d.json",
+        "counties.timeseries.90d.json",
         "counties.csv",
         "counties.timeseries.csv",
         "counties.json",


### PR DESCRIPTION
Here's a feature I've been meaning to add for a while:

Creates a couple more aggregate files `states.timeseries.30d.json`, `counties.timeseries.30d.json`, `counties.timeseries.90d.json`, etc. that truncate the history at 30 days or 90 days.

Then on the api, I added a query arg `daysBack` that lets you specify either 30 or 90 days back.  The cloudfront edge function modifies the s3 uri to request the appropriate file.

so a query of `https://api.covidactnow.org/v2/counties.timeseries.json?daysBack=30` would just return the `counties.timeseries.30d.json` file.

This should help immensely with location summary issues (and i've heard similar issues from other customers).  The counties.timeseries.json file is currently 742 MB, in contrast, the 30d county file is 81MB. 

Currently this is only for the json files, but could make for the csvs as well