### PR TITLE
add new vaccine pct fields in combined_datasets

### DIFF
--- a/data/multiregion.json
+++ b/data/multiregion.json
@@ -7,9 +7,9 @@
     "is_dirty": false
   },
   "model_git_info": {
-    "sha": "5460a8ec8faa61a54c622d42bc463f5648267d1e",
-    "branch": "main",
+    "sha": "aad38109d09dc79e2b19bb26aaa27472079dd7b5",
+    "branch": "tgb-846-vaccine-pct-combined-data",
     "is_dirty": false
   },
-  "updated_at": "2021-02-02T21:40:04.817787"
+  "updated_at": "2021-02-03T00:00:08.093911"
 }

--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -185,6 +185,8 @@ ALL_TIMESERIES_FEATURE_DEFINITION: FeatureDataSourceMap = {
     CommonFields.VACCINES_ADMINISTERED: [CANScraperStateProviders],
     CommonFields.VACCINATIONS_INITIATED: [CANScraperStateProviders, CDCVaccinesDataset],
     CommonFields.VACCINATIONS_COMPLETED: [CANScraperStateProviders, CDCVaccinesDataset],
+    CommonFields.VACCINATIONS_INITIATED_PCT: [CANScraperStateProviders],
+    CommonFields.VACCINATIONS_COMPLETED_PCT: [CANScraperStateProviders],
 }
 
 ALL_FIELDS_FEATURE_DEFINITION: FeatureDataSourceMap = {

--- a/libs/datasets/sources/can_scraper_state_providers.py
+++ b/libs/datasets/sources/can_scraper_state_providers.py
@@ -21,4 +21,6 @@ class CANScraperStateProviders(data_source.DataSource):
         CommonFields.CURRENT_HOSPITALIZED,
         CommonFields.POSITIVE_TESTS_VIRAL,
         CommonFields.CURRENT_ICU,
+        CommonFields.VACCINATIONS_INITIATED_PCT,
+        CommonFields.VACCINATIONS_COMPLETED_PCT,
     ]


### PR DESCRIPTION
This PR is part of https://trello.com/c/PgOjusc7/846-etl-tn-county-vaccine-data-into-api

## Tested

```
./run.py data update
git difftool -t vimdiff data/multiregion-wide-dates.csv
```
finds vaccinations_completed_pct and vaccinations_initiated_pct added to TN counties and a few CBSA (most likely in TN too).
No other changes.
