### PR TITLE
use loc to set aggregate_level

### DIFF
--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -1410,7 +1410,7 @@ def aggregate_regions(
     if CommonFields.AGGREGATE_LEVEL in dataset_in.static.columns:
         # location_id_to_level returns an AggregationLevel enum, but we use the str in DataFrames.
         # These are not equivalent so put the `value` attribute in static_agg.
-        static_agg[CommonFields.AGGREGATE_LEVEL] = (
+        static_agg.loc[:, CommonFields.AGGREGATE_LEVEL] = (
             static_agg.index.get_level_values(CommonFields.LOCATION_ID)
             .map(pipeline.location_id_to_level)
             .map(lambda l: l.value)


### PR DESCRIPTION
I'm not 100% sure why, but I think the change https://github.com/covid-projections/covid-data-public/pull/208/files caused https://sentry.io/organizations/covidactnow/issues/2229338105/?project=5203044&query=is%3Aunresolved.  

changing the way we set location_id here seems to do the trick - not sure if we'll see more of these pop up or not