### PR TITLE
Adding aggregate level to dataset if not included

### DIFF
--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -193,6 +193,16 @@ def _add_state_if_missing(df: pd.DataFrame):
         )
 
 
+def _add_aggregate_level_if_missing(df: pd.DataFrame):
+    """Adds the aggregate level column if missing, in place."""
+    assert CommonFields.LOCATION_ID in df.columns
+
+    if CommonFields.AGGREGATE_LEVEL not in df.columns:
+        df[CommonFields.AGGREGATE_LEVEL] = df[CommonFields.LOCATION_ID].apply(
+            lambda x: Region.from_location_id(x).level.value
+        )
+
+
 def _geodata_df_to_static_attribute_df(geodata_df: pd.DataFrame) -> pd.DataFrame:
     """Creates a DataFrame to use as static from geo data taken from timeseries CSV."""
     assert geodata_df.index.names == [None]  # [CommonFields.LOCATION_ID, CommonFields.DATE]
@@ -438,7 +448,6 @@ class MultiRegionDataset:
             # are not modified.
             timeseries_df = timeseries_df.fillna(np.nan).apply(pd.to_numeric).sort_index()
         geodata_df = timeseries_and_geodata_df.loc[:, geodata_column_mask]
-
         static_df = _geodata_df_to_static_attribute_df(
             geodata_df.reset_index().drop(columns=[CommonFields.DATE])
         )
@@ -567,6 +576,7 @@ class MultiRegionDataset:
     def from_fips_timeseries_df(ts_df: pd.DataFrame) -> "MultiRegionDataset":
         ts_df = _add_location_id(ts_df)
         _add_state_if_missing(ts_df)
+        _add_aggregate_level_if_missing(ts_df)
 
         return MultiRegionDataset.from_geodata_timeseries_df(ts_df)
 

--- a/tests/libs/datasets/data_source_test.py
+++ b/tests/libs/datasets/data_source_test.py
@@ -68,7 +68,11 @@ def test_data_source_make_dataset(tmpdir):
         pass
 
     region = pipeline.Region.from_state("AZ")
-    region_static = {CommonFields.STATE: "AZ", CommonFields.FIPS: "04"}
+    region_static = {
+        CommonFields.STATE: "AZ",
+        CommonFields.FIPS: "04",
+        CommonFields.AGGREGATE_LEVEL: "state",
+    }
     tmp_data_root = pathlib.Path(tmpdir)
     csv_path = tmp_data_root / NYTimesForTest.COMMON_DF_CSV_PATH
     csv_path.parent.mkdir(parents=True)

--- a/tests/libs/datasets/timeseries_test.py
+++ b/tests/libs/datasets/timeseries_test.py
@@ -265,6 +265,12 @@ def test_one_region_multiple_provenance():
     assert sorted(one_region.provenance[CommonFields.ICU_BEDS]) == ["prov1", "prov2"]
 
 
+def test_add_aggregate_level():
+    ts_df = read_csv_and_index_fips_date("fips,date,m1,m2\n" "36061,2020-04-02,2,\n").reset_index()
+    multiregion = timeseries.MultiRegionDataset.from_fips_timeseries_df(ts_df)
+    assert multiregion.static.aggregate_level.to_list() == ["county"]
+
+
 def test_append_regions():
     ts_fips = timeseries.MultiRegionDataset.from_csv(
         io.StringIO(

--- a/tests/libs/generate_api_v2_test.py
+++ b/tests/libs/generate_api_v2_test.py
@@ -83,16 +83,7 @@ def test_build_summary_for_fips(
             vaccinationsCompleted=nyc_latest.get("vaccinations_completed"),
         ),
         annotations=Annotations(
-            cases=FieldAnnotations(
-                sources=[field_source_usafacts],
-                anomalies=[
-                    {
-                        "date": datetime.date(2021, 2, 25),
-                        "original_observation": 102666.0,
-                        "type": "cumulative_tail_truncated",
-                    }
-                ],
-            ),
+            cases=FieldAnnotations(sources=[field_source_usafacts], anomalies=[],),
             deaths=FieldAnnotations(sources=[field_source_usafacts], anomalies=[],),
             positiveTests=None,
             negativeTests=None,
@@ -134,38 +125,11 @@ def test_build_summary_for_fips(
                 ],
                 anomalies=[],
             ),
-            caseDensity=FieldAnnotations(
-                sources=[field_source_usafacts],
-                anomalies=[
-                    {
-                        "date": datetime.date(2021, 2, 25),
-                        "original_observation": 102666.0,
-                        "type": "cumulative_tail_truncated",
-                    }
-                ],
-            ),
+            caseDensity=FieldAnnotations(sources=[field_source_usafacts], anomalies=[],),
             icuCapacityRatio=FieldAnnotations(sources=[field_source_hhshospital], anomalies=[]),
             icuHeadroomRatio=FieldAnnotations(sources=[field_source_hhshospital], anomalies=[]),
-            infectionRate=FieldAnnotations(
-                sources=[field_source_usafacts],
-                anomalies=[
-                    {
-                        "date": datetime.date(2021, 2, 25),
-                        "original_observation": 102666.0,
-                        "type": "cumulative_tail_truncated",
-                    }
-                ],
-            ),
-            infectionRateCI90=FieldAnnotations(
-                sources=[field_source_usafacts],
-                anomalies=[
-                    {
-                        "date": datetime.date(2021, 2, 25),
-                        "original_observation": 102666.0,
-                        "type": "cumulative_tail_truncated",
-                    }
-                ],
-            ),
+            infectionRate=FieldAnnotations(sources=[field_source_usafacts], anomalies=[],),
+            infectionRateCI90=FieldAnnotations(sources=[field_source_usafacts], anomalies=[],),
         ),
         lastUpdatedDate=datetime.datetime.utcnow(),
         url="https://covidactnow.org/us/new_york-ny/county/bronx_county",


### PR DESCRIPTION
This will fix the breakage in the data update by making sure that all data has an aggregate level.