### PR TITLE
Enable pagination for query results

### DIFF
--- a/libs/update_api_user_metrics.py
+++ b/libs/update_api_user_metrics.py
@@ -90,8 +90,6 @@ def _run_query(database: str, query: str,) -> List[dict]:
     if response["Status"]["State"] != "SUCCEEDED":
         raise CloudWatchQueryError()
 
-    response_query_result = client.get_query_results(QueryExecutionId=query_id)
-
     results_paginator = client.get_paginator("get_query_results")
     results_iter = results_paginator.paginate(
         QueryExecutionId=query_id, PaginationConfig={"PageSize": 1000}

--- a/libs/update_api_user_metrics.py
+++ b/libs/update_api_user_metrics.py
@@ -109,8 +109,10 @@ def _run_query(database: str, query: str,) -> List[dict]:
         # For the first page, set header
         if not header:
             header = rows[0]
-
-        data = rows[1:]
+            data = rows[1:]
+        else:
+            # For pages without header, use all rows
+            data = rows
 
         for row in data:
             record = {}


### PR DESCRIPTION
good news, we have over 1k API users! The code was only equipped to handle the first page, so this paginates the response and will update with all active users.

Tested by running locally against the athena data that has more than 1000 rows