### PR TITLE
Move parquet transforms to covid-data-model

### DIFF
--- a/data/multiregion.json
+++ b/data/multiregion.json
@@ -4,12 +4,12 @@
   "data_git_info": {
     "sha": "e77a812683be47850b272fd1b4d644b853bafc84",
     "branch": "main",
-    "is_dirty": true
+    "is_dirty": false
   },
   "model_git_info": {
-    "sha": "cf83fd41c231c7388984f90584935071167adb15",
-    "branch": "tgb-849-move-parquet-transform",
-    "is_dirty": true
+    "sha": "52ce73efcbc6a0725e7e4b73f3cc25668b2b967b",
+    "branch": "main",
+    "is_dirty": false
   },
-  "updated_at": "2021-02-10T20:19:26.132506"
+  "updated_at": "2021-02-10T16:24:58.907864"
 }

--- a/data/multiregion.json
+++ b/data/multiregion.json
@@ -4,12 +4,12 @@
   "data_git_info": {
     "sha": "e77a812683be47850b272fd1b4d644b853bafc84",
     "branch": "main",
-    "is_dirty": false
+    "is_dirty": true
   },
   "model_git_info": {
-    "sha": "52ce73efcbc6a0725e7e4b73f3cc25668b2b967b",
-    "branch": "main",
-    "is_dirty": false
+    "sha": "cf83fd41c231c7388984f90584935071167adb15",
+    "branch": "tgb-849-move-parquet-transform",
+    "is_dirty": true
   },
-  "updated_at": "2021-02-10T16:24:58.907864"
+  "updated_at": "2021-02-10T20:19:26.132506"
 }

--- a/libs/datasets/data_source.py
+++ b/libs/datasets/data_source.py
@@ -75,15 +75,15 @@ class DataSource(object):
 # TODO(tom): Clean up the mess that is subclasses of DataSource and
 #  instances of DataSourceAndRegionMasks
 class CanScraperBase(DataSource):
-    # The method called to transform the DataFrame returned by CovidCountyDataset into what is
+    # The method called to transform the DataFrame returned by CanScraperLoader into what is
     # consumed by DataSource.make_dataset. Must be set in subclasses.
     TRANSFORM_METHOD: Callable[[pd.DataFrame], pd.DataFrame]
 
     @staticmethod
     @lru_cache(None)
-    def _get_covid_county_dataset() -> ccd_helpers.CovidCountyDataset:
-        # TODO(tom): Rename CovidCountyDataset to CanScraperLoader or the something like that.
-        return ccd_helpers.CovidCountyDataset.load()
+    def _get_covid_county_dataset() -> ccd_helpers.CanScraperLoader:
+        # TODO(tom): Rename CanScraperLoader to CanScraperLoader or the something like that.
+        return ccd_helpers.CanScraperLoader.load()
 
     @classmethod
     def _load_data(cls) -> pd.DataFrame:

--- a/libs/datasets/data_source.py
+++ b/libs/datasets/data_source.py
@@ -7,7 +7,7 @@ from typing import Union
 import structlog
 from covidactnow.datapublic import common_df
 from covidactnow.datapublic.common_fields import CommonFields
-from scripts import ccd_helpers
+from libs.datasets.sources import can_scraper_helpers as ccd_helpers
 
 from libs.datasets import dataset_utils
 from libs.datasets import timeseries
@@ -83,7 +83,7 @@ class CanScraperBase(DataSource):
     @lru_cache(None)
     def _get_covid_county_dataset() -> ccd_helpers.CovidCountyDataset:
         # TODO(tom): Rename CovidCountyDataset to CanScraperLoader or the something like that.
-        return ccd_helpers.CovidCountyDataset.load(fetch=False)
+        return ccd_helpers.CovidCountyDataset.load()
 
     @classmethod
     def _load_data(cls) -> pd.DataFrame:

--- a/libs/datasets/data_source.py
+++ b/libs/datasets/data_source.py
@@ -71,7 +71,6 @@ class DataSource(object):
         return MultiRegionDataset.from_fips_timeseries_df(data).add_provenance_all(cls.SOURCE_NAME)
 
 
-# TODO(tom): Move all the ccd_helpers code to this repo
 # TODO(tom): Clean up the mess that is subclasses of DataSource and
 #  instances of DataSourceAndRegionMasks
 class CanScraperBase(DataSource):
@@ -82,7 +81,6 @@ class CanScraperBase(DataSource):
     @staticmethod
     @lru_cache(None)
     def _get_covid_county_dataset() -> ccd_helpers.CanScraperLoader:
-        # TODO(tom): Rename CanScraperLoader to CanScraperLoader or the something like that.
         return ccd_helpers.CanScraperLoader.load()
 
     @classmethod

--- a/libs/datasets/sources/can_scraper_helpers.py
+++ b/libs/datasets/sources/can_scraper_helpers.py
@@ -1,0 +1,184 @@
+"""Helpers to access and query data loaded from the CAN Scraper parquet file.
+"""
+from typing import List
+import enum
+import dataclasses
+from typing import Optional
+
+import more_itertools
+import structlog
+import pandas as pd
+from covidactnow.datapublic.common_fields import FieldNameAndCommonField
+from covidactnow.datapublic.common_fields import GetByValueMixin
+from covidactnow.datapublic.common_fields import CommonFields
+
+
+# Airflow jobs output a single parquet file with all of the data - this is where
+# it is currently stored.
+from libs.datasets import dataset_utils
+
+PARQUET_PATH = "data/can-scrape/can_scrape_api_covid_us.parquet"
+
+
+_logger = structlog.getLogger()
+
+
+@enum.unique
+class Fields(GetByValueMixin, FieldNameAndCommonField, enum.Enum):
+    """Fields in CCD DataFrame."""
+
+    PROVIDER = "provider", None
+    DATE = "dt", CommonFields.DATE
+    LOCATION_TYPE = "location_type", CommonFields.AGGREGATE_LEVEL
+    # Special transformation to FIPS
+    LOCATION = "location", CommonFields.FIPS
+    VARIABLE_NAME = "variable_name", None
+    MEASUREMENT = "measurement", None
+    UNIT = "unit", None
+    AGE = "age", None
+    RACE = "race", None
+    SEX = "sex", None
+    VALUE = "value", None
+
+
+@dataclasses.dataclass(frozen=True)
+class ScraperVariable:
+    """Represents a specific variable scraped in CAN Scraper Dataset.
+
+    ScraperVariable has two modes:
+    * If `common_field`, `measurement` and `unit` are falsy the scraper variable is dropped.
+    * If they are truthy values from the scraper variable are copied to the output.
+    `query_multiple_variables` asserts that each ScraperVariable is in one of these modes.
+    Turning these into two different classes seems like more work than it is worth right now.
+
+    The table at https://github.com/covid-projections/can-scrapers/blob/main/can_tools/bootstrap_data/covid_variables.csv
+    """
+
+    variable_name: str
+    provider: str
+    measurement: str = ""
+    unit: str = ""
+    common_field: Optional[CommonFields] = None
+    age: str = "all"
+    race: str = "all"
+    sex: str = "all"
+
+
+def _fips_from_int(param: pd.Series):
+    """Transform FIPS from an int64 to a string of 2 or 5 chars.
+
+    See https://github.com/valorumdata/covid_county_data.py/issues/3
+
+    Copied from covid-data-public/scripts/helpers.py
+    """
+    return param.apply(lambda v: f"{v:0>{2 if v < 100 else 5}}")
+
+
+@dataclasses.dataclass
+class CanScraperLoader:
+
+    timeseries_df: pd.DataFrame
+
+    def _get_rows(self, variable: ScraperVariable) -> pd.DataFrame:
+        all_df = self.timeseries_df
+
+        is_selected_data = (
+            (all_df[Fields.PROVIDER] == variable.provider)
+            & (all_df[Fields.VARIABLE_NAME] == variable.variable_name)
+            & (all_df[Fields.AGE] == variable.age)
+            & (all_df[Fields.RACE] == variable.race)
+            & (all_df[Fields.SEX] == variable.sex)
+        )
+        if variable.measurement:
+            is_selected_data = is_selected_data & (
+                all_df[Fields.MEASUREMENT] == variable.measurement
+            )
+        if variable.unit:
+            is_selected_data = is_selected_data & (all_df[Fields.UNIT] == variable.unit)
+
+        return all_df.loc[is_selected_data, :].copy()
+
+    def query_multiple_variables(
+        self, variables: List[ScraperVariable], *, log_provider_coverage_warnings: bool = False
+    ) -> pd.DataFrame:
+        """Queries multiple variables returning wide df with variable names as columns.
+
+        Args:
+            variables: Variables to query
+            log_provider_coverage_warnings: Log warnings when upstream data has variables not in
+              `variables` and hints when a variable has no data.
+        """
+        if log_provider_coverage_warnings:
+            self.check_variable_coverage(variables)
+        selected_data = []
+
+        for variable in variables:
+            # Check that `variable` agrees with stuff in the ScraperVariable docstring.
+            if variable.common_field is None:
+                assert variable.measurement == ""
+                assert variable.unit == ""
+                continue
+            else:
+                # Must be set when copying to the return value
+                assert variable.measurement
+                assert variable.unit
+
+            data = self._get_rows(variable)
+            if data.empty and log_provider_coverage_warnings:
+                _logger.info("No data rows found for variable", variable=variable)
+                more_data = self._get_rows(dataclasses.replace(variable, measurement="", unit=""))
+                _logger.info(
+                    "Try these parameters",
+                    variable_name=variable.variable_name,
+                    measurement_counts=str(more_data[Fields.MEASUREMENT].value_counts().to_dict()),
+                    unit_counts=str(more_data[Fields.UNIT].value_counts().to_dict()),
+                )
+
+            # Rename fields if common field name exists
+            if variable.common_field:
+                data.loc[:, Fields.VARIABLE_NAME] = variable.common_field
+
+            selected_data.append(data)
+
+        combined_df = pd.concat(selected_data)
+
+        wide_df = combined_df.pivot_table(
+            index=[Fields.LOCATION.value, Fields.DATE.value, Fields.LOCATION_TYPE.value],
+            columns=Fields.VARIABLE_NAME.value,
+            values=Fields.VALUE.value,
+        ).reset_index()
+
+        data = wide_df.rename(
+            columns={
+                Fields.LOCATION.value: CommonFields.FIPS,
+                Fields.DATE.value: CommonFields.DATE,
+                Fields.LOCATION_TYPE.value: CommonFields.AGGREGATE_LEVEL,
+            }
+        )
+        data.columns.name = None
+        return data
+
+    def check_variable_coverage(self, variables: List[ScraperVariable]):
+        provider_name = more_itertools.one(set(v.provider for v in variables))
+        provider_mask = self.timeseries_df[Fields.PROVIDER] == provider_name
+        counts = self.timeseries_df.loc[provider_mask, Fields.VARIABLE_NAME].value_counts()
+        variables_by_name = {var.variable_name: var for var in variables}
+        for variable_name, count in counts.iteritems():
+            if variable_name not in variables_by_name:
+                _logger.info(
+                    "Upstream has variable not in variables list",
+                    variable_name=variable_name,
+                    count=count,
+                )
+
+    @staticmethod
+    def load() -> "CanScraperLoader":
+        """Returns a CanScraperLoader which holds data loaded from the CAN Scraper."""
+
+        data_root = dataset_utils.LOCAL_PUBLIC_DATA_PATH
+        input_path = data_root / PARQUET_PATH
+
+        all_df = pd.read_parquet(input_path)
+        all_df[Fields.LOCATION] = _fips_from_int(all_df[Fields.LOCATION])
+
+        return CanScraperLoader(all_df)

--- a/libs/datasets/sources/can_scraper_state_providers.py
+++ b/libs/datasets/sources/can_scraper_state_providers.py
@@ -1,15 +1,149 @@
-from covidactnow.datapublic.common_fields import CommonFields
-
-# TODO(tom): Remove this really ugly import from the covid-data-public repo.
-from scripts import update_can_scraper_state_providers
-
 from libs.datasets import data_source
+from covidactnow.datapublic.common_fields import CommonFields
+from libs.datasets.sources import can_scraper_helpers as ccd_helpers
+
+
+def transform(dataset: ccd_helpers.CovidCountyDataset):
+    variables = [
+        ccd_helpers.ScraperVariable(variable_name="pcr_tests_negative", provider="state"),
+        ccd_helpers.ScraperVariable(variable_name="unspecified_tests_total", provider="state"),
+        ccd_helpers.ScraperVariable(variable_name="unspecified_tests_positive", provider="state"),
+        ccd_helpers.ScraperVariable(variable_name="icu_beds_available", provider="state"),
+        ccd_helpers.ScraperVariable(variable_name="antibody_tests_total", provider="state"),
+        ccd_helpers.ScraperVariable(variable_name="antigen_tests_positive", provider="state"),
+        ccd_helpers.ScraperVariable(variable_name="antigen_tests_negative", provider="state"),
+        ccd_helpers.ScraperVariable(
+            variable_name="total_vaccine_doses_administered", provider="state"
+        ),
+        ccd_helpers.ScraperVariable(variable_name="hospital_beds_in_use", provider="state"),
+        ccd_helpers.ScraperVariable(variable_name="ventilators_in_use", provider="state"),
+        ccd_helpers.ScraperVariable(variable_name="ventilators_available", provider="state"),
+        ccd_helpers.ScraperVariable(variable_name="ventilators_capacity", provider="state"),
+        ccd_helpers.ScraperVariable(variable_name="pediatric_icu_beds_in_use", provider="state"),
+        ccd_helpers.ScraperVariable(variable_name="adult_icu_beds_available", provider="state"),
+        ccd_helpers.ScraperVariable(variable_name="pediatric_icu_beds_capacity", provider="state"),
+        ccd_helpers.ScraperVariable(variable_name="unspecified_tests_negative", provider="state"),
+        ccd_helpers.ScraperVariable(variable_name="antigen_tests_total", provider="state"),
+        ccd_helpers.ScraperVariable(variable_name="adult_icu_beds_in_use", provider="state"),
+        ccd_helpers.ScraperVariable(variable_name="hospital_beds_available", provider="state"),
+        ccd_helpers.ScraperVariable(variable_name="pediatric_icu_beds_available", provider="state"),
+        ccd_helpers.ScraperVariable(variable_name="adult_icu_beds_capacity", provider="state"),
+        ccd_helpers.ScraperVariable(variable_name="icu_beds_in_use", provider="state"),
+        ccd_helpers.ScraperVariable(
+            variable_name="cases",
+            measurement="cumulative",
+            unit="people",
+            provider="state",
+            common_field=CommonFields.CASES,
+        ),
+        ccd_helpers.ScraperVariable(
+            variable_name="deaths",
+            measurement="cumulative",
+            unit="people",
+            provider="state",
+            common_field=CommonFields.DEATHS,
+        ),
+        ccd_helpers.ScraperVariable(
+            variable_name="hospital_beds_in_use_covid",
+            measurement="current",
+            unit="beds",
+            provider="state",
+            common_field=CommonFields.CURRENT_HOSPITALIZED,
+        ),
+        ccd_helpers.ScraperVariable(
+            variable_name="hospital_beds_capacity",
+            measurement="current",
+            unit="beds",
+            provider="state",
+            common_field=CommonFields.STAFFED_BEDS,
+        ),
+        ccd_helpers.ScraperVariable(
+            variable_name="icu_beds_capacity",
+            measurement="current",
+            unit="beds",
+            provider="state",
+            common_field=CommonFields.ICU_BEDS,
+        ),
+        ccd_helpers.ScraperVariable(
+            variable_name="icu_beds_in_use_covid",
+            measurement="current",
+            unit="beds",
+            provider="state",
+            common_field=CommonFields.CURRENT_ICU,
+        ),
+        ccd_helpers.ScraperVariable(
+            variable_name="pcr_tests_total",
+            measurement="cumulative",
+            unit="specimens",  # Ignores less common unit=test_encounters and unit=unique_people
+            provider="state",
+            common_field=CommonFields.TOTAL_TESTS_VIRAL,
+        ),
+        ccd_helpers.ScraperVariable(
+            variable_name="pcr_tests_positive",
+            measurement="cumulative",
+            unit="specimens",  # Ignores test_encounters and unique_people
+            provider="state",
+            common_field=CommonFields.POSITIVE_TESTS_VIRAL,
+        ),
+        ccd_helpers.ScraperVariable(
+            variable_name="total_vaccine_allocated",
+            measurement="cumulative",
+            unit="doses",
+            provider="state",
+            common_field=CommonFields.VACCINES_ALLOCATED,
+        ),
+        ccd_helpers.ScraperVariable(
+            variable_name="total_vaccine_distributed",
+            measurement="cumulative",
+            unit="doses",
+            provider="state",
+            common_field=CommonFields.VACCINES_DISTRIBUTED,
+        ),
+        ccd_helpers.ScraperVariable(
+            variable_name="total_vaccine_initiated",
+            measurement="cumulative",
+            unit="people",
+            provider="state",
+            common_field=CommonFields.VACCINATIONS_INITIATED,
+        ),
+        ccd_helpers.ScraperVariable(
+            variable_name="total_vaccine_initiated",
+            measurement="current",
+            unit="percentage",
+            provider="state",
+            common_field=CommonFields.VACCINATIONS_INITIATED_PCT,
+        ),
+        ccd_helpers.ScraperVariable(
+            variable_name="total_vaccine_completed",
+            measurement="cumulative",
+            unit="people",
+            provider="state",
+            common_field=CommonFields.VACCINATIONS_COMPLETED,
+        ),
+        ccd_helpers.ScraperVariable(
+            variable_name="total_vaccine_completed",
+            measurement="current",
+            unit="percentage",
+            provider="state",
+            common_field=CommonFields.VACCINATIONS_COMPLETED_PCT,
+        ),
+        ccd_helpers.ScraperVariable(
+            variable_name="total_vaccine_doses_administered",
+            measurement="cumulative",
+            unit="doses",
+            provider="state",
+            common_field=CommonFields.VACCINES_ADMINISTERED,
+        ),
+    ]
+
+    results = dataset.query_multiple_variables(variables, log_provider_coverage_warnings=True)
+    return results
 
 
 class CANScraperStateProviders(data_source.CanScraperBase):
     SOURCE_NAME = "CANScrapersStateProviders"
 
-    TRANSFORM_METHOD = update_can_scraper_state_providers.transform
+    TRANSFORM_METHOD = transform
 
     EXPECTED_FIELDS = [
         CommonFields.STAFFED_BEDS,

--- a/libs/datasets/sources/can_scraper_state_providers.py
+++ b/libs/datasets/sources/can_scraper_state_providers.py
@@ -3,7 +3,7 @@ from covidactnow.datapublic.common_fields import CommonFields
 from libs.datasets.sources import can_scraper_helpers as ccd_helpers
 
 
-def transform(dataset: ccd_helpers.CovidCountyDataset):
+def transform(dataset: ccd_helpers.CanScraperLoader):
     variables = [
         ccd_helpers.ScraperVariable(variable_name="pcr_tests_negative", provider="state"),
         ccd_helpers.ScraperVariable(variable_name="unspecified_tests_total", provider="state"),

--- a/libs/datasets/sources/can_scraper_usafacts.py
+++ b/libs/datasets/sources/can_scraper_usafacts.py
@@ -5,7 +5,7 @@ from libs.datasets.sources import can_scraper_helpers as ccd_helpers
 from libs.datasets import data_source
 
 
-def transform_cases_and_deaths(dataset: ccd_helpers.CovidCountyDataset):
+def transform_cases_and_deaths(dataset: ccd_helpers.CanScraperLoader):
     variables = [
         ccd_helpers.ScraperVariable(
             variable_name="cases",

--- a/libs/datasets/sources/can_scraper_usafacts.py
+++ b/libs/datasets/sources/can_scraper_usafacts.py
@@ -1,7 +1,6 @@
 from covidactnow.datapublic.common_fields import CommonFields
 
-# TODO(tom): Remove this really ugly import from the covid-data-public repo.
-from scripts import ccd_helpers
+from libs.datasets.sources import can_scraper_helpers as ccd_helpers
 
 from libs.datasets import data_source
 

--- a/libs/datasets/sources/cdc_testing_dataset.py
+++ b/libs/datasets/sources/cdc_testing_dataset.py
@@ -1,15 +1,73 @@
-from covidactnow.datapublic.common_fields import CommonFields
-
-# TODO(tom): Remove this really ugly import from the covid-data-public repo.
-from scripts import update_cdc_test_data
-
 from libs.datasets import data_source
+import pandas as pd
+from covidactnow.datapublic.common_fields import CommonFields
+from libs.datasets.sources import can_scraper_helpers as ccd_helpers
+
+
+DC_COUNTY_FIPS = "11001"
+DC_STATE_FIPS = "11"
+
+
+def _remove_trailing_zeros(series: pd.Series) -> pd.Series:
+
+    series = series.copy()
+
+    index = series.loc[series != 0].last_valid_index()
+
+    if index is None:
+        # If test positivity is 0% the entire time, considering the data inaccurate, returning
+        # none.
+        series[:] = None
+        return series
+
+    series[index + pd.DateOffset(1) :] = None
+    return series
+
+
+def remove_trailing_zeros(data: pd.DataFrame) -> pd.DataFrame:
+    data = data.sort_values([CommonFields.FIPS, CommonFields.DATE]).set_index(CommonFields.DATE)
+    test_pos = data.groupby(CommonFields.FIPS)[CommonFields.TEST_POSITIVITY_7D].apply(
+        _remove_trailing_zeros
+    )
+    data[CommonFields.TEST_POSITIVITY_7D] = test_pos
+    return data.reset_index()
+
+
+def transform(dataset: ccd_helpers.CovidCountyDataset):
+
+    variables = [
+        ccd_helpers.ScraperVariable(
+            variable_name="pcr_tests_positive",
+            measurement="rolling_average_7_day",
+            provider="cdc",
+            unit="percentage",
+            common_field=CommonFields.TEST_POSITIVITY_7D,
+        ),
+    ]
+    results = dataset.query_multiple_variables(variables)
+    # Test positivity should be a ratio
+    results.loc[:, CommonFields.TEST_POSITIVITY_7D] = (
+        results.loc[:, CommonFields.TEST_POSITIVITY_7D] / 100.0
+    )
+    # Should only be picking up county all_df for now.  May need additional logic if states
+    # are included as well
+    assert (results[CommonFields.FIPS].str.len() == 5).all()
+
+    # Duplicating DC County results as state results because of a downstream
+    # use of how dc state data is used to override DC county data.
+    dc_results = results.loc[results[CommonFields.FIPS] == DC_COUNTY_FIPS, :].copy()
+    dc_results.loc[:, CommonFields.FIPS] = DC_STATE_FIPS
+    dc_results.loc[:, CommonFields.AGGREGATE_LEVEL] = "state"
+
+    results = pd.concat([results, dc_results])
+
+    return remove_trailing_zeros(results)
 
 
 class CDCTestingDataset(data_source.CanScraperBase):
     SOURCE_NAME = "CDCTesting"
 
-    TRANSFORM_METHOD = update_cdc_test_data.transform
+    TRANSFORM_METHOD = transform
 
     EXPECTED_FIELDS = [
         CommonFields.TEST_POSITIVITY_7D,

--- a/libs/datasets/sources/cdc_testing_dataset.py
+++ b/libs/datasets/sources/cdc_testing_dataset.py
@@ -25,6 +25,8 @@ def _remove_trailing_zeros(series: pd.Series) -> pd.Series:
 
 
 def remove_trailing_zeros(data: pd.DataFrame) -> pd.DataFrame:
+    # TODO(tom): See if TailFilter+zeros_filter produce the same data and if so, remove this
+    #  function.
     data = data.sort_values([CommonFields.FIPS, CommonFields.DATE]).set_index(CommonFields.DATE)
     test_pos = data.groupby(CommonFields.FIPS)[CommonFields.TEST_POSITIVITY_7D].apply(
         _remove_trailing_zeros
@@ -33,7 +35,7 @@ def remove_trailing_zeros(data: pd.DataFrame) -> pd.DataFrame:
     return data.reset_index()
 
 
-def transform(dataset: ccd_helpers.CovidCountyDataset):
+def transform(dataset: ccd_helpers.CanScraperLoader):
 
     variables = [
         ccd_helpers.ScraperVariable(

--- a/libs/datasets/sources/cdc_vaccine_dataset.py
+++ b/libs/datasets/sources/cdc_vaccine_dataset.py
@@ -1,15 +1,49 @@
-from covidactnow.datapublic.common_fields import CommonFields
-
-# TODO(tom): Remove this really ugly import from the covid-data-public repo.
-from scripts import update_cdc_vaccine_data
-
 from libs.datasets import data_source
+from covidactnow.datapublic.common_fields import CommonFields
+from libs.datasets.sources import can_scraper_helpers as ccd_helpers
+
+
+def transform(dataset: ccd_helpers.CovidCountyDataset):
+
+    variables = [
+        ccd_helpers.ScraperVariable(
+            variable_name="total_vaccine_allocated",
+            measurement="cumulative",
+            unit="doses",
+            provider="cdc",
+            common_field=CommonFields.VACCINES_ALLOCATED,
+        ),
+        ccd_helpers.ScraperVariable(
+            variable_name="total_vaccine_distributed",
+            measurement="cumulative",
+            unit="doses",
+            provider="cdc",
+            common_field=CommonFields.VACCINES_DISTRIBUTED,
+        ),
+        ccd_helpers.ScraperVariable(
+            variable_name="total_vaccine_initiated",
+            measurement="cumulative",
+            unit="people",
+            provider="cdc",
+            common_field=CommonFields.VACCINATIONS_INITIATED,
+        ),
+        ccd_helpers.ScraperVariable(
+            variable_name="total_vaccine_completed",
+            measurement="cumulative",
+            unit="people",
+            provider="cdc",
+            common_field=CommonFields.VACCINATIONS_COMPLETED,
+        ),
+    ]
+
+    results = dataset.query_multiple_variables(variables)
+    return results
 
 
 class CDCVaccinesDataset(data_source.CanScraperBase):
     SOURCE_NAME = "CDCVaccine"
 
-    TRANSFORM_METHOD = update_cdc_vaccine_data.transform
+    TRANSFORM_METHOD = transform
 
     EXPECTED_FIELDS = [
         CommonFields.VACCINES_ALLOCATED,

--- a/libs/datasets/sources/cdc_vaccine_dataset.py
+++ b/libs/datasets/sources/cdc_vaccine_dataset.py
@@ -3,7 +3,7 @@ from covidactnow.datapublic.common_fields import CommonFields
 from libs.datasets.sources import can_scraper_helpers as ccd_helpers
 
 
-def transform(dataset: ccd_helpers.CovidCountyDataset):
+def transform(dataset: ccd_helpers.CanScraperLoader):
 
     variables = [
         ccd_helpers.ScraperVariable(

--- a/tests/libs/datasets/sources/can_scraper_helpers_test.py
+++ b/tests/libs/datasets/sources/can_scraper_helpers_test.py
@@ -1,0 +1,76 @@
+from typing import Dict, List
+import io
+import datetime
+from covidactnow.datapublic.common_fields import CommonFields
+from covidactnow.datapublic import common_df
+import pandas as pd
+
+from libs.datasets.sources import can_scraper_helpers as ccd_helpers
+
+
+# Match fields in the CAN Scraper DB
+DEFAULT_LOCATION = "36"
+DEFAULT_LOCATION_TYPE = "state"
+
+
+def _build_can_scraper_dataframe(
+    data_by_variable: Dict[ccd_helpers.ScraperVariable, List[float]],
+    location=DEFAULT_LOCATION,
+    location_type=DEFAULT_LOCATION_TYPE,
+    start_date="2021-01-01",
+) -> pd.DataFrame:
+    start_date = datetime.datetime.fromisoformat(start_date)
+    rows = []
+    for variable, data in data_by_variable.items():
+
+        for i, value in enumerate(data):
+            date = start_date + datetime.timedelta(days=i)
+            row = {
+                "provider": variable.provider,
+                "dt": date,
+                "location_type": location_type,
+                "location": location,
+                "variable_name": variable.variable_name,
+                "measurement": variable.measurement,
+                "unit": variable.unit,
+                "age": variable.age,
+                "race": variable.race,
+                "sex": variable.sex,
+                "value": value,
+            }
+            rows.append(row)
+
+    return pd.DataFrame(rows)
+
+
+def test_query_multiple_variables():
+    variable = ccd_helpers.ScraperVariable(
+        variable_name="total_vaccine_completed",
+        measurement="cumulative",
+        unit="people",
+        provider="cdc",
+        common_field=CommonFields.VACCINATIONS_COMPLETED,
+    )
+    not_included_variable = ccd_helpers.ScraperVariable(
+        variable_name="total_vaccine_completed",
+        measurement="cumulative",
+        unit="people",
+        # Different provider, so query shouldn't return it
+        provider="hhs",
+        common_field=CommonFields.VACCINATIONS_COMPLETED,
+    )
+
+    input_data = _build_can_scraper_dataframe(
+        {variable: [10, 20, 30], not_included_variable: [10, 20, 40]}
+    )
+    data = ccd_helpers.CanScraperLoader(input_data)
+    results = data.query_multiple_variables([variable])
+
+    expected_buf = io.StringIO(
+        "fips,date,aggregate_level,vaccinations_completed\n"
+        f"36,2021-01-01,state,10\n"
+        f"36,2021-01-02,state,20\n"
+        f"36,2021-01-03,state,30\n"
+    )
+    expected = common_df.read_csv(expected_buf, set_index=False)
+    pd.testing.assert_frame_equal(expected, results)


### PR DESCRIPTION
This PR is part of https://trello.com/c/lbiZpKwH/849-proposal-improve-the-provenance-link-so-that-we-can-show-a-source-urls-instead-of-a-data-class

It moves the files that are run in the this repo and will be modified to load source_url, into this repo.

* Move parquet transforms from covid-data-public repo to covid-data-model without changing the structure or names much
* Import the copied module as ccd_helpers to avoid changing the transform functions at all
* rename CovidCountyDataset to CanScraperLoader

## Tested

Deleted the data from my local covid-data-public repo
```
	deleted:    data/can-scrapers-state-providers/timeseries-common.csv
	deleted:    data/testing-cdc/timeseries-common.csv
	deleted:    data/vaccines-cdc/timeseries-common.csv
	deleted:    scripts/ccd_helpers.py
	deleted:    scripts/update_can_scraper_state_providers.py
	deleted:    scripts/update_cdc_test_data.py
	deleted:    scripts/update_cdc_vaccine_data.py
```
then ran `./run.py data update` and checked that identical data was produced.
