### PR TITLE
rm hotreload from webhook setup

### DIFF
--- a/services/webhook/webhook.service
+++ b/services/webhook/webhook.service
@@ -23,7 +23,7 @@ Description=Webhook daemon
 User=tom
 Group=tom
 Type=simple
-ExecStart=/usr/bin/webhook -template -hooks /home/tom/covid-data-model/services/webhook/hooks.json  -verbose -ip "127.0.0.1" -urlprefix "" -hotreload
+ExecStart=/usr/bin/webhook -template -hooks /home/tom/covid-data-model/services/webhook/hooks.json  -verbose -ip "127.0.0.1" -urlprefix ""
 Restart=always
 RestartSec=5s
 


### PR DESCRIPTION
It looks like webhook sometimes confuses git futzing around with files as the file being removed and it doesn't read the new file, leaving it without any loaded webhook. Disable hotreload to avoid the problem.

Example from `sudo systemctl status webhook`:

```
Feb 18 16:24:01 data-pipeline-dashboard-1 webhook[17711]: [webhook] 2021/02/18 16:24:01 hooks file /home/tom/covid-data-model/services/webhook/hooks.json removed, no longer watching this file for changes, removing hooks that were load
Feb 18 16:24:01 data-pipeline-dashboard-1 webhook[17711]: [webhook] 2021/02/18 16:24:01         removing: pull-covid-data-model
Feb 18 16:24:01 data-pipeline-dashboard-1 webhook[17711]: [webhook] 2021/02/18 16:24:01 removed 1 hook(s) that were loaded from file /home/tom/covid-data-model/services/webhook/hooks.json
```
