### PR TITLE
Data update with fixed vaccine aggregations

### DIFF
--- a/data/multiregion-wide-dates.csv
+++ b/data/multiregion-wide-dates.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:78b6687c98de9fa651e60099340a12c2f0520242bd8da2e023839558dc3bdf23
-size 30404848
+oid sha256:a4e24fb6d85d420e4bc7bd3dc98e51134d70eccd190ccf44f1b95f485f57fb9c
+size 30404855

--- a/data/multiregion.json
+++ b/data/multiregion.json
@@ -7,9 +7,9 @@
     "is_dirty": false
   },
   "model_git_info": {
-    "sha": "50c1c96e12880e3d9d6870fd3501ba7ebd03d7b9",
-    "branch": "main",
+    "sha": "d4416f99bd62491c93bd87120ba53f30f387afaa",
+    "branch": "tgb-865-agg-vac-ratio",
     "is_dirty": false
   },
-  "updated_at": "2021-02-03T12:03:39.415173"
+  "updated_at": "2021-02-03T20:15:24.391479"
 }

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -1246,6 +1246,12 @@ WEIGHTED_AGGREGATIONS = (
     StaticWeightedAverageAggregation(CommonFields.TEST_POSITIVITY_7D, CommonFields.POPULATION),
     StaticWeightedAverageAggregation(CommonFields.TEST_POSITIVITY_14D, CommonFields.POPULATION),
     StaticWeightedAverageAggregation(
+        CommonFields.VACCINATIONS_INITIATED_PCT, CommonFields.POPULATION
+    ),
+    StaticWeightedAverageAggregation(
+        CommonFields.VACCINATIONS_COMPLETED_PCT, CommonFields.POPULATION
+    ),
+    StaticWeightedAverageAggregation(
         CommonFields.ALL_BED_TYPICAL_OCCUPANCY_RATE, CommonFields.MAX_BED_COUNT
     ),
     StaticWeightedAverageAggregation(


### PR DESCRIPTION
This PR addresses https://trello.com/c/WYdvQgl4/865-metro-vaccinated-incorrect

Data update follow up to https://github.com/covid-projections/covid-data-model/pull/928 after failure in github action that I don't need (https://github.com/covid-projections/covid-data-public/runs/1825313387).