### PR TITLE
source_url in API

### DIFF
--- a/api/can_api_v2_definition.py
+++ b/api/can_api_v2_definition.py
@@ -194,6 +194,7 @@ class FieldAnnotations(base_model.APIBaseModel):
 
     sources: List[FieldSource]
     anomalies: List[AnomalyAnnotation]
+    source_url: str = pydantic.Field(None)
 
 
 class Annotations(base_model.APIBaseModel):

--- a/libs/build_api_v2.py
+++ b/libs/build_api_v2.py
@@ -27,7 +27,7 @@ from libs.datasets.timeseries import OneRegionTimeseriesDataset
 
 
 METRIC_SOURCES_NOT_FOUND_MESSAGE = "Unable to find provenance in FieldSource enum"
-
+METRIC_MULTIPLE_SOURCE_URLS_MESSAGE = "More than one source_url for a field"
 
 USA_VACCINATION_START_DATE = datetime(2020, 12, 14)
 
@@ -111,6 +111,15 @@ def build_annotations(one_region: OneRegionTimeseriesDataset, log) -> Annotation
         ),
         icuBeds=_build_metric_annotations(one_region, CommonFields.ICU_BEDS, log),
         newCases=_build_metric_annotations(one_region, CommonFields.NEW_CASES, log),
+        vaccinesDistributed=_build_metric_annotations(
+            one_region, CommonFields.VACCINES_DISTRIBUTED, log
+        ),
+        vaccinationsInitiated=_build_metric_annotations(
+            one_region, CommonFields.VACCINATIONS_INITIATED, log
+        ),
+        vaccinationsCompleted=_build_metric_annotations(
+            one_region, CommonFields.VACCINATIONS_COMPLETED, log
+        ),
     )
 
 
@@ -136,10 +145,24 @@ def _build_metric_annotations(
         for tag in anomalies
     ]
 
+    source_urls = set(tag_series.source_url.get(field_name, []))
+    if not source_urls:
+        source_url = None
+    else:
+        if len(source_urls) > 1:
+            log.warning(
+                METRIC_MULTIPLE_SOURCE_URLS_MESSAGE,
+                field_name=field_name,
+                urls=list(sorted(source_urls)),
+            )
+        # If multiple URLs actually happens in a meaningful way consider doing something better than
+        # returning one at random.
+        source_url = source_urls.pop()
+
     if not sources_enum and not anomalies:
         return None
 
-    return FieldAnnotations(sources=sources_enum, anomalies=anomalies)
+    return FieldAnnotations(sources=sources_enum, anomalies=anomalies, source_url=source_url)
 
 
 def build_region_timeseries(

--- a/libs/build_api_v2.py
+++ b/libs/build_api_v2.py
@@ -159,7 +159,7 @@ def _build_metric_annotations(
         # returning one at random.
         source_url = source_urls.pop()
 
-    if not sources_enum and not anomalies:
+    if not sources_enum and not anomalies and not source_url:
         return None
 
     return FieldAnnotations(sources=sources_enum, anomalies=anomalies, source_url=source_url)

--- a/tests/libs/api_v2_pipeline_test.py
+++ b/tests/libs/api_v2_pipeline_test.py
@@ -135,6 +135,7 @@ def test_annotation(rt_dataset, icu_dataset):
             CommonFields.CASES: TimeseriesLiteral(
                 [100, 200, 300], provenance="NYTimes", source_url=cases_urls
             ),
+            # NEW_CASES has only source_url set, to make sure that an annotation is still output.
             CommonFields.NEW_CASES: TimeseriesLiteral([100, 100, 100], source_url=new_cases_url),
             CommonFields.CONTACT_TRACERS_COUNT: [10] * 3,
             CommonFields.ICU_BEDS: TimeseriesLiteral([20, 20, 20], provenance="NotFound"),
@@ -193,35 +194,6 @@ def test_annotation(rt_dataset, icu_dataset):
 
 
 def test_annotation_all_fields_copied(rt_dataset, icu_dataset):
-    region = Region.from_state("IL")
-    # Create a dataset with bogus data for every CommonFields, excluding a few that are not
-    # expected to have timeseries values.
-    fields_excluded = {*TIMESERIES_INDEX_FIELDS, *GEO_DATA_COLUMNS, CommonFields.LOCATION_ID}
-    ds = test_helpers.build_default_region_dataset(
-        {
-            field: TimeseriesLiteral([100, 200, 300], provenance="NYTimes")
-            for field in CommonFields
-            if field not in fields_excluded
-        },
-        region=region,
-        static={
-            CommonFields.POPULATION: 100_000,
-            CommonFields.STATE: "IL",
-            CommonFields.CAN_LOCATION_PAGE_URL: "http://covidactnow.org/foo/bar",
-        },
-    )
-    regional_input = api_v2_pipeline.RegionalInput.from_region_and_model_output(
-        region, ds, rt_dataset, icu_dataset
-    )
-
-    timeseries_for_region = api_v2_pipeline.build_timeseries_for_region(regional_input)
-
-    # Check that build_annotations set every field in Annotations.
-    for field_name in can_api_v2_definition.Annotations.__fields__.keys():
-        assert getattr(timeseries_for_region.annotations, field_name), f"{field_name} not set"
-
-
-def test_annotation_one_source(rt_dataset, icu_dataset):
     region = Region.from_state("IL")
     # Create a dataset with bogus data for every CommonFields, excluding a few that are not
     # expected to have timeseries values.

--- a/tests/libs/api_v2_pipeline_test.py
+++ b/tests/libs/api_v2_pipeline_test.py
@@ -1,9 +1,12 @@
 import pytest
 from covidactnow.datapublic.common_fields import CommonFields
 
+from api import can_api_v2_definition
 from api.can_api_v2_definition import AnomalyAnnotation
 from api.can_api_v2_definition import FieldSource
 from libs import build_api_v2
+from libs.datasets.dataset_utils import GEO_DATA_COLUMNS
+from libs.datasets.dataset_utils import TIMESERIES_INDEX_FIELDS
 from libs.metrics import test_positivity
 from libs.datasets import timeseries
 from libs.pipeline import Region
@@ -122,17 +125,21 @@ def test_output_no_timeseries_rows(nyc_regional_input, tmp_path):
 def test_annotation(rt_dataset, icu_dataset):
     region = Region.from_state("IL")
     tag = test_helpers.make_tag(date="2020-04-01", original_observation=10.0)
+    death_url = "http://can.com/death_source"
+    cases_urls = ["http://can.com/one", "http://can.com/two"]
+
     ds = test_helpers.build_default_region_dataset(
         {
-            CommonFields.CASES: TimeseriesLiteral([100, 200, 300], provenance="NYTimes"),
+            CommonFields.CASES: TimeseriesLiteral(
+                [100, 200, 300], provenance="NYTimes", source_url=cases_urls
+            ),
             CommonFields.NEW_CASES: [100, 100, 100],
             CommonFields.CONTACT_TRACERS_COUNT: [10] * 3,
             CommonFields.ICU_BEDS: TimeseriesLiteral([20, 20, 20], provenance="NotFound"),
             CommonFields.CURRENT_ICU: [5, 5, 5],
-            CommonFields.DEATHS: TimeseriesLiteral([2, 3, 2], annotation=[tag],),
-            CommonFields.VACCINES_DISTRIBUTED: [None, 110, 220],
-            CommonFields.VACCINATIONS_INITIATED: [None, None, 100],
-            CommonFields.VACCINATIONS_COMPLETED: [None, None, 50],
+            CommonFields.DEATHS: TimeseriesLiteral(
+                [2, 3, 2], annotation=[tag], source_url=death_url
+            ),
         },
         region=region,
         static={
@@ -151,21 +158,89 @@ def test_annotation(rt_dataset, icu_dataset):
     assert logs == [
         {
             "location_id": region.location_id,
+            "field_name": CommonFields.CASES,
+            "event": build_api_v2.METRIC_MULTIPLE_SOURCE_URLS_MESSAGE,
+            "log_level": "warning",
+            "urls": cases_urls,
+        },
+        {
+            "location_id": region.location_id,
             "field_name": CommonFields.ICU_BEDS,
             "provenance": "NotFound",
             "event": build_api_v2.METRIC_SOURCES_NOT_FOUND_MESSAGE,
             "log_level": "info",
-        }
+        },
     ]
     assert timeseries_for_region.annotations.icuBeds.sources == [FieldSource.OTHER]
     assert timeseries_for_region.annotations.icuBeds.anomalies == []
 
     assert timeseries_for_region.annotations.cases.sources == [FieldSource.NYTimes]
     assert timeseries_for_region.annotations.cases.anomalies == []
+    # _build_metric_annotations picks one source_url at random.
+    assert timeseries_for_region.annotations.cases.source_url in cases_urls
 
     assert timeseries_for_region.annotations.deaths.sources == []
+    assert timeseries_for_region.annotations.deaths.source_url == death_url
     assert timeseries_for_region.annotations.deaths.anomalies == [
         AnomalyAnnotation(date="2020-04-01", original_observation=10.0, type=tag.type)
     ]
 
     assert timeseries_for_region.annotations.contactTracers is None
+
+
+def test_annotation_all_fields_copied(rt_dataset, icu_dataset):
+    region = Region.from_state("IL")
+    # Create a dataset with bogus data for every CommonFields, excluding a few that are not
+    # expected to have timeseries values.
+    fields_excluded = {*TIMESERIES_INDEX_FIELDS, *GEO_DATA_COLUMNS, CommonFields.LOCATION_ID}
+    ds = test_helpers.build_default_region_dataset(
+        {
+            field: TimeseriesLiteral([100, 200, 300], provenance="NYTimes")
+            for field in CommonFields
+            if field not in fields_excluded
+        },
+        region=region,
+        static={
+            CommonFields.POPULATION: 100_000,
+            CommonFields.STATE: "IL",
+            CommonFields.CAN_LOCATION_PAGE_URL: "http://covidactnow.org/foo/bar",
+        },
+    )
+    regional_input = api_v2_pipeline.RegionalInput.from_region_and_model_output(
+        region, ds, rt_dataset, icu_dataset
+    )
+
+    timeseries_for_region = api_v2_pipeline.build_timeseries_for_region(regional_input)
+
+    # Check that build_annotations set every field in Annotations.
+    for field_name in can_api_v2_definition.Annotations.__fields__.keys():
+        assert getattr(timeseries_for_region.annotations, field_name), f"{field_name} not set"
+
+
+def test_annotation_one_source(rt_dataset, icu_dataset):
+    region = Region.from_state("IL")
+    # Create a dataset with bogus data for every CommonFields, excluding a few that are not
+    # expected to have timeseries values.
+    fields_excluded = {*TIMESERIES_INDEX_FIELDS, *GEO_DATA_COLUMNS, CommonFields.LOCATION_ID}
+    ds = test_helpers.build_default_region_dataset(
+        {
+            field: TimeseriesLiteral([100, 200, 300], provenance="NYTimes")
+            for field in CommonFields
+            if field not in fields_excluded
+        },
+        region=region,
+        static={
+            CommonFields.POPULATION: 100_000,
+            CommonFields.STATE: "IL",
+            CommonFields.CAN_LOCATION_PAGE_URL: "http://covidactnow.org/foo/bar",
+        },
+    )
+    regional_input = api_v2_pipeline.RegionalInput.from_region_and_model_output(
+        region, ds, rt_dataset, icu_dataset
+    )
+
+    timeseries_for_region = api_v2_pipeline.build_timeseries_for_region(regional_input)
+
+    # Check that build_annotations set every field in Annotations.
+    for field_name in can_api_v2_definition.Annotations.__fields__.keys():
+        assert getattr(timeseries_for_region.annotations, field_name), f"{field_name} not set"

--- a/tests/libs/generate_api_v2_test.py
+++ b/tests/libs/generate_api_v2_test.py
@@ -96,11 +96,6 @@ def test_build_summary_for_fips(
                         "original_observation": 1737.0,
                         "type": "zscore_outlier",
                     },
-                    {
-                        "date": datetime.date(2021, 1, 7),
-                        "original_observation": 1732.0,
-                        "type": "zscore_outlier",
-                    },
                 ],
             ),
         ),


### PR DESCRIPTION
This PR is part of https://trello.com/c/lbiZpKwH/849-proposal-improve-the-provenance-link-so-that-we-can-show-a-source-urls-instead-of-a-data-class

* Adds ￼source_url to API FieldAnnotations
* Adds annotations for vaccines which were in the API but never populated.
* Adds a tests to make sure all FieldAnnotations are populated

## Tested

Changed to branch `git checkout tgb-849-add-source-url`, ran `./run.py data update` then switched back to this branch with updated data. Then ran `python pyseir/cli.py build-all --generate-api-v2 -s FL --fips 12011` and checked with `jq . output/county/12011.timeseries.json` that some URLs were added.