### PR TITLE
Update source names in generate_api_v2_test

### DIFF
--- a/tests/libs/generate_api_v2_test.py
+++ b/tests/libs/generate_api_v2_test.py
@@ -79,11 +79,15 @@ def test_build_summary_for_fips(
         ),
         annotations=Annotations(
             cases=FieldAnnotations(
-                sources=[FieldSource(type=FieldSourceType.USA_FACTS, url=usafacts_url)],
+                sources=[
+                    FieldSource(name="USAFacts", type=FieldSourceType.USA_FACTS, url=usafacts_url)
+                ],
                 anomalies=[],
             ),
             deaths=FieldAnnotations(
-                sources=[FieldSource(type=FieldSourceType.USA_FACTS, url=usafacts_url)],
+                sources=[
+                    FieldSource(name="USAFacts", type=FieldSourceType.USA_FACTS, url=usafacts_url)
+                ],
                 anomalies=[],
             ),
             positiveTests=None,
@@ -113,6 +117,7 @@ def test_build_summary_for_fips(
             vaccinationsCompleted=FieldAnnotations(
                 sources=[
                     FieldSource(
+                        name="New York State Department of Health",
                         type=FieldSourceType.CANScrapersStateProviders,
                         url="https://covid19vaccine.health.ny.gov/covid-19-vaccine-tracker",
                     )
@@ -122,6 +127,7 @@ def test_build_summary_for_fips(
             vaccinationsInitiated=FieldAnnotations(
                 sources=[
                     FieldSource(
+                        name="New York State Department of Health",
                         type=FieldSourceType.CANScrapersStateProviders,
                         url="https://covid19vaccine.health.ny.gov/covid-19-vaccine-tracker",
                     )


### PR DESCRIPTION
The test started failing when combined datasets was updated to add `name` when loading from `CanScraperLoader`.