### PR TITLE
Add static name and URL to non-CAN Scraper 

### DIFF
--- a/libs/datasets/sources/cms_testing_dataset.py
+++ b/libs/datasets/sources/cms_testing_dataset.py
@@ -4,6 +4,8 @@ from libs.datasets import data_source
 
 class CMSTestingDataset(data_source.DataSource):
     SOURCE_TYPE = "CMSTesting"
+    SOURCE_NAME = "The Centers for Medicare & Medicaid Services"
+    SOURCE_URL = "https://data.cms.gov/stories/s/COVID-19-Nursing-Home-Data/bkwz-xpvg"
 
     COMMON_DF_CSV_PATH = "data/testing-cms/timeseries-common.csv"
 

--- a/libs/datasets/sources/covid_tracking_source.py
+++ b/libs/datasets/sources/covid_tracking_source.py
@@ -1,9 +1,12 @@
 from covidactnow.datapublic.common_fields import CommonFields
 from libs.datasets import data_source
+from libs.datasets.taglib import UrlStr
 
 
 class CovidTrackingDataSource(data_source.DataSource):
     SOURCE_TYPE = "covid_tracking"
+    SOURCE_NAME = "The COVID Tracking Project"
+    SOURCE_URL = UrlStr("https://covidtracking.com/")
 
     COMMON_DF_CSV_PATH = "data/covid-tracking/timeseries.csv"
 

--- a/libs/datasets/sources/nytimes_dataset.py
+++ b/libs/datasets/sources/nytimes_dataset.py
@@ -5,7 +5,7 @@ from libs.datasets.taglib import UrlStr
 
 class NYTimesDataset(data_source.DataSource):
     SOURCE_TYPE = "NYTimes"
-    SOURCE_NAME = "New York Times"
+    SOURCE_NAME = "The New York Times"
     SOURCE_URL = UrlStr("https://github.com/nytimes/covid-19-data")
 
     COMMON_DF_CSV_PATH = "data/cases-nytimes/timeseries-common.csv"

--- a/libs/datasets/sources/nytimes_dataset.py
+++ b/libs/datasets/sources/nytimes_dataset.py
@@ -1,9 +1,12 @@
 from covidactnow.datapublic.common_fields import CommonFields
 from libs.datasets import data_source
+from libs.datasets.taglib import UrlStr
 
 
 class NYTimesDataset(data_source.DataSource):
     SOURCE_TYPE = "NYTimes"
+    SOURCE_NAME = "New York Times"
+    SOURCE_URL = UrlStr("https://github.com/nytimes/covid-19-data")
 
     COMMON_DF_CSV_PATH = "data/cases-nytimes/timeseries-common.csv"
 


### PR DESCRIPTION
This PR completes :crossed_fingers: https://trello.com/c/rI3EQlS6/976-add-nytimes-source-name-to-annotations

* Adds source name and URL to older data sources that are not part of the new CAN Scraper system