### PR TITLE
DataSource attributes to support source names

### DIFF
--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -84,9 +84,9 @@ class DataSourceAndRegionMasks:
         return self.data_source_cls.EXPECTED_FIELDS
 
     @property
-    def SOURCE_NAME(self):
+    def SOURCE_TYPE(self):
         """Implements the same interface as the wrapped DataSource class."""
-        return self.data_source_cls.SOURCE_NAME
+        return self.data_source_cls.SOURCE_TYPE
 
     def make_dataset(self) -> MultiRegionDataset:
         """Returns the dataset of the wrapped DataSource class, with a subset of the regions.

--- a/libs/datasets/data_source.py
+++ b/libs/datasets/data_source.py
@@ -25,7 +25,7 @@ class DataSource(object):
 
     # Name of source
     # TODO(tom): Make an enum of these.
-    SOURCE_NAME = None
+    SOURCE_TYPE = None
 
     # Fields expected to be in the DataFrame loaded by common_df.read_csv
     EXPECTED_FIELDS: Optional[List[CommonFields]] = None
@@ -49,13 +49,13 @@ class DataSource(object):
         if not extra_fields.empty:
             _log.info(
                 "DataSource produced extra unexpected fields, which were dropped.",
-                cls=cls.SOURCE_NAME,
+                cls=cls.SOURCE_TYPE,
                 extra_fields=extra_fields,
             )
         if not missing_fields.empty:
             _log.info(
                 "DataSource failed to produce all expected fields",
-                cls=cls.SOURCE_NAME,
+                cls=cls.SOURCE_TYPE,
                 missing_fields=missing_fields,
             )
         return data
@@ -69,7 +69,7 @@ class DataSource(object):
         input_path = data_root / cls.COMMON_DF_CSV_PATH
         data = common_df.read_csv(input_path, set_index=False)
         data = cls._check_data(data)
-        return MultiRegionDataset.from_fips_timeseries_df(data).add_provenance_all(cls.SOURCE_NAME)
+        return MultiRegionDataset.from_fips_timeseries_df(data).add_provenance_all(cls.SOURCE_TYPE)
 
 
 # TODO(tom): Clean up the mess that is subclasses of DataSource and
@@ -95,7 +95,7 @@ class CanScraperBase(DataSource):
         assert cls.VARIABLES
         ccd_dataset = CanScraperBase._get_covid_county_dataset()
         data, source_df = ccd_dataset.query_multiple_variables(
-            cls.VARIABLES, log_provider_coverage_warnings=True, source_type=cls.SOURCE_NAME
+            cls.VARIABLES, log_provider_coverage_warnings=True, source_type=cls.SOURCE_TYPE
         )
         data = cls.transform_data(data)
         data = cls._check_data(data)

--- a/libs/datasets/sources/can_location_page_urls.py
+++ b/libs/datasets/sources/can_location_page_urls.py
@@ -8,7 +8,7 @@ from libs.datasets import timeseries
 
 
 class CANLocationPageURLS(data_source.DataSource):
-    SOURCE_NAME = "can_urls"
+    SOURCE_TYPE = "can_urls"
 
     STATIC_CSV = "data/misc/can_location_page_urls.csv"
 

--- a/libs/datasets/sources/can_scraper_state_providers.py
+++ b/libs/datasets/sources/can_scraper_state_providers.py
@@ -4,7 +4,7 @@ from libs.datasets.sources import can_scraper_helpers as ccd_helpers
 
 
 class CANScraperStateProviders(data_source.CanScraperBase):
-    SOURCE_NAME = "CANScrapersStateProviders"
+    SOURCE_TYPE = "CANScrapersStateProviders"
 
     EXPECTED_FIELDS = [
         CommonFields.STAFFED_BEDS,

--- a/libs/datasets/sources/can_scraper_usafacts.py
+++ b/libs/datasets/sources/can_scraper_usafacts.py
@@ -6,7 +6,7 @@ from libs.datasets import data_source
 
 
 class CANScraperUSAFactsProvider(data_source.CanScraperBase):
-    SOURCE_NAME = "USAFacts"
+    SOURCE_TYPE = "USAFacts"
 
     EXPECTED_FIELDS = [
         CommonFields.CASES,

--- a/libs/datasets/sources/cdc_testing_dataset.py
+++ b/libs/datasets/sources/cdc_testing_dataset.py
@@ -36,7 +36,7 @@ def remove_trailing_zeros(data: pd.DataFrame) -> pd.DataFrame:
 
 
 class CDCTestingDataset(data_source.CanScraperBase):
-    SOURCE_NAME = "CDCTesting"
+    SOURCE_TYPE = "CDCTesting"
 
     EXPECTED_FIELDS = [
         CommonFields.TEST_POSITIVITY_7D,

--- a/libs/datasets/sources/cdc_vaccine_dataset.py
+++ b/libs/datasets/sources/cdc_vaccine_dataset.py
@@ -4,7 +4,7 @@ from libs.datasets.sources import can_scraper_helpers as ccd_helpers
 
 
 class CDCVaccinesDataset(data_source.CanScraperBase):
-    SOURCE_NAME = "CDCVaccine"
+    SOURCE_TYPE = "CDCVaccine"
 
     EXPECTED_FIELDS = [
         CommonFields.VACCINES_ADMINISTERED,

--- a/libs/datasets/sources/cms_testing_dataset.py
+++ b/libs/datasets/sources/cms_testing_dataset.py
@@ -3,7 +3,7 @@ from libs.datasets import data_source
 
 
 class CMSTestingDataset(data_source.DataSource):
-    SOURCE_NAME = "CMSTesting"
+    SOURCE_TYPE = "CMSTesting"
 
     COMMON_DF_CSV_PATH = "data/testing-cms/timeseries-common.csv"
 

--- a/libs/datasets/sources/covid_care_map.py
+++ b/libs/datasets/sources/covid_care_map.py
@@ -10,7 +10,7 @@ from libs.datasets import timeseries
 class CovidCareMapBeds(data_source.DataSource):
     STATIC_CSV = "data/covid-care-map/static.csv"
 
-    SOURCE_NAME = "CCM"
+    SOURCE_TYPE = "CCM"
 
     EXPECTED_FIELDS = [
         CommonFields.STAFFED_BEDS,

--- a/libs/datasets/sources/covid_tracking_source.py
+++ b/libs/datasets/sources/covid_tracking_source.py
@@ -3,7 +3,7 @@ from libs.datasets import data_source
 
 
 class CovidTrackingDataSource(data_source.DataSource):
-    SOURCE_NAME = "covid_tracking"
+    SOURCE_TYPE = "covid_tracking"
 
     COMMON_DF_CSV_PATH = "data/covid-tracking/timeseries.csv"
 

--- a/libs/datasets/sources/fips_population.py
+++ b/libs/datasets/sources/fips_population.py
@@ -25,7 +25,7 @@ class FIPSPopulation(data_source.DataSource):
 
     FILE_PATH = "data/misc/fips_population.csv"
 
-    SOURCE_NAME = "FIPS"
+    SOURCE_TYPE = "FIPS"
 
     class Fields(object):
         STATE = "state"

--- a/libs/datasets/sources/forecast_hub.py
+++ b/libs/datasets/sources/forecast_hub.py
@@ -8,7 +8,7 @@ class ForecastHubDataset(data_source.DataSource):
     they are not included in CommonFields and would be filtered out regardless.
     """
 
-    SOURCE_NAME = "ForecastHub"
+    SOURCE_TYPE = "ForecastHub"
 
     COMMON_DF_CSV_PATH = "data/forecast-hub/timeseries-common.csv"
 

--- a/libs/datasets/sources/hhs_hospital_dataset.py
+++ b/libs/datasets/sources/hhs_hospital_dataset.py
@@ -5,7 +5,7 @@ from libs.datasets.timeseries import MultiRegionDataset
 
 
 class HHSHospitalDataset(data_source.DataSource):
-    SOURCE_NAME = "HHSHospital"
+    SOURCE_TYPE = "HHSHospital"
 
     COMMON_DF_CSV_PATH = "data/hospital-hhs/timeseries-common.csv"
 

--- a/libs/datasets/sources/hhs_testing_dataset.py
+++ b/libs/datasets/sources/hhs_testing_dataset.py
@@ -3,7 +3,7 @@ from libs.datasets import data_source
 
 
 class HHSTestingDataset(data_source.DataSource):
-    SOURCE_NAME = "HHSTesting"
+    SOURCE_TYPE = "HHSTesting"
 
     COMMON_DF_CSV_PATH = "data/testing-hhs/timeseries-common.csv"
 

--- a/libs/datasets/sources/nytimes_dataset.py
+++ b/libs/datasets/sources/nytimes_dataset.py
@@ -3,7 +3,7 @@ from libs.datasets import data_source
 
 
 class NYTimesDataset(data_source.DataSource):
-    SOURCE_NAME = "NYTimes"
+    SOURCE_TYPE = "NYTimes"
 
     COMMON_DF_CSV_PATH = "data/cases-nytimes/timeseries-common.csv"
 

--- a/libs/datasets/sources/test_and_trace.py
+++ b/libs/datasets/sources/test_and_trace.py
@@ -3,7 +3,7 @@ from libs.datasets import data_source
 
 
 class TestAndTraceData(data_source.DataSource):
-    SOURCE_NAME = "TestAndTrace"
+    SOURCE_TYPE = "TestAndTrace"
 
     COMMON_DF_CSV_PATH = "data/test-and-trace/state_data.csv"
 

--- a/libs/datasets/sources/texas_hospitalizations.py
+++ b/libs/datasets/sources/texas_hospitalizations.py
@@ -3,7 +3,7 @@ from libs.datasets import data_source
 
 
 class TexasHospitalizations(data_source.DataSource):
-    SOURCE_NAME = "tx_hosp"
+    SOURCE_TYPE = "tx_hosp"
 
     COMMON_DF_CSV_PATH = "data/states/tx/tx_fips_hospitalizations.csv"
 

--- a/tests/combined_dataset_test.py
+++ b/tests/combined_dataset_test.py
@@ -205,8 +205,8 @@ def test_combined_datasets_uses_only_expected_fields():
     for field_name, sources in combined_datasets.ALL_TIMESERIES_FEATURE_DEFINITION.items():
         for source in sources:
             assert field_name in source.EXPECTED_FIELDS, (
-                f"{source.SOURCE_NAME} is in combined_datasets for {field_name} but the field "
-                f"is not in the {source.SOURCE_NAME} EXPECTED_FIELDS."
+                f"{source.SOURCE_TYPE} is in combined_datasets for {field_name} but the field "
+                f"is not in the {source.SOURCE_TYPE} EXPECTED_FIELDS."
             )
 
 
@@ -220,7 +220,7 @@ def test_dataclass_include_exclude():
     ny_source = combined_datasets.datasource_regions(
         orig_data_source_cls, RegionMask(states=["NY"])
     )
-    assert ny_source.SOURCE_NAME == orig_data_source_cls.SOURCE_NAME
+    assert ny_source.SOURCE_TYPE == orig_data_source_cls.SOURCE_TYPE
     assert ny_source.EXPECTED_FIELDS == orig_data_source_cls.EXPECTED_FIELDS
     ny_ds = ny_source.make_dataset()
     assert "iso1:us#iso2:us-tx" not in ny_ds.static.index


### PR DESCRIPTION
This PR is for  https://trello.com/c/rI3EQlS6/976-add-nytimes-source-name-to-annotations

* Adds SOURCE_NAME and SOURCE_URL, renames current name to SOURCE_TYPE