### PR TITLE
Tests for 'cannot be pickled'

### DIFF
--- a/tests/libs/datasets/custom_aggregations_test.py
+++ b/tests/libs/datasets/custom_aggregations_test.py
@@ -1,5 +1,6 @@
 import dataclasses
 
+import pytest
 from covidactnow.datapublic.common_fields import CommonFields
 
 from libs import pipeline
@@ -7,6 +8,16 @@ from libs.datasets import combined_datasets
 from libs.datasets import custom_aggregations
 
 
+@pytest.mark.slow
+def test_aggregate_to_new_york_city(nyc_region):
+    dataset_in = combined_datasets.load_us_timeseries_dataset().get_regions_subset(
+        custom_aggregations.ALL_NYC_REGIONS
+    )
+    dataset_out = custom_aggregations.aggregate_to_new_york_city(dataset_in)
+    assert dataset_out
+
+
+@pytest.mark.slow
 def test_replace_dc_county(nyc_region):
     dc_state_region = pipeline.Region.from_fips("11")
     dc_county_region = pipeline.Region.from_fips("11001")

--- a/tests/libs/datasets/timeseries_test.py
+++ b/tests/libs/datasets/timeseries_test.py
@@ -2,6 +2,7 @@ import datetime
 import io
 import pathlib
 import dataclasses
+import pickle
 
 import pytest
 import pandas as pd
@@ -1636,3 +1637,19 @@ def test_remove_test_positivity_outliers(last_value, is_outlier):
 
     else:
         test_helpers.assert_dataset_like(dataset_in, dataset_out, drop_na_dates=True)
+
+
+def test_pickle():
+    ts = TimeseriesLiteral(
+        [0, 2, 4],
+        annotation=[
+            test_helpers.make_tag(date="2020-04-01"),
+            test_helpers.make_tag(date="2020-04-02"),
+        ],
+        source_url=UrlStr("http://public.com"),
+    )
+    ds_in = test_helpers.build_default_region_dataset({CommonFields.CASES: ts})
+
+    ds_out = pickle.loads(pickle.dumps(ds_in))
+
+    test_helpers.assert_dataset_like(ds_in, ds_out)


### PR DESCRIPTION
This PR adds tests for pickle of MultiRegionDataset and running aggregate_to_new_york_city in attempt to catch problem in https://github.com/covid-projections/covid-data-public/pull/208