### PR TITLE
add zeros_filter

### DIFF
--- a/cli/data.py
+++ b/cli/data.py
@@ -26,6 +26,7 @@ from libs.datasets import dataset_utils
 from libs.datasets import combined_datasets
 from libs.datasets.sources import forecast_hub
 from libs.datasets import tail_filter
+from libs.datasets.sources import zeros_filter
 from libs.us_state_abbrev import ABBREV_US_UNKNOWN_COUNTY_FIPS
 from pyseir import DATA_DIR
 import pyseir.icu.utils
@@ -96,6 +97,15 @@ def update(aggregate_to_country: bool, state: Optional[str], fips: Optional[str]
     )
     # Filter for stalled cumulative values before deriving NEW_CASES from CASES.
     _, multiregion_dataset = TailFilter.run(multiregion_dataset, CUMULATIVE_FIELDS_TO_FILTER,)
+    multiregion_dataset = zeros_filter.drop_all_zero_timeseries(
+        multiregion_dataset,
+        [
+            CommonFields.VACCINES_DISTRIBUTED,
+            CommonFields.VACCINES_ADMINISTERED,
+            CommonFields.VACCINATIONS_COMPLETED,
+            CommonFields.VACCINATIONS_INITIATED,
+        ],
+    )
     multiregion_dataset = timeseries.add_new_cases(multiregion_dataset)
     multiregion_dataset = timeseries.drop_new_case_outliers(multiregion_dataset)
     multiregion_dataset = timeseries.backfill_vaccination_initiated(multiregion_dataset)

--- a/libs/datasets/sources/zeros_filter.py
+++ b/libs/datasets/sources/zeros_filter.py
@@ -1,0 +1,48 @@
+from typing import Collection
+
+import structlog
+from covidactnow.datapublic.common_fields import CommonFields
+from covidactnow.datapublic.common_fields import PdFields
+
+from libs.datasets import timeseries
+import pandas as pd
+
+
+_log = structlog.get_logger()
+
+
+DROPPING_TIMESERIES_WITH_ONLY_ZEROS = "Dropping timeseries with only zeros"
+
+
+def drop_all_zero_timeseries(
+    ds_in: timeseries.MultiRegionDataset, fields: Collection[CommonFields]
+) -> timeseries.MultiRegionDataset:
+    ts_wide = ds_in.timeseries_wide_dates()
+
+    # Separate into timeseries in `fields` and all others.
+    variable_mask = ts_wide.index.get_level_values(PdFields.VARIABLE).isin(fields)
+    ts_wide_other_variables = ts_wide.loc[~variable_mask]
+    ts_wide_variables = ts_wide.loc[variable_mask]
+
+    # Keep rows/timeseries that have at least one value that is not 0 or NA
+    to_keep_mask = ts_wide_variables.replace(pd.NA, 0).any(axis=1)
+    to_drop = ts_wide_variables.loc[~to_keep_mask].index
+    if not to_drop.empty:
+        # Maybe add filtering to not log about the known bad data in OH counties and Loving
+        # County Texas using a RegionMask(level=County, state=OH) and some kind of RegionMask
+        # representing counties with a small population.
+        _log.info(DROPPING_TIMESERIES_WITH_ONLY_ZEROS, dropped=to_drop)
+    ts_wide_kept = ts_wide_variables.loc[to_keep_mask]
+
+    ts_wide_out = pd.concat([ts_wide_kept, ts_wide_other_variables])
+
+    # Make a new dataset without the dropped timeseries. This does not drop the tags of the
+    # dropped timeseries but keeping the provenance tags doesn't seem to be a problem. Maybe it'd
+    # be cleaner to add a method 'MultiRegionDataset.drop_timeseries' similar to 'remove_regions' or
+    # move this into 'MultiRegionDataset' similar to 'drop_stale_timeseries'.
+    ds_out = (
+        timeseries.MultiRegionDataset.from_timeseries_wide_dates_df(ts_wide_out)
+        .append_tag_df(ds_in.tag.reset_index())
+        .add_static_values(ds_in.static.reset_index())
+    )
+    return ds_out

--- a/tests/libs/datasets/zeros_filter_test.py
+++ b/tests/libs/datasets/zeros_filter_test.py
@@ -1,0 +1,47 @@
+import more_itertools
+import structlog
+from covidactnow.datapublic.common_fields import CommonFields
+
+from libs.datasets.sources import zeros_filter
+from libs.pipeline import Region
+from tests import test_helpers
+from tests.test_helpers import TimeseriesLiteral
+import pandas as pd
+
+
+def test_basic():
+    region_tx = Region.from_state("TX")
+    region_sf = Region.from_fips("06075")
+    region_hi = Region.from_state("HI")
+    # Add a timeseries with a tag to make sure they are preserved.
+    ts_with_tag = TimeseriesLiteral(
+        [0, 0, 0], annotation=[test_helpers.make_tag(date="2020-04-01")]
+    )
+    ds_in = test_helpers.build_dataset(
+        {
+            region_tx: {CommonFields.VACCINES_DISTRIBUTED: [0, 0, 0]},
+            region_sf: {CommonFields.VACCINES_DISTRIBUTED: [0, 0, 1]},
+            region_hi: {
+                CommonFields.VACCINES_DISTRIBUTED: [0, 0, None],
+                CommonFields.CASES: ts_with_tag,
+            },
+        }
+    )
+
+    with structlog.testing.capture_logs() as logs:
+        ds_out = zeros_filter.drop_all_zero_timeseries(ds_in, [CommonFields.VACCINES_DISTRIBUTED])
+    ds_expected = test_helpers.build_dataset(
+        {
+            region_sf: {CommonFields.VACCINES_DISTRIBUTED: [0, 0, 1]},
+            region_hi: {CommonFields.CASES: ts_with_tag},
+        }
+    )
+    log = more_itertools.one(logs)
+    assert log["event"] == zeros_filter.DROPPING_TIMESERIES_WITH_ONLY_ZEROS
+    assert pd.MultiIndex.from_tuples(
+        [
+            (region_hi.location_id, CommonFields.VACCINES_DISTRIBUTED),
+            (region_tx.location_id, CommonFields.VACCINES_DISTRIBUTED),
+        ]
+    ).equals(log["dropped"])
+    test_helpers.assert_dataset_like(ds_expected, ds_out)


### PR DESCRIPTION
This PR adds a filter to remove all-zero vaccine data, for https://trello.com/c/J3M0Ksb5/827-unmask-ohio-vaccination-data

## Tested

Ran `./run.py data update` and `git difftool -t vimdiff data/multiregion-wide-dates.csv` to see that only data in OH counties and the tiny county of Loving, TX were dropped.
