### PR TITLE
refactoring for adding source tag

### DIFF
--- a/libs/build_api_v2.py
+++ b/libs/build_api_v2.py
@@ -23,6 +23,7 @@ from api.can_api_v2_definition import AnomalyAnnotation
 from api.can_api_v2_definition import FieldSource
 from api.can_api_v2_definition import FieldSourceType
 from libs.datasets import timeseries
+from libs.datasets.taglib import TagType
 from libs.datasets.tail_filter import TagField
 from libs.datasets.timeseries import OneRegionTimeseriesDataset
 
@@ -129,53 +130,64 @@ def _build_metric_annotations(
     tag_series: timeseries.OneRegionTimeseriesDataset, field_name: CommonFields, log
 ) -> Optional[FieldAnnotations]:
 
-    sources_enum = set()
-    for source_str in tag_series.provenance.get(field_name, []):
-        source_enum = FieldSourceType.get(source_str)
-        if source_enum is None:
-            source_enum = FieldSourceType.OTHER
-            log.info(
-                METRIC_SOURCES_NOT_FOUND_MESSAGE, field_name=field_name, provenance=source_str,
-            )
-        sources_enum.add(source_enum)
-    if not sources_enum:
-        source_enum = None
-    else:
-        if len(sources_enum) > 1:
-            log.warning(METRIC_MULTIPLE_SOURCE_TYPES_MESSAGE, field_name=field_name)
-        source_enum = sources_enum.pop()
+    sources = [
+        FieldSource(type=_lookup_source_type(tag.type, field_name, log), url=tag.url)
+        for tag in tag_series.tag_objects_df.loc[[field_name], [TagType.SOURCE]]
+    ]
+
+    if not sources:
+        # Fall back to using provenance and source_url.
+        # TODO(tom): Remove this block of code when we're pretty sure `source` has taken over.
+        sources_enum = set()
+        for source_str in tag_series.provenance.get(field_name, []):
+            sources_enum.add(_lookup_source_type(source_str, field_name, log))
+
+        if not sources_enum:
+            source_enum = None
+        else:
+            if len(sources_enum) > 1:
+                log.warning(METRIC_MULTIPLE_SOURCE_TYPES_MESSAGE, field_name=field_name)
+            source_enum = sources_enum.pop()
+
+        source_urls = set(tag_series.source_url.get(field_name, []))
+        if not source_urls:
+            source_url = None
+        else:
+            if len(source_urls) > 1:
+                log.warning(
+                    METRIC_MULTIPLE_SOURCE_URLS_MESSAGE,
+                    field_name=field_name,
+                    urls=list(sorted(source_urls)),
+                )
+            # If multiple URLs actually happens in a meaningful way consider doing something better than
+            # returning one at random.
+            source_url = source_urls.pop()
+
+        if source_url or source_enum:
+            sources = [FieldSource(type=source_enum, url=source_url)]
 
     anomalies = tag_series.annotations(field_name)
     anomalies = [
         AnomalyAnnotation(
-            date=tag.date, original_observation=tag.original_observation, type=tag.type
+            date=tag.date, original_observation=tag.original_observation, type=tag.tag_type
         )
         for tag in anomalies
     ]
-
-    source_urls = set(tag_series.source_url.get(field_name, []))
-    if not source_urls:
-        source_url = None
-    else:
-        if len(source_urls) > 1:
-            log.warning(
-                METRIC_MULTIPLE_SOURCE_URLS_MESSAGE,
-                field_name=field_name,
-                urls=list(sorted(source_urls)),
-            )
-        # If multiple URLs actually happens in a meaningful way consider doing something better than
-        # returning one at random.
-        source_url = source_urls.pop()
-
-    if source_url or source_enum:
-        sources = [FieldSource(type=source_enum, url=source_url)]
-    else:
-        sources = []
 
     if not sources and not anomalies:
         return None
 
     return FieldAnnotations(sources=sources, anomalies=anomalies)
+
+
+def _lookup_source_type(source_str, field_name, log) -> FieldSourceType:
+    source_enum = FieldSourceType.get(source_str)
+    if source_enum is None:
+        source_enum = FieldSourceType.OTHER
+        log.info(
+            METRIC_SOURCES_NOT_FOUND_MESSAGE, field_name=field_name, provenance=source_str,
+        )
+    return source_enum
 
 
 def build_region_timeseries(

--- a/libs/build_api_v2.py
+++ b/libs/build_api_v2.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import List
 from typing import Optional
 import pandas as pd
 from api.can_api_v2_definition import (
@@ -129,7 +130,7 @@ def _build_metric_annotations(
     tag_series: timeseries.OneRegionTimeseriesDataset, field_name: CommonFields, log
 ) -> Optional[FieldAnnotations]:
 
-    sources = _sources_from_provenance_and_source_url(field_name, log, tag_series)
+    sources = _sources_from_provenance_and_source_url(field_name, tag_series, log)
 
     anomalies = tag_series.annotations(field_name)
     anomalies = [
@@ -145,7 +146,9 @@ def _build_metric_annotations(
     return FieldAnnotations(sources=sources, anomalies=anomalies)
 
 
-def _sources_from_provenance_and_source_url(field_name, log, tag_series):
+def _sources_from_provenance_and_source_url(
+    field_name: CommonFields, tag_series: timeseries.OneRegionTimeseriesDataset, log
+) -> List[FieldSource]:
     sources_enum = set()
     for source_str in tag_series.provenance.get(field_name, []):
         sources_enum.add(_lookup_source_type(source_str, field_name, log))

--- a/libs/datasets/taglib.py
+++ b/libs/datasets/taglib.py
@@ -63,7 +63,7 @@ class TagInTimeseries(ABC):
     TAG_TYPE: ClassVar[TagType]
 
     @property
-    def type(self) -> TagType:
+    def tag_type(self) -> TagType:
         return self.TAG_TYPE
 
     @property
@@ -87,7 +87,7 @@ class TagInTimeseries(ABC):
         return {
             TagField.LOCATION_ID: location_id,
             TagField.VARIABLE: variable,
-            TagField.TYPE: self.type,
+            TagField.TYPE: self.tag_type,
             TagField.CONTENT: self.content,
         }
 

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -109,10 +109,10 @@ class OneRegionTimeseriesDataset:
         return source_url_series.groupby(level=0).agg(list).to_dict()
 
     def annotations(self, metric: FieldName) -> List[taglib.AnnotationWithDate]:
-        return self.tag_objects_df.loc[[metric], ANNOTATION_TAG_TYPES].to_list()
+        return self.tag_objects_series.loc[[metric], ANNOTATION_TAG_TYPES].to_list()
 
     @cached_property
-    def tag_objects_df(self) -> pd.Series:
+    def tag_objects_series(self) -> pd.Series:
         """A Series of TagInTimeseries objects, indexed like self.tag for easy lookups."""
         assert self.tag.index.names[1] == TagField.TYPE
         # Apply a function to each element in the Series self.tag with the function having access to

--- a/tests/libs/api_v2_pipeline_test.py
+++ b/tests/libs/api_v2_pipeline_test.py
@@ -186,7 +186,7 @@ def test_annotation(rt_dataset, icu_dataset):
 
     assert one(timeseries_for_region.annotations.deaths.sources) == FieldSource(url=death_url)
     assert timeseries_for_region.annotations.deaths.anomalies == [
-        AnomalyAnnotation(date="2020-04-01", original_observation=10.0, type=tag.type)
+        AnomalyAnnotation(date="2020-04-01", original_observation=10.0, type=tag.tag_type)
     ]
 
     assert one(timeseries_for_region.annotations.newCases.sources) == FieldSource(url=new_cases_url)

--- a/tests/libs/datasets/timeseries_test.py
+++ b/tests/libs/datasets/timeseries_test.py
@@ -17,6 +17,7 @@ from libs import github_utils
 from libs.datasets import AggregationLevel
 from libs.datasets import combined_datasets
 from libs.datasets import dataset_pointer
+from libs.datasets import taglib
 
 from libs.datasets import timeseries
 from libs.datasets.taglib import TagType
@@ -726,6 +727,30 @@ def test_one_region_annotations():
         region: one_region_dataset.annotations(CommonFields.CASES)
         for region, one_region_dataset in dataset_tx_and_sf.iter_one_regions()
     } == {region_sf: [tag2a, tag2b], region_tx: [tag1],}
+
+
+def test_one_region_tag_objects_series():
+    values = [100, 200]
+    tag1 = test_helpers.make_tag(tag_type=TagType.ZSCORE_OUTLIER, date="2020-04-01")
+    tag2a = test_helpers.make_tag(date="2020-04-02")
+    tag2b = test_helpers.make_tag(date="2020-04-03")
+
+    one_region = test_helpers.build_one_region_dataset(
+        {
+            CommonFields.CASES: TimeseriesLiteral(values, annotation=[tag1]),
+            CommonFields.ICU_BEDS: TimeseriesLiteral(values, provenance="prov1"),
+            CommonFields.DEATHS: TimeseriesLiteral(values, annotation=[tag2a, tag2b]),
+        }
+    )
+
+    assert isinstance(one_region.tag_objects_series, pd.Series)
+    assert one_region.tag.index.equals(one_region.tag_objects_series.index)
+    assert set(one_region.tag_objects_series.reset_index().itertuples(index=False)) == {
+        (CommonFields.CASES, tag1.tag_type, tag1),
+        (CommonFields.ICU_BEDS, "provenance", taglib.ProvenanceTag(source="prov1")),
+        (CommonFields.DEATHS, tag2a.tag_type, tag2a),
+        (CommonFields.DEATHS, tag2b.tag_type, tag2b),
+    }
 
 
 def test_timeseries_latest_values():

--- a/tests/libs/datasets/timeseries_test.py
+++ b/tests/libs/datasets/timeseries_test.py
@@ -559,7 +559,7 @@ def test_write_read_wide_dates_csv_with_annotation(tmpdir):
             [0, 2, 4],
             annotation=[
                 test_helpers.make_tag(date="2020-04-01"),
-                test_helpers.make_tag(type=TagType.ZSCORE_OUTLIER, date="2020-04-02"),
+                test_helpers.make_tag(TagType.ZSCORE_OUTLIER, date="2020-04-02"),
             ],
         ),
         CommonFields.CASES: [100, 200, 300],
@@ -731,7 +731,7 @@ def test_one_region_annotations():
 
 def test_one_region_tag_objects_series():
     values = [100, 200]
-    tag1 = test_helpers.make_tag(tag_type=TagType.ZSCORE_OUTLIER, date="2020-04-01")
+    tag1 = test_helpers.make_tag(TagType.ZSCORE_OUTLIER, date="2020-04-01")
     tag2a = test_helpers.make_tag(date="2020-04-02")
     tag2b = test_helpers.make_tag(date="2020-04-03")
 

--- a/tests/libs/metrics/test_positivity_test.py
+++ b/tests/libs/metrics/test_positivity_test.py
@@ -275,11 +275,11 @@ def test_provenance():
 def test_preserve_tags():
     region_as = Region.from_state("AS")
     region_tx = Region.from_state("TX")
-    tag1 = test_helpers.make_tag(type=TagType.CUMULATIVE_LONG_TAIL_TRUNCATED, date="2020-04-04")
-    tag2 = test_helpers.make_tag(type=TagType.CUMULATIVE_TAIL_TRUNCATED, date="2020-04-04")
-    tag_drop = test_helpers.make_tag(type=TagType.ZSCORE_OUTLIER, date="2020-04-01")
-    tag3 = test_helpers.make_tag(type=TagType.ZSCORE_OUTLIER, date="2020-04-04")
-    tag4 = test_helpers.make_tag(type=TagType.ZSCORE_OUTLIER, date="2020-04-03")
+    tag1 = test_helpers.make_tag(TagType.CUMULATIVE_LONG_TAIL_TRUNCATED, date="2020-04-04")
+    tag2 = test_helpers.make_tag(TagType.CUMULATIVE_TAIL_TRUNCATED, date="2020-04-04")
+    tag_drop = test_helpers.make_tag(TagType.ZSCORE_OUTLIER, date="2020-04-01")
+    tag3 = test_helpers.make_tag(TagType.ZSCORE_OUTLIER, date="2020-04-04")
+    tag4 = test_helpers.make_tag(TagType.ZSCORE_OUTLIER, date="2020-04-03")
     metrics_as = {
         CommonFields.POSITIVE_TESTS: TimeseriesLiteral(
             [1, 2, 3, 4], annotation=[tag1], provenance="pos"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -113,14 +113,14 @@ def make_tag_df(
 
 
 def make_tag(
-    type: TagType = TagType.CUMULATIVE_TAIL_TRUNCATED, **kwargs,
+    tag_type: TagType = TagType.CUMULATIVE_TAIL_TRUNCATED, **kwargs,
 ) -> taglib.TagInTimeseries:
-    if type in timeseries.ANNOTATION_TAG_TYPES:
+    if tag_type in timeseries.ANNOTATION_TAG_TYPES:
         # Force to the expected types and add defaults if not in kwargs
         kwargs["original_observation"] = float(kwargs.get("original_observation", 10))
         kwargs["date"] = pd.to_datetime(kwargs.get("date", "2020-04-02"))
 
-    return taglib.TAG_TYPE_TO_CLASS[type](**kwargs)
+    return taglib.TAG_TYPE_TO_CLASS[tag_type](**kwargs)
 
 
 def build_dataset(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -102,7 +102,10 @@ def make_tag_df(
     region: Region, metric: CommonFields, records: List[taglib.TagInTimeseries]
 ) -> pd.DataFrame:
     df = pd.DataFrame(
-        {TagField.TYPE: [r.type for r in records], TagField.CONTENT: [r.content for r in records],}
+        {
+            TagField.TYPE: [r.tag_type for r in records],
+            TagField.CONTENT: [r.content for r in records],
+        }
     )
     df[TagField.LOCATION_ID] = region.location_id
     df[TagField.VARIABLE] = metric


### PR DESCRIPTION
This PR is prep for https://trello.com/c/hSJN82y9/927-pipe-through-source-names-to-fe

* Extracts API code that makes `FieldSource` so it can be more easily replaced
* Renames ` TagInTimeseries` field `type` to `tag_type` so that `Source` can have `type` property.
* Adds `OneRegionTimeseriesDataset.tag_objects_series` for easier access to these, by type
