### PR TITLE
Add metric annotations

### DIFF
--- a/api/can_api_v2_definition.py
+++ b/api/can_api_v2_definition.py
@@ -244,9 +244,6 @@ class Annotations(base_model.APIBaseModel):
     testPositivityRatio: Optional[FieldAnnotations] = pydantic.Field(
         None, description="Annotations for testPositivityRatio"
     )
-    testPositivityRatioDetails: Optional[FieldAnnotations] = pydantic.Field(
-        None, description="Annotations for testPositivityRatioDetails"
-    )
     caseDensity: Optional[FieldAnnotations] = pydantic.Field(
         None, description="Annotations for caseDensity"
     )
@@ -261,9 +258,6 @@ class Annotations(base_model.APIBaseModel):
     )
     icuHeadroomRatio: Optional[FieldAnnotations] = pydantic.Field(
         None, description="Annotations for icuHeadroomRatio"
-    )
-    icuHeadroomDetails: Optional[FieldAnnotations] = pydantic.Field(
-        None, description="Annotations for icuHeadroomDetails"
     )
     icuCapacityRatio: Optional[FieldAnnotations] = pydantic.Field(
         None, description="Annotations for icuCapacityRatio"

--- a/api/can_api_v2_definition.py
+++ b/api/can_api_v2_definition.py
@@ -138,6 +138,7 @@ Fields:
         description="""
 New confirmed or suspected cases.
 
+
 New cases are a processed timeseries of cases - summing new cases may not equal
 the cumulative case count.
 
@@ -209,7 +210,7 @@ class FieldAnnotations(base_model.APIBaseModel):
 class Annotations(base_model.APIBaseModel):
     """Annotations for each field."""
 
-    # Keep this list of fields in sync with the fields in `Actuals`.
+    # Keep this list of fields in sync with the fields in `Actuals`
     cases: Optional[FieldAnnotations] = pydantic.Field(None, description="Annotations for cases")
     deaths: Optional[FieldAnnotations] = pydantic.Field(None, description="Annotations for deaths")
     positiveTests: Optional[FieldAnnotations] = pydantic.Field(
@@ -238,6 +239,40 @@ class Annotations(base_model.APIBaseModel):
     )
     vaccinationsCompleted: Optional[FieldAnnotations] = pydantic.Field(
         None, description="Annotations for vaccinationsCompleted"
+    )
+    # Keep this list of fields in sync with the fields in `Metrics`
+    testPositivityRatio: Optional[FieldAnnotations] = pydantic.Field(
+        None, description="Annotations for testPositivityRatio"
+    )
+    testPositivityRatioDetails: Optional[FieldAnnotations] = pydantic.Field(
+        None, description="Annotations for testPositivityRatioDetails"
+    )
+    caseDensity: Optional[FieldAnnotations] = pydantic.Field(
+        None, description="Annotations for caseDensity"
+    )
+    contactTracerCapacityRatio: Optional[FieldAnnotations] = pydantic.Field(
+        None, description="Annotations for contactTracerCapacityRatio"
+    )
+    infectionRate: Optional[FieldAnnotations] = pydantic.Field(
+        None, description="Annotations for infectionRate"
+    )
+    infectionRateCI90: Optional[FieldAnnotations] = pydantic.Field(
+        None, description="Annotations for infectionRateCI90"
+    )
+    icuHeadroomRatio: Optional[FieldAnnotations] = pydantic.Field(
+        None, description="Annotations for icuHeadroomRatio"
+    )
+    icuHeadroomDetails: Optional[FieldAnnotations] = pydantic.Field(
+        None, description="Annotations for icuHeadroomDetails"
+    )
+    icuCapacityRatio: Optional[FieldAnnotations] = pydantic.Field(
+        None, description="Annotations for icuCapacityRatio"
+    )
+    vaccinationsInitiatedRatio: Optional[FieldAnnotations] = pydantic.Field(
+        None, description="Annotations for vaccinationsInitiatedRatio"
+    )
+    vaccinationsCompletedRatio: Optional[FieldAnnotations] = pydantic.Field(
+        None, description="Annotations for vaccinationsCompletedRatio"
     )
 
 

--- a/libs/build_api_v2.py
+++ b/libs/build_api_v2.py
@@ -116,14 +116,14 @@ ACTUALS_NAME_TO_COMMON_FIELD = {
 
 METRICS_NAME_TO_COMMON_FIELD = {
     "contactTracerCapacityRatio": CommonFields.CONTACT_TRACERS_COUNT,
-    "caseDensity": CommonFields.CASES,  # TODO(chris): Fix this
-    "infectionRate": CommonFields.CASES,  # TODO(chris): Fix this
+    "caseDensity": CommonFields.CASES,
+    "infectionRate": CommonFields.CASES,
     "testPositivityRatio": CommonFields.TEST_POSITIVITY,
-    "icuHeadroomRatio": CommonFields.CASES,  # TODO(chris): Fix this
-    "infectionRateCI90": CommonFields.CASES,  # TODO(chris): Fix this
+    "icuHeadroomRatio": CommonFields.CURRENT_ICU_TOTAL,
+    "infectionRateCI90": CommonFields.CASES,
     "vaccinationsInitiatedRatio": CommonFields.VACCINATIONS_INITIATED_PCT,
     "vaccinationsCompletedRatio": CommonFields.VACCINATIONS_COMPLETED_PCT,
-    "icuCapacityRatio": CommonFields.CURRENT_ICU,  # TODO(chris): Fix this
+    "icuCapacityRatio": CommonFields.CURRENT_ICU,
 }
 
 

--- a/libs/build_api_v2.py
+++ b/libs/build_api_v2.py
@@ -99,31 +99,45 @@ def build_region_summary(
     )
 
 
+ACTUALS_NAME_TO_COMMON_FIELD = {
+    "cases": CommonFields.CASES,
+    "deaths": CommonFields.DEATHS,
+    "positiveTests": CommonFields.POSITIVE_TESTS,
+    "negativeTests": CommonFields.NEGATIVE_TESTS,
+    "contactTracers": CommonFields.CONTACT_TRACERS_COUNT,
+    "hospitalBeds": CommonFields.HOSPITAL_BEDS_IN_USE_ANY,
+    "icuBeds": CommonFields.ICU_BEDS,
+    "newCases": CommonFields.NEW_CASES,
+    "vaccinesDistributed": CommonFields.VACCINES_DISTRIBUTED,
+    "vaccinationsInitiated": CommonFields.VACCINATIONS_INITIATED,
+    "vaccinationsCompleted": CommonFields.VACCINATIONS_COMPLETED,
+}
+
+
+METRICS_NAME_TO_COMMON_FIELD = {
+    "contactTracerCapacityRatio": CommonFields.CONTACT_TRACERS_COUNT,
+    "caseDensity": CommonFields.CASES,  # TODO(chris): Fix this
+    "infectionRate": CommonFields.CASES,  # TODO(chris): Fix this
+    "testPositivityRatio": CommonFields.TEST_POSITIVITY,
+    "icuHeadroomRatio": CommonFields.CASES,  # TODO(chris): Fix this
+    "infectionRateCI90": CommonFields.CASES,  # TODO(chris): Fix this
+    "vaccinationsInitiatedRatio": CommonFields.VACCINATIONS_INITIATED_PCT,
+    "vaccinationsCompletedRatio": CommonFields.VACCINATIONS_COMPLETED_PCT,
+    "icuCapacityRatio": CommonFields.CURRENT_ICU,  # TODO(chris): Fix this
+}
+
+
 def build_annotations(one_region: OneRegionTimeseriesDataset, log) -> Annotations:
     assert one_region.tag.index.names == [TagField.VARIABLE, TagField.TYPE]
-    return Annotations(
-        cases=_build_metric_annotations(one_region, CommonFields.CASES, log),
-        deaths=_build_metric_annotations(one_region, CommonFields.DEATHS, log),
-        positiveTests=_build_metric_annotations(one_region, CommonFields.POSITIVE_TESTS, log),
-        negativeTests=_build_metric_annotations(one_region, CommonFields.NEGATIVE_TESTS, log),
-        contactTracers=_build_metric_annotations(
-            one_region, CommonFields.CONTACT_TRACERS_COUNT, log
-        ),
-        hospitalBeds=_build_metric_annotations(
-            one_region, CommonFields.HOSPITAL_BEDS_IN_USE_ANY, log
-        ),
-        icuBeds=_build_metric_annotations(one_region, CommonFields.ICU_BEDS, log),
-        newCases=_build_metric_annotations(one_region, CommonFields.NEW_CASES, log),
-        vaccinesDistributed=_build_metric_annotations(
-            one_region, CommonFields.VACCINES_DISTRIBUTED, log
-        ),
-        vaccinationsInitiated=_build_metric_annotations(
-            one_region, CommonFields.VACCINATIONS_INITIATED, log
-        ),
-        vaccinationsCompleted=_build_metric_annotations(
-            one_region, CommonFields.VACCINATIONS_COMPLETED, log
-        ),
-    )
+    name_and_common_field = [
+        *ACTUALS_NAME_TO_COMMON_FIELD.items(),
+        *METRICS_NAME_TO_COMMON_FIELD.items(),
+    ]
+    annotations = {
+        annotations_name: _build_metric_annotations(one_region, field_name, log)
+        for annotations_name, field_name in name_and_common_field
+    }
+    return Annotations(**annotations)
 
 
 def _build_metric_annotations(

--- a/tests/api/can_api_v2_definition_test.py
+++ b/tests/api/can_api_v2_definition_test.py
@@ -1,0 +1,19 @@
+from api import can_api_v2_definition
+
+
+def test_annotations_is_complete():
+    metrics_names = list(can_api_v2_definition.Metrics.__fields__.keys())
+    actuals_names = list(can_api_v2_definition.Actuals.__fields__.keys())
+    # This test checks that metrics and actuals have annotations in a consistent order.
+    expected_names = actuals_names + metrics_names
+
+    annotations_names = list(can_api_v2_definition.Annotations.__fields__.keys())
+
+    missing_names = [name for name in expected_names if name not in annotations_names]
+    for name in missing_names:
+        print(
+            f"    {name}: Optional[FieldAnnotations] = pydantic.Field(None, "
+            f'description="Annotations for {name}")'
+        )
+
+    assert annotations_names == expected_names, "Annotations out of order"

--- a/tests/api/can_api_v2_definition_test.py
+++ b/tests/api/can_api_v2_definition_test.py
@@ -2,18 +2,24 @@ from api import can_api_v2_definition
 
 
 def test_annotations_is_complete():
-    metrics_names = list(can_api_v2_definition.Metrics.__fields__.keys())
     actuals_names = list(can_api_v2_definition.Actuals.__fields__.keys())
+    metrics_names = list(can_api_v2_definition.Metrics.__fields__.keys())
     # This test checks that metrics and actuals have annotations in a consistent order.
-    expected_names = actuals_names + metrics_names
+    # Names ending "Details" are the old annotation fields.
+    expected_names = [
+        name for name in actuals_names + metrics_names if not name.endswith("Details")
+    ]
 
     annotations_names = list(can_api_v2_definition.Annotations.__fields__.keys())
 
+    # Make a list to preserve order of expected_names.
     missing_names = [name for name in expected_names if name not in annotations_names]
-    for name in missing_names:
-        print(
-            f"    {name}: Optional[FieldAnnotations] = pydantic.Field(None, "
-            f'description="Annotations for {name}")'
-        )
+    if missing_names:
+        print("Copying the following into can_api_v2_definition.py class Annotations.")
+        for name in missing_names:
+            print(
+                f"    {name}: Optional[FieldAnnotations] = pydantic.Field(None, "
+                f'description="Annotations for {name}")'
+            )
 
-    assert annotations_names == expected_names, "Annotations out of order"
+    assert annotations_names == expected_names, "Expected Annotations: actuals then metrics"

--- a/tests/libs/api_v2_pipeline_test.py
+++ b/tests/libs/api_v2_pipeline_test.py
@@ -130,16 +130,16 @@ def test_annotation(rt_dataset, icu_dataset):
     region = Region.from_state("IL")
     tag = test_helpers.make_tag(date="2020-04-01", original_observation=10.0)
     death_url = UrlStr("http://can.com/death_source")
-    cases_urls = [UrlStr("http://can.com/one"), UrlStr("http://can.com/two")]
-    new_cases_url = UrlStr("http://can.com/new_cases")
+    cases_url = UrlStr("http://can.com/cases")
+    new_cases_urls = [UrlStr("http://can.com/new_cases1"), UrlStr("http://can.com/new_cases2")]
 
     ds = test_helpers.build_default_region_dataset(
         {
             CommonFields.CASES: TimeseriesLiteral(
-                [100, 200, 300], provenance="NYTimes", source_url=cases_urls
+                [100, 200, 300], provenance="NYTimes", source_url=cases_url
             ),
             # NEW_CASES has only source_url set, to make sure that an annotation is still output.
-            CommonFields.NEW_CASES: TimeseriesLiteral([100, 100, 100], source_url=new_cases_url),
+            CommonFields.NEW_CASES: TimeseriesLiteral([100, 100, 100], source_url=new_cases_urls),
             CommonFields.CONTACT_TRACERS_COUNT: [10] * 3,
             CommonFields.ICU_BEDS: TimeseriesLiteral([20, 20, 20], provenance="NotFound"),
             CommonFields.CURRENT_ICU: [5, 5, 5],
@@ -164,17 +164,17 @@ def test_annotation(rt_dataset, icu_dataset):
     assert logs == [
         {
             "location_id": region.location_id,
-            "field_name": CommonFields.CASES,
-            "event": build_api_v2.METRIC_MULTIPLE_SOURCE_URLS_MESSAGE,
-            "log_level": "warning",
-            "urls": cases_urls,
-        },
-        {
-            "location_id": region.location_id,
             "field_name": CommonFields.ICU_BEDS,
             "provenance": "NotFound",
             "event": build_api_v2.METRIC_SOURCES_NOT_FOUND_MESSAGE,
             "log_level": "info",
+        },
+        {
+            "location_id": region.location_id,
+            "field_name": CommonFields.NEW_CASES,
+            "event": build_api_v2.METRIC_MULTIPLE_SOURCE_URLS_MESSAGE,
+            "log_level": "warning",
+            "urls": new_cases_urls,
         },
     ]
     assert one(timeseries_for_region.annotations.icuBeds.sources).type == FieldSourceType.OTHER
@@ -182,15 +182,15 @@ def test_annotation(rt_dataset, icu_dataset):
 
     assert one(timeseries_for_region.annotations.cases.sources).type == FieldSourceType.NYTimes
     assert timeseries_for_region.annotations.cases.anomalies == []
-    # _build_metric_annotations picks one source_url at random.
-    assert one(timeseries_for_region.annotations.cases.sources).url in cases_urls
+    assert one(timeseries_for_region.annotations.cases.sources).url == cases_url
 
     assert one(timeseries_for_region.annotations.deaths.sources) == FieldSource(url=death_url)
     assert timeseries_for_region.annotations.deaths.anomalies == [
         AnomalyAnnotation(date="2020-04-01", original_observation=10.0, type=tag.tag_type)
     ]
 
-    assert one(timeseries_for_region.annotations.newCases.sources) == FieldSource(url=new_cases_url)
+    # _build_metric_annotations picks one source_url at random.
+    assert one(timeseries_for_region.annotations.newCases.sources).url in new_cases_urls
 
     assert timeseries_for_region.annotations.contactTracers is None
 
@@ -296,5 +296,15 @@ def test_annotation_all_fields_copied(rt_dataset, icu_dataset):
     timeseries_for_region = api_v2_pipeline.build_timeseries_for_region(regional_input)
 
     # Check that build_annotations set every field in Annotations.
-    for field_name in can_api_v2_definition.Annotations.__fields__.keys():
-        assert getattr(timeseries_for_region.annotations, field_name), f"{field_name} not set"
+    expected_names = set(can_api_v2_definition.Annotations.__fields__.keys())
+    missing_names = []
+    for field_name in expected_names:
+        if not getattr(timeseries_for_region.annotations, field_name):
+            missing_names.append(field_name)
+
+    if missing_names:
+        print("Add the following somewhere around build_annotations:")
+        for name in missing_names:
+            print(f'    "{name}": CommonFields.PICK_CORRECT_FIELD,')
+
+    assert not missing_names

--- a/tests/libs/generate_api_v2_test.py
+++ b/tests/libs/generate_api_v2_test.py
@@ -33,7 +33,11 @@ def test_build_summary_for_fips(
     fips_timeseries = us_timeseries.get_one_region(nyc_region)
     nyc_latest = fips_timeseries.latest
     log = structlog.get_logger()
-    usafacts_url = "https://usafacts.org/issues/coronavirus/"
+    field_source_usafacts = FieldSource(
+        name="USAFacts",
+        type=FieldSourceType.USA_FACTS,
+        url="https://usafacts.org/issues/coronavirus/",
+    )
 
     metrics_series, latest_metric = api_v2_pipeline.generate_metrics_and_latest(
         fips_timeseries, nyc_rt_dataset, nyc_icu_dataset, log,
@@ -41,6 +45,7 @@ def test_build_summary_for_fips(
     risk_levels = top_level_metric_risk_levels.calculate_risk_level_from_metrics(latest_metric)
     assert latest_metric
     summary = build_api_v2.build_region_summary(fips_timeseries, latest_metric, risk_levels, log)
+    field_source_hhshospital = FieldSource(type=FieldSourceType.HHSHospital)
     expected = RegionSummary(
         population=nyc_latest["population"],
         state="NY",
@@ -78,26 +83,12 @@ def test_build_summary_for_fips(
             vaccinationsCompleted=nyc_latest.get("vaccinations_completed"),
         ),
         annotations=Annotations(
-            cases=FieldAnnotations(
-                sources=[
-                    FieldSource(name="USAFacts", type=FieldSourceType.USA_FACTS, url=usafacts_url)
-                ],
-                anomalies=[],
-            ),
-            deaths=FieldAnnotations(
-                sources=[
-                    FieldSource(name="USAFacts", type=FieldSourceType.USA_FACTS, url=usafacts_url)
-                ],
-                anomalies=[],
-            ),
+            cases=FieldAnnotations(sources=[field_source_usafacts], anomalies=[],),
+            deaths=FieldAnnotations(sources=[field_source_usafacts], anomalies=[],),
             positiveTests=None,
             negativeTests=None,
-            hospitalBeds=FieldAnnotations(
-                sources=[FieldSource(type=FieldSourceType.HHSHospital)], anomalies=[]
-            ),
-            icuBeds=FieldAnnotations(
-                sources=[FieldSource(type=FieldSourceType.HHSHospital)], anomalies=[]
-            ),
+            hospitalBeds=FieldAnnotations(sources=[field_source_hhshospital], anomalies=[]),
+            icuBeds=FieldAnnotations(sources=[field_source_hhshospital], anomalies=[]),
             contactTracers=None,
             newCases=FieldAnnotations(
                 sources=[],
@@ -134,6 +125,11 @@ def test_build_summary_for_fips(
                 ],
                 anomalies=[],
             ),
+            caseDensity=FieldAnnotations(sources=[field_source_usafacts], anomalies=[]),
+            icuCapacityRatio=FieldAnnotations(sources=[field_source_hhshospital], anomalies=[]),
+            icuHeadroomRatio=FieldAnnotations(sources=[field_source_hhshospital], anomalies=[]),
+            infectionRate=FieldAnnotations(sources=[field_source_usafacts], anomalies=[]),
+            infectionRateCI90=FieldAnnotations(sources=[field_source_usafacts], anomalies=[]),
         ),
         lastUpdatedDate=datetime.datetime.utcnow(),
         url="https://covidactnow.org/us/new_york-ny/county/bronx_county",


### PR DESCRIPTION
This PR addresses https://trello.com/c/g0fSP3MT/974-change-annotation-names-to-match-metric-names

* Adds Annotations for metrics
* Adds some test that will hopefully make maintaining these less dependent on us noticing problems
* Changes `build_annotations` to use two maps of constants instead of long list of hard-coded function calls
* Changes `test_annotation` to put duplicate URLs in new_cases instead of cases. Currently `cases` is used multiple times which produced multiple log warning calls and broke the log event check in the test.