### PR TITLE
Move variables to a CanScraperBase attribute

### DIFF
--- a/libs/datasets/data_source.py
+++ b/libs/datasets/data_source.py
@@ -1,5 +1,4 @@
 import pathlib
-from typing import Callable
 from typing import List
 from typing import Optional
 from typing import Union

--- a/libs/datasets/sources/can_scraper_state_providers.py
+++ b/libs/datasets/sources/can_scraper_state_providers.py
@@ -3,8 +3,28 @@ from covidactnow.datapublic.common_fields import CommonFields
 from libs.datasets.sources import can_scraper_helpers as ccd_helpers
 
 
-def transform(dataset: ccd_helpers.CanScraperLoader):
-    variables = [
+class CANScraperStateProviders(data_source.CanScraperBase):
+    SOURCE_NAME = "CANScrapersStateProviders"
+
+    EXPECTED_FIELDS = [
+        CommonFields.STAFFED_BEDS,
+        CommonFields.CASES,
+        CommonFields.DEATHS,
+        CommonFields.VACCINES_ALLOCATED,
+        CommonFields.VACCINES_ADMINISTERED,
+        CommonFields.VACCINES_DISTRIBUTED,
+        CommonFields.VACCINATIONS_INITIATED,
+        CommonFields.VACCINATIONS_COMPLETED,
+        CommonFields.TOTAL_TESTS_VIRAL,
+        CommonFields.ICU_BEDS,
+        CommonFields.CURRENT_HOSPITALIZED,
+        CommonFields.POSITIVE_TESTS_VIRAL,
+        CommonFields.CURRENT_ICU,
+        CommonFields.VACCINATIONS_INITIATED_PCT,
+        CommonFields.VACCINATIONS_COMPLETED_PCT,
+    ]
+
+    VARIABLES = [
         ccd_helpers.ScraperVariable(variable_name="pcr_tests_negative", provider="state"),
         ccd_helpers.ScraperVariable(variable_name="unspecified_tests_total", provider="state"),
         ccd_helpers.ScraperVariable(variable_name="unspecified_tests_positive", provider="state"),
@@ -134,31 +154,4 @@ def transform(dataset: ccd_helpers.CanScraperLoader):
             provider="state",
             common_field=CommonFields.VACCINES_ADMINISTERED,
         ),
-    ]
-
-    results = dataset.query_multiple_variables(variables, log_provider_coverage_warnings=True)
-    return results
-
-
-class CANScraperStateProviders(data_source.CanScraperBase):
-    SOURCE_NAME = "CANScrapersStateProviders"
-
-    TRANSFORM_METHOD = transform
-
-    EXPECTED_FIELDS = [
-        CommonFields.STAFFED_BEDS,
-        CommonFields.CASES,
-        CommonFields.DEATHS,
-        CommonFields.VACCINES_ALLOCATED,
-        CommonFields.VACCINES_ADMINISTERED,
-        CommonFields.VACCINES_DISTRIBUTED,
-        CommonFields.VACCINATIONS_INITIATED,
-        CommonFields.VACCINATIONS_COMPLETED,
-        CommonFields.TOTAL_TESTS_VIRAL,
-        CommonFields.ICU_BEDS,
-        CommonFields.CURRENT_HOSPITALIZED,
-        CommonFields.POSITIVE_TESTS_VIRAL,
-        CommonFields.CURRENT_ICU,
-        CommonFields.VACCINATIONS_INITIATED_PCT,
-        CommonFields.VACCINATIONS_COMPLETED_PCT,
     ]

--- a/libs/datasets/sources/can_scraper_usafacts.py
+++ b/libs/datasets/sources/can_scraper_usafacts.py
@@ -5,8 +5,15 @@ from libs.datasets.sources import can_scraper_helpers as ccd_helpers
 from libs.datasets import data_source
 
 
-def transform_cases_and_deaths(dataset: ccd_helpers.CanScraperLoader):
-    variables = [
+class CANScraperUSAFactsProvider(data_source.CanScraperBase):
+    SOURCE_NAME = "USAFacts"
+
+    EXPECTED_FIELDS = [
+        CommonFields.CASES,
+        CommonFields.DEATHS,
+    ]
+
+    VARIABLES = [
         ccd_helpers.ScraperVariable(
             variable_name="cases",
             measurement="cumulative",
@@ -21,17 +28,4 @@ def transform_cases_and_deaths(dataset: ccd_helpers.CanScraperLoader):
             provider="usafacts",
             common_field=CommonFields.DEATHS,
         ),
-    ]
-    results = dataset.query_multiple_variables(variables, log_provider_coverage_warnings=True)
-    return results
-
-
-class CANScraperUSAFactsProvider(data_source.CanScraperBase):
-    SOURCE_NAME = "USAFacts"
-
-    TRANSFORM_METHOD = transform_cases_and_deaths
-
-    EXPECTED_FIELDS = [
-        CommonFields.CASES,
-        CommonFields.DEATHS,
     ]

--- a/libs/datasets/sources/cdc_vaccine_dataset.py
+++ b/libs/datasets/sources/cdc_vaccine_dataset.py
@@ -3,9 +3,17 @@ from covidactnow.datapublic.common_fields import CommonFields
 from libs.datasets.sources import can_scraper_helpers as ccd_helpers
 
 
-def transform(dataset: ccd_helpers.CanScraperLoader):
+class CDCVaccinesDataset(data_source.CanScraperBase):
+    SOURCE_NAME = "CDCVaccine"
 
-    variables = [
+    EXPECTED_FIELDS = [
+        CommonFields.VACCINES_ALLOCATED,
+        CommonFields.VACCINES_DISTRIBUTED,
+        CommonFields.VACCINATIONS_INITIATED,
+        CommonFields.VACCINATIONS_COMPLETED,
+    ]
+
+    VARIABLES = [
         ccd_helpers.ScraperVariable(
             variable_name="total_vaccine_allocated",
             measurement="cumulative",
@@ -34,20 +42,4 @@ def transform(dataset: ccd_helpers.CanScraperLoader):
             provider="cdc",
             common_field=CommonFields.VACCINATIONS_COMPLETED,
         ),
-    ]
-
-    results = dataset.query_multiple_variables(variables)
-    return results
-
-
-class CDCVaccinesDataset(data_source.CanScraperBase):
-    SOURCE_NAME = "CDCVaccine"
-
-    TRANSFORM_METHOD = transform
-
-    EXPECTED_FIELDS = [
-        CommonFields.VACCINES_ALLOCATED,
-        CommonFields.VACCINES_DISTRIBUTED,
-        CommonFields.VACCINATIONS_INITIATED,
-        CommonFields.VACCINATIONS_COMPLETED,
     ]


### PR DESCRIPTION
This PR is part of https://trello.com/c/lbiZpKwH/849-proposal-improve-the-provenance-link-so-that-we-can-show-a-source-urls-instead-of-a-data-class

replace CanScraperBase.TRANSFORM_METHOD with VARIABLES and a method that can be overridden. This will make it easier to have query_multiple_variables return source_url values that can be added to the MultiRegionDataset.

## Tested

Ran `data update` and checked that identical output was produced.
