### PR TITLE
copy Source.name to FieldSource.name

### DIFF
--- a/libs/build_api_v2.py
+++ b/libs/build_api_v2.py
@@ -131,7 +131,7 @@ def _build_metric_annotations(
 ) -> Optional[FieldAnnotations]:
 
     sources = [
-        FieldSource(type=_lookup_source_type(tag.type, field_name, log), url=tag.url)
+        FieldSource(type=_lookup_source_type(tag.type, field_name, log), url=tag.url, name=tag.name)
         for tag in tag_series.sources(field_name)
     ]
 

--- a/tests/libs/api_v2_pipeline_test.py
+++ b/tests/libs/api_v2_pipeline_test.py
@@ -199,9 +199,10 @@ def test_source(rt_dataset, icu_dataset):
     """Test the `source` tag can produce data similar to that in `test_annotation`."""
     region = Region.from_state("IL")
     tag = test_helpers.make_tag(date="2020-04-01", original_observation=10.0)
-    death_url = UrlStr("http://can.com/death_source")
+    deaths_url = UrlStr("http://can.com/death_source")
     cases_urls = [UrlStr("http://can.com/one"), UrlStr("http://can.com/two")]
     new_cases_url = UrlStr("http://can.com/new_cases")
+    deaths_source = taglib.Source("USAFacts", deaths_url, "*The* USA Facts")
 
     ds = test_helpers.build_default_region_dataset(
         {
@@ -222,7 +223,7 @@ def test_source(rt_dataset, icu_dataset):
             ),
             CommonFields.CURRENT_ICU: [5, 5, 5],
             CommonFields.DEATHS: TimeseriesLiteral(
-                [2, 3, 2], annotation=[tag], source=taglib.Source("NYTimes", death_url)
+                [2, 3, 2], annotation=[tag], source=deaths_source
             ),
         },
         region=region,
@@ -257,7 +258,7 @@ def test_source(rt_dataset, icu_dataset):
     assert timeseries_for_region.annotations.cases.anomalies == []
 
     assert one(timeseries_for_region.annotations.deaths.sources) == FieldSource(
-        type=FieldSourceType.NYTimes, url=death_url
+        type=FieldSourceType.USA_FACTS, url=deaths_url, name=deaths_source.name
     )
     assert timeseries_for_region.annotations.deaths.anomalies == [
         AnomalyAnnotation(date="2020-04-01", original_observation=10.0, type=tag.tag_type)


### PR DESCRIPTION
This PR is part of https://trello.com/c/hSJN82y9/927-pipe-through-source-names-to-fe

Copies Source.name to FieldSource.name.

## Tested

Extends an existing unittest.

Testing with this PR and https://github.com/covid-projections/covid-data-model/pull/969 with something like

```
python pyseir/cli.py build-all --generate-api-v2 --location-id-matches '.+fips:(48201|06073|12011)'
vimdiff output-before/county/12011.timeseries.json output/county/12011.timeseries.json
csvgrep -c location_id -m fips:12011 data/multiregion-wide-dates.csv  |csvcut -c location_id,variable,source
```
finds some new names in the output JSON, for example:
```
    "vaccinationsInitiated": {
      "sources": [
        {
          "type": "CANScrapersStateProviders",
          "url": "https://floridahealthcovid19.gov/#latest-stats",
          "name": "Florida Department of Health"
        }
      ],
      "anomalies": []
    },

```
