### PR TITLE
Add source_url tag

### DIFF
--- a/libs/datasets/taglib.py
+++ b/libs/datasets/taglib.py
@@ -98,22 +98,28 @@ class ProvenanceTag(TagInTimeseries):
 
     @classmethod
     def make_instance(cls, *, content: str) -> "TagInTimeseries":
-        return ProvenanceTag(source=content)
+        return cls(source=content)
 
     @property
     def content(self) -> str:
         return self.source
 
 
+class UrlStr(str):
+    """"""
+
+    pass
+
+
 @dataclass(frozen=True)
 class SourceUrl(TagInTimeseries):
-    source: str
+    source: UrlStr
 
     TAG_TYPE = TagType.SOURCE_URL
 
     @classmethod
     def make_instance(cls, *, content: str) -> "TagInTimeseries":
-        return SourceUrl(source=content)
+        return cls(source=UrlStr(content))
 
     @property
     def content(self) -> str:
@@ -163,6 +169,7 @@ TAG_TYPE_TO_CLASS = {
     TagType.CUMULATIVE_LONG_TAIL_TRUNCATED: CumulativeLongTailTruncated,
     TagType.ZSCORE_OUTLIER: ZScoreOutlier,
     TagType.PROVENANCE: ProvenanceTag,
+    TagType.SOURCE_URL: SourceUrl,
 }
 
 

--- a/libs/datasets/taglib.py
+++ b/libs/datasets/taglib.py
@@ -112,6 +112,8 @@ class UrlStr(str):
     pass
 
 
+# TODO(tom): Consider merging source_url into provenance. See
+#  https://github.com/covid-projections/covid-data-model/pull/935#pullrequestreview-587070370
 @dataclass(frozen=True)
 class SourceUrl(TagInTimeseries):
     source: UrlStr

--- a/libs/datasets/taglib.py
+++ b/libs/datasets/taglib.py
@@ -106,8 +106,9 @@ class ProvenanceTag(TagInTimeseries):
 
 
 class UrlStr(str):
-    """"""
+    """Wraps str to provide some type safety."""
 
+    # If we need to do more with URLs consider replacing UrlStr with https://pypi.org/project/yarl/
     pass
 
 

--- a/libs/datasets/taglib.py
+++ b/libs/datasets/taglib.py
@@ -50,6 +50,7 @@ class TagType(GetByValueMixin, ValueAsStrMixin, str, enum.Enum):
     ZSCORE_OUTLIER = "zscore_outlier"
 
     PROVENANCE = PdFields.PROVENANCE
+    SOURCE_URL = "source_url"
 
 
 @dataclass(frozen=True)
@@ -98,6 +99,21 @@ class ProvenanceTag(TagInTimeseries):
     @classmethod
     def make_instance(cls, *, content: str) -> "TagInTimeseries":
         return ProvenanceTag(source=content)
+
+    @property
+    def content(self) -> str:
+        return self.source
+
+
+@dataclass(frozen=True)
+class SourceUrl(TagInTimeseries):
+    source: str
+
+    TAG_TYPE = TagType.SOURCE_URL
+
+    @classmethod
+    def make_instance(cls, *, content: str) -> "TagInTimeseries":
+        return SourceUrl(source=content)
 
     @property
     def content(self) -> str:

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -36,6 +36,7 @@ from libs.datasets.dataset_utils import TIMESERIES_INDEX_FIELDS
 from libs.datasets import taglib
 from libs.datasets.taglib import TagField
 from libs.datasets.taglib import TagType
+from libs.datasets.taglib import UrlStr
 from libs.pipeline import Region
 import pandas.core.groupby.generic
 from backports.cached_property import cached_property
@@ -100,6 +101,12 @@ class OneRegionTimeseriesDataset:
         provenance_series = self.tag.loc[:, [TagType.PROVENANCE]].droplevel([TagField.TYPE])
         # https://stackoverflow.com/a/56065318
         return provenance_series.groupby(level=0).agg(list).to_dict()
+
+    @property
+    def source_url(self) -> Mapping[CommonFields, List[UrlStr]]:
+        source_url_series = self.tag.loc[:, [TagType.SOURCE_URL]].droplevel([TagField.TYPE])
+        # https://stackoverflow.com/a/56065318
+        return source_url_series.groupby(level=0).agg(list).to_dict()
 
     def annotations(self, metric: FieldName) -> List[taglib.AnnotationWithDate]:
         return_value = []

--- a/tests/libs/datasets/timeseries_test.py
+++ b/tests/libs/datasets/timeseries_test.py
@@ -1,6 +1,7 @@
 import datetime
 import io
 import pathlib
+import dataclasses
 
 import pytest
 import pandas as pd
@@ -1010,7 +1011,7 @@ def test_add_provenance_all_with_tags():
 
     dataset_out = dataset_in.add_provenance_all("prov_prov")
 
-    timeseries.provenance = "prov_prov"
+    timeseries = dataclasses.replace(timeseries, provenance=["prov_prov"])
     dataset_expected = test_helpers.build_dataset({region: {CommonFields.CASES: timeseries}})
 
     test_helpers.assert_dataset_like(dataset_out, dataset_expected)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -34,6 +34,7 @@ T = TypeVar("T")
 
 
 def _to_list(list_or_scalar: Union[None, T, List[T]]) -> List[T]:
+    """Returns a list which may be empty, contain the single non-list parameter or the parameter."""
     if isinstance(list_or_scalar, List):
         return list_or_scalar
     elif list_or_scalar:
@@ -42,21 +43,59 @@ def _to_list(list_or_scalar: Union[None, T, List[T]]) -> List[T]:
         return []
 
 
-class TimeseriesLiteral(UserList):
-    """Represents a timeseries literal, a sequence of floats and provenance string."""
+# TODO(tom): Remove dataclass_with_default_init once we are using Python 3.9. See
+#  https://stackoverflow.com/a/58336722
+def dataclass_with_default_init(_cls=None, *args, **kwargs):
+    def wrap(cls):
+        # Save the current __init__ and remove it so dataclass will
+        # create the default __init__.
+        user_init = getattr(cls, "__init__")
+        delattr(cls, "__init__")
 
+        # let dataclass process our class.
+        result = dataclasses.dataclass(cls, *args, **kwargs)
+
+        # Restore the user's __init__ save the default init to __default_init__.
+        setattr(result, "__default_init__", result.__init__)
+        setattr(result, "__init__", user_init)
+
+        # Just in case that dataclass will return a new instance,
+        # (currently, does not happen), restore cls's __init__.
+        if result is not cls:
+            setattr(cls, "__init__", user_init)
+
+        return result
+
+    # Support both dataclass_with_default_init() and dataclass_with_default_init
+    if _cls is None:
+        return wrap
+    else:
+        return wrap(_cls)
+
+
+@dataclass_with_default_init(frozen=True)
+class TimeseriesLiteral(UserList):
+    """Represents a timeseries literal: a sequence of floats and some related attributes."""
+
+    data: Sequence[float]
+    provenance: Sequence[str]
+    source_url: Sequence[UrlStr]
+    annotation: Sequence[taglib.TagInTimeseries] = ()
+
+    # noinspection PyMissingConstructor
     def __init__(
         self,
-        ts_list,
-        *,
+        *args,
         provenance: Union[None, str, List[str]] = None,
         source_url: Union[None, UrlStr, List[UrlStr]] = None,
-        annotation: Sequence[taglib.TagInTimeseries] = (),
+        **kwargs,
     ):
-        super().__init__(ts_list)
-        self.provenance = _to_list(provenance)
-        self.source_url = _to_list(source_url)
-        self.annotation = annotation
+        """Initialize `self`, doing some type conversion."""
+        # UserList.__init__ attempts to set self.data, which fails on this frozen class. Instead
+        # let the dataclasses code initialize `data`.
+        self.__default_init__(  # pylint: disable=E1101
+            *args, provenance=_to_list(provenance), source_url=_to_list(source_url), **kwargs
+        )
 
 
 def make_tag_df(


### PR DESCRIPTION
This PR is a big part of https://trello.com/c/lbiZpKwH/849-proposal-improve-the-provenance-link-so-that-we-can-show-a-source-urls-instead-of-a-data-class

* Adds `class SourceUrl(TagInTimeseries)` and an property to get them in `OneRegionTimeseriesDataset`
* Changes `test_helper.TimeseriesLiteral` to a frozen dataclass with some type conversion in `__init__`
* Adds `dataclass_with_default_init`, backport of code in Python 3.9

Instead of doing type conversion in `test_helper.TimeseriesLiteral` i could leave the attributes as one of 3 types and added properties provenance_as_list and source_url_as_list. Either is fine but I had to pick one.