### PR TITLE
Add cdc doses administered

### DIFF
--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -190,7 +190,7 @@ ALL_TIMESERIES_FEATURE_DEFINITION: FeatureDataSourceMap = {
     CommonFields.TEST_POSITIVITY_14D: [CMSTestingDataset],
     CommonFields.TEST_POSITIVITY_7D: [CDCTestingDataset],
     CommonFields.VACCINES_DISTRIBUTED: [CANScraperStateProviders, CDCVaccinesDataset],
-    CommonFields.VACCINES_ADMINISTERED: [CANScraperStateProviders],
+    CommonFields.VACCINES_ADMINISTERED: [CANScraperStateProviders, CDCVaccinesDataset],
     CommonFields.VACCINATIONS_INITIATED: [CANScraperStateProviders, CDCVaccinesDataset],
     CommonFields.VACCINATIONS_COMPLETED: [CANScraperStateProviders, CDCVaccinesDataset],
     CommonFields.VACCINATIONS_INITIATED_PCT: [CANScraperStateProviders],

--- a/libs/datasets/sources/cdc_vaccine_dataset.py
+++ b/libs/datasets/sources/cdc_vaccine_dataset.py
@@ -7,6 +7,7 @@ class CDCVaccinesDataset(data_source.CanScraperBase):
     SOURCE_NAME = "CDCVaccine"
 
     EXPECTED_FIELDS = [
+        CommonFields.VACCINES_ADMINISTERED,
         CommonFields.VACCINES_ALLOCATED,
         CommonFields.VACCINES_DISTRIBUTED,
         CommonFields.VACCINATIONS_INITIATED,
@@ -27,6 +28,13 @@ class CDCVaccinesDataset(data_source.CanScraperBase):
             unit="doses",
             provider="cdc",
             common_field=CommonFields.VACCINES_DISTRIBUTED,
+        ),
+        ccd_helpers.ScraperVariable(
+            variable_name="total_vaccine_doses_administered",
+            measurement="cumulative",
+            unit="doses",
+            provider="cdc",
+            common_field=CommonFields.VACCINES_ADMINISTERED,
         ),
         ccd_helpers.ScraperVariable(
             variable_name="total_vaccine_initiated",


### PR DESCRIPTION
This adds CDC doses administered to combined datasets which will be used to help estimate CA vaccination county rates