### PR TITLE
Add TestAndTrace and CAN Scraper sources in API

### DIFF
--- a/api/can_api_v2_definition.py
+++ b/api/can_api_v2_definition.py
@@ -31,6 +31,8 @@ class FieldSource(GetByValueMixin, enum.Enum):
     VALORUM = "Valorum"
     COVID_TRACKING = "covid_tracking"
     USA_FACTS = "USAFacts"
+    TestAndTrace = "TestAndTrace"
+    CANScrapersStateProviders = "CANScrapersStateProviders"
     OTHER = "other"
 
 


### PR DESCRIPTION
This PR add sources found in API build logging: https://github.com/covid-projections/covid-data-model/runs/1818041994
