### PR TITLE
fix zscore_outlier data in generate_api_v2_test

### DIFF
--- a/tests/libs/generate_api_v2_test.py
+++ b/tests/libs/generate_api_v2_test.py
@@ -96,6 +96,11 @@ def test_build_summary_for_fips(
                         "original_observation": 1737.0,
                         "type": "zscore_outlier",
                     },
+                    {
+                        "date": datetime.date(2021, 1, 7),
+                        "original_observation": 1732.0,
+                        "type": "zscore_outlier",
+                    },
                 ],
             ),
         ),


### PR DESCRIPTION
This PR addresses issue #<insert number>

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/main/api/schemas) updated?
- [ ] Are tests passing?
