### PR TITLE
add NY vacine source in test_build_summary_for_fips

### DIFF
--- a/tests/libs/generate_api_v2_test.py
+++ b/tests/libs/generate_api_v2_test.py
@@ -110,6 +110,24 @@ def test_build_summary_for_fips(
                     },
                 ],
             ),
+            vaccinationsCompleted=FieldAnnotations(
+                sources=[
+                    FieldSource(
+                        type=FieldSourceType.CANScrapersStateProviders,
+                        url="https://covid19vaccine.health.ny.gov/covid-19-vaccine-tracker",
+                    )
+                ],
+                anomalies=[],
+            ),
+            vaccinationsInitiated=FieldAnnotations(
+                sources=[
+                    FieldSource(
+                        type=FieldSourceType.CANScrapersStateProviders,
+                        url="https://covid19vaccine.health.ny.gov/covid-19-vaccine-tracker",
+                    )
+                ],
+                anomalies=[],
+            ),
         ),
         lastUpdatedDate=datetime.datetime.utcnow(),
         url="https://covidactnow.org/us/new_york-ny/county/bronx_county",


### PR DESCRIPTION
This PR addresses issue #<insert number>

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/main/api/schemas) updated?
- [ ] Are tests passing?
