### PR TITLE
work-around for https://github.com/adnanh/webhook/pull/327

### DIFF
--- a/services/webhook/hooks.json
+++ b/services/webhook/hooks.json
@@ -1,7 +1,7 @@
 [
     {
       "id": "pull-covid-data-model",
-      "execute-command": "./services/webhook/update_repos.sh",
+      "execute-command": "/home/tom/covid-data-model/services/webhook/update.sh",
       "command-working-directory": "/home/tom/covid-data-model",
       "trigger-rule": {
         "and": [

--- a/services/webhook/update.sh
+++ b/services/webhook/update.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 git pull origin main
 make -C services/data-pipeline-dashboard restart


### PR DESCRIPTION
All being well, this PR finishes https://trello.com/c/s0ObL5ii/860-deploy-dashapppy-the-data-pipeline-dashboard

There is a bug in older versions of webhook where it fails to find a command given relative to the working directory. An absolute path is ugly but works.