### PR TITLE
mark more slow tests

### DIFF
--- a/tests/combined_dataset_test.py
+++ b/tests/combined_dataset_test.py
@@ -30,6 +30,7 @@ def test_unique_index_values_us_timeseries():
 
 
 # Check some counties picked arbitrarily: San Francisco/06075 and Houston (Harris County, TX)/48201
+@pytest.mark.slow
 @pytest.mark.parametrize("fips", ["06075", "48201"])
 def test_combined_county_has_some_data(fips):
     region_data = combined_datasets.load_us_timeseries_dataset().get_one_region(
@@ -40,6 +41,7 @@ def test_combined_county_has_some_data(fips):
     assert region_data.latest[CommonFields.DEATHS] > 1
 
 
+@pytest.mark.slow
 def test_pr_aggregation():
     dataset = combined_datasets.load_us_timeseries_dataset()
     data = dataset.get_one_region(Region.from_fips("72")).latest
@@ -48,6 +50,7 @@ def test_pr_aggregation():
     assert data["icu_occupancy_rate"] < 1
 
 
+@pytest.mark.slow
 def test_nyc_aggregation(nyc_region):
     dataset = combined_datasets.load_us_timeseries_dataset()
     data = dataset.get_one_region(nyc_region).latest
@@ -58,6 +61,7 @@ def test_nyc_aggregation(nyc_region):
 
 
 # Check some counties picked arbitrarily: (Orange County, CA)/06059 and (Harris County, TX)/48201
+@pytest.mark.slow
 @pytest.mark.parametrize("fips", ["06059", "48201"])
 def test_combined_county_has_some_timeseries_data(fips):
     region = Region.from_fips(fips)
@@ -78,6 +82,7 @@ def test_combined_county_has_some_timeseries_data(fips):
     assert one_date[CommonFields.CURRENT_ICU] > 0
 
 
+@pytest.mark.slow
 def test_get_county_name():
     assert combined_datasets.get_county_name(Region.from_fips("06059")) == "Orange County"
     assert combined_datasets.get_county_name(Region.from_fips("48201")) == "Harris County"
@@ -205,6 +210,7 @@ def test_combined_datasets_uses_only_expected_fields():
             )
 
 
+@pytest.mark.slow
 def test_dataclass_include_exclude():
     orig_data_source_cls = CANScraperUSAFactsProvider
     orig_ds = orig_data_source_cls.make_dataset()

--- a/tests/infer_rt_test.py
+++ b/tests/infer_rt_test.py
@@ -244,6 +244,7 @@ def test_generate_infection_rate_new_orleans_patch():
     assert set(r.location_id for r in regions) == set(returned_location_ids)
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("fips", ["48999", "48998"])
 def test_generate_infection_rate_metric_fake_fips(fips):
     with pytest.raises(timeseries.RegionLatestNotFound):

--- a/tests/nowcast_seir_model_basic_test.py
+++ b/tests/nowcast_seir_model_basic_test.py
@@ -85,6 +85,7 @@ def test_median_age_history():
     fig.savefig(TEST_OUTPUT_DIR / "test_median_age_history.pdf", bbox_inches="tight")
 
 
+@pytest.mark.slow
 def test_validate_rt_over_time():
     """
     Check that our Bettencourt R(t) predictions integrate properly to explain

--- a/tests/nowcast_seir_model_end_to_end_test.py
+++ b/tests/nowcast_seir_model_end_to_end_test.py
@@ -127,6 +127,7 @@ def test_historical_peaks_positivity_to_real_cfr():
     fig.savefig(TEST_OUTPUT_DIR / "test_historical_peaks_positivity_to_real_cfr.pdf")
 
 
+@pytest.mark.slow
 def test_demonstrate_hospitalization_delay_changes():
     """
     Demonstrates that hospitalization peaks are delayed relative to new cases

--- a/tests/original_seir_model_test.py
+++ b/tests/original_seir_model_test.py
@@ -60,6 +60,7 @@ def create_standard_model(r0, sup, days=100, ratios=None):
     return model
 
 
+@pytest.mark.slow
 def test_run_model_orig():
     def sup(t):
         return 1.0 if t < 50 else 0.6
@@ -72,6 +73,7 @@ def test_run_model_orig():
     fig.savefig(TEST_OUTPUT_DIR / "test_run_model_orig.pdf", bbox_inches="tight")
 
 
+@pytest.mark.slow
 def test_restart_existing_model_from_ratios():
     ratios = steady_state_ratios(1.4)
 


### PR DESCRIPTION
Mark tests found by `pytest -k 'not slow' --durations=50 tests` as taking more than a second as slow.

This brings `pytest -k 'not slow' tests` back down to about a minute.... not bad but not fast.