### PR TITLE
can_scraper_helpers_test using make_dataset

### DIFF
--- a/libs/datasets/data_source.py
+++ b/libs/datasets/data_source.py
@@ -103,7 +103,6 @@ class CanScraperBase(DataSource):
     @lru_cache(None)
     def make_dataset(cls) -> timeseries.MultiRegionDataset:
         """Default implementation of make_dataset that loads data from the parquet file."""
-        assert cls.VARIABLES
         ccd_dataset = cls._get_covid_county_dataset()
         data, source_df = ccd_dataset.query_multiple_variables(
             cls.VARIABLES, log_provider_coverage_warnings=True, source_type=cls.SOURCE_TYPE

--- a/libs/datasets/data_source.py
+++ b/libs/datasets/data_source.py
@@ -1,4 +1,5 @@
 import pathlib
+from typing import Collection
 from typing import List
 from typing import Optional
 from typing import Union
@@ -49,8 +50,8 @@ class DataSource(object):
         return taglib.Source(type=cls.SOURCE_TYPE, url=cls.SOURCE_URL, name=cls.SOURCE_NAME)
 
     @classmethod
-    def _check_data(cls, data: pd.DataFrame):
-        expected_fields = pd.Index({*cls.EXPECTED_FIELDS, *TIMESERIES_INDEX_FIELDS})
+    def _check_data(cls, data: pd.DataFrame, expected_fields: Collection[str]):
+        expected_fields = pd.Index({*expected_fields, *TIMESERIES_INDEX_FIELDS})
         # Keep only the expected fields.
         found_expected_fields = data.columns.intersection(expected_fields)
         data = data[found_expected_fields]
@@ -78,7 +79,7 @@ class DataSource(object):
         data_root = dataset_utils.LOCAL_PUBLIC_DATA_PATH
         input_path = data_root / cls.COMMON_DF_CSV_PATH
         data = common_df.read_csv(input_path, set_index=False)
-        data = cls._check_data(data)
+        data = cls._check_data(data, cls.EXPECTED_FIELDS)
         return MultiRegionDataset.from_fips_timeseries_df(data).add_tag_all(cls.source_tag())
 
 
@@ -103,12 +104,15 @@ class CanScraperBase(DataSource):
     def make_dataset(cls) -> timeseries.MultiRegionDataset:
         """Default implementation of make_dataset that loads data from the parquet file."""
         assert cls.VARIABLES
-        ccd_dataset = CanScraperBase._get_covid_county_dataset()
+        ccd_dataset = cls._get_covid_county_dataset()
         data, source_df = ccd_dataset.query_multiple_variables(
             cls.VARIABLES, log_provider_coverage_warnings=True, source_type=cls.SOURCE_TYPE
         )
         data = cls.transform_data(data)
-        data = cls._check_data(data)
+        expected_fields = cls.EXPECTED_FIELDS
+        if not expected_fields:
+            expected_fields = [v.common_field for v in cls.VARIABLES]
+        data = cls._check_data(data, expected_fields)
         ds = MultiRegionDataset.from_fips_timeseries_df(data)
         if not source_df.empty:
             # For each FIPS-VARIABLE pair keep the source_url row with the last DATE.

--- a/libs/datasets/data_source.py
+++ b/libs/datasets/data_source.py
@@ -109,9 +109,7 @@ class CanScraperBase(DataSource):
             cls.VARIABLES, log_provider_coverage_warnings=True, source_type=cls.SOURCE_TYPE
         )
         data = cls.transform_data(data)
-        expected_fields = cls.EXPECTED_FIELDS
-        if not expected_fields:
-            expected_fields = [v.common_field for v in cls.VARIABLES]
+        expected_fields = [v.common_field for v in cls.VARIABLES if v.common_field is not None]
         data = cls._check_data(data, expected_fields)
         ds = MultiRegionDataset.from_fips_timeseries_df(data)
         if not source_df.empty:

--- a/libs/datasets/sources/can_scraper_state_providers.py
+++ b/libs/datasets/sources/can_scraper_state_providers.py
@@ -6,24 +6,6 @@ from libs.datasets.sources import can_scraper_helpers as ccd_helpers
 class CANScraperStateProviders(data_source.CanScraperBase):
     SOURCE_TYPE = "CANScrapersStateProviders"
 
-    EXPECTED_FIELDS = [
-        CommonFields.STAFFED_BEDS,
-        CommonFields.CASES,
-        CommonFields.DEATHS,
-        CommonFields.VACCINES_ALLOCATED,
-        CommonFields.VACCINES_ADMINISTERED,
-        CommonFields.VACCINES_DISTRIBUTED,
-        CommonFields.VACCINATIONS_INITIATED,
-        CommonFields.VACCINATIONS_COMPLETED,
-        CommonFields.TOTAL_TESTS_VIRAL,
-        CommonFields.ICU_BEDS,
-        CommonFields.CURRENT_HOSPITALIZED,
-        CommonFields.POSITIVE_TESTS_VIRAL,
-        CommonFields.CURRENT_ICU,
-        CommonFields.VACCINATIONS_INITIATED_PCT,
-        CommonFields.VACCINATIONS_COMPLETED_PCT,
-    ]
-
     VARIABLES = [
         ccd_helpers.ScraperVariable(variable_name="pcr_tests_negative", provider="state"),
         ccd_helpers.ScraperVariable(variable_name="unspecified_tests_total", provider="state"),

--- a/libs/datasets/sources/can_scraper_usafacts.py
+++ b/libs/datasets/sources/can_scraper_usafacts.py
@@ -8,11 +8,6 @@ from libs.datasets import data_source
 class CANScraperUSAFactsProvider(data_source.CanScraperBase):
     SOURCE_TYPE = "USAFacts"
 
-    EXPECTED_FIELDS = [
-        CommonFields.CASES,
-        CommonFields.DEATHS,
-    ]
-
     VARIABLES = [
         ccd_helpers.ScraperVariable(
             variable_name="cases",

--- a/libs/datasets/sources/cdc_testing_dataset.py
+++ b/libs/datasets/sources/cdc_testing_dataset.py
@@ -38,10 +38,6 @@ def remove_trailing_zeros(data: pd.DataFrame) -> pd.DataFrame:
 class CDCTestingDataset(data_source.CanScraperBase):
     SOURCE_TYPE = "CDCTesting"
 
-    EXPECTED_FIELDS = [
-        CommonFields.TEST_POSITIVITY_7D,
-    ]
-
     VARIABLES = [
         ccd_helpers.ScraperVariable(
             variable_name="pcr_tests_positive",

--- a/libs/datasets/sources/cdc_vaccine_dataset.py
+++ b/libs/datasets/sources/cdc_vaccine_dataset.py
@@ -6,14 +6,6 @@ from libs.datasets.sources import can_scraper_helpers as ccd_helpers
 class CDCVaccinesDataset(data_source.CanScraperBase):
     SOURCE_TYPE = "CDCVaccine"
 
-    EXPECTED_FIELDS = [
-        CommonFields.VACCINES_ADMINISTERED,
-        CommonFields.VACCINES_ALLOCATED,
-        CommonFields.VACCINES_DISTRIBUTED,
-        CommonFields.VACCINATIONS_INITIATED,
-        CommonFields.VACCINATIONS_COMPLETED,
-    ]
-
     VARIABLES = [
         ccd_helpers.ScraperVariable(
             variable_name="total_vaccine_allocated",

--- a/tests/libs/datasets/data_source_test.py
+++ b/tests/libs/datasets/data_source_test.py
@@ -119,9 +119,16 @@ def test_can_scraper_class_unique_variable_names():
         assert len(variables_not_none) == len(set(v.common_field for v in variables_not_none))
 
 
-def test_can_scraper_class_variable_set_expected_fields_unset():
+def test_can_scraper_class_variable_set():
     cls: data_source.CanScraperBase
     for cls in test_helpers.get_concrete_subclasses(data_source.CanScraperBase):
-        # EXPECTED_FIELDS is empty. It is computed from VARIABLES.
-        assert not cls.EXPECTED_FIELDS
         assert cls.VARIABLES
+
+
+def test_can_scraper_class_expected_fields_set():
+    cls: data_source.DataSource
+    for cls in test_helpers.get_concrete_subclasses(data_source.DataSource):
+        assert cls.EXPECTED_FIELDS
+        assert isinstance(cls.EXPECTED_FIELDS, list)
+        assert cls.SOURCE_TYPE
+        assert isinstance(cls.SOURCE_TYPE, str)

--- a/tests/libs/datasets/data_source_test.py
+++ b/tests/libs/datasets/data_source_test.py
@@ -126,9 +126,12 @@ def test_can_scraper_class_variable_set():
 
 
 def test_can_scraper_class_expected_fields_set():
+    # EXPECTED_FIELD is not set in the base class but is set in all concrete subclasses,
+    # though it may be an empty list.
+    with pytest.raises(AttributeError):
+        data_source.DataSource.EXPECTED_FIELDS
     cls: data_source.DataSource
     for cls in test_helpers.get_concrete_subclasses(data_source.DataSource):
-        assert cls.EXPECTED_FIELDS
         assert isinstance(cls.EXPECTED_FIELDS, list)
         assert cls.SOURCE_TYPE
         assert isinstance(cls.SOURCE_TYPE, str)

--- a/tests/libs/datasets/data_source_test.py
+++ b/tests/libs/datasets/data_source_test.py
@@ -119,10 +119,9 @@ def test_can_scraper_class_unique_variable_names():
         assert len(variables_not_none) == len(set(v.common_field for v in variables_not_none))
 
 
-def test_can_scraper_class_expected_matches_common_fields():
+def test_can_scraper_class_variable_set_expected_fields_unset():
     cls: data_source.CanScraperBase
     for cls in test_helpers.get_concrete_subclasses(data_source.CanScraperBase):
-        variables_not_none = [v for v in cls.VARIABLES if v.common_field is not None]
-        cls_variable_common_fields = set(v.common_field for v in variables_not_none)
-        cls_expected_fields = set(cls.EXPECTED_FIELDS)
-        assert cls_variable_common_fields == cls_expected_fields
+        # EXPECTED_FIELDS is empty. It is computed from VARIABLES.
+        assert not cls.EXPECTED_FIELDS
+        assert cls.VARIABLES

--- a/tests/libs/datasets/sources/can_scraper_helpers_test.py
+++ b/tests/libs/datasets/sources/can_scraper_helpers_test.py
@@ -14,15 +14,21 @@ from covidactnow.datapublic import common_df
 import pandas as pd
 from covidactnow.datapublic.common_fields import PdFields
 
+from libs.datasets import data_source
 from libs.datasets import taglib
 from libs.datasets.sources import can_scraper_helpers as ccd_helpers
 
 
 # Match fields in the CAN Scraper DB
+from libs.datasets.sources import can_scraper_usafacts
 from libs.datasets.taglib import UrlStr
+from libs.pipeline import Region
+from tests import test_helpers
+from tests.test_helpers import TimeseriesLiteral
 
 DEFAULT_LOCATION = "36"
 DEFAULT_LOCATION_TYPE = "state"
+DEFAULT_START_DATE = test_helpers.DEFAULT_START_DATE
 
 
 def _make_iterator(maybe_iterable: Union[None, str, Iterable[str]]) -> Optional[Iterator[str]]:
@@ -38,7 +44,7 @@ def build_can_scraper_dataframe(
     data_by_variable: Dict[ccd_helpers.ScraperVariable, List[float]],
     location=DEFAULT_LOCATION,
     location_type=DEFAULT_LOCATION_TYPE,
-    start_date="2021-01-01",
+    start_date=DEFAULT_START_DATE,
     source_url: Union[None, str, Iterable[str]] = None,
     source_name: Union[None, str, Iterable[str]] = None,
 ) -> pd.DataFrame:
@@ -100,16 +106,26 @@ def test_query_multiple_variables():
         {variable: [10, 20, 30], not_included_variable: [10, 20, 40]}
     )
     data = ccd_helpers.CanScraperLoader(input_data)
-    results, _ = data.query_multiple_variables([variable], source_type="MySource")
 
-    expected_buf = io.StringIO(
-        "fips,      date,vaccinations_completed\n"
-        f" 36,2021-01-01,                    10\n"
-        f" 36,2021-01-02,                    20\n"
-        f" 36,2021-01-03,                    30\n".replace(" ", "")
+    # Make a new subclass to keep this test separate from others in the make_dataset lru_cache.
+    class CANScraperForTest(data_source.CanScraperBase):
+        VARIABLES = [variable]
+        SOURCE_TYPE = "MySource"
+
+        @staticmethod
+        def _get_covid_county_dataset() -> ccd_helpers.CanScraperLoader:
+            return data
+
+    ds = CANScraperForTest.make_dataset()
+
+    vaccinations_completed = TimeseriesLiteral([10, 20, 30], source=taglib.Source(type="MySource"))
+    expected_ds = test_helpers.build_default_region_dataset(
+        {CommonFields.VACCINATIONS_COMPLETED: vaccinations_completed},
+        region=Region.from_fips("36"),
+        static={CommonFields.STATE: "NY", CommonFields.FIPS: "36"},
     )
-    expected = common_df.read_csv(expected_buf, set_index=False)
-    pd.testing.assert_frame_equal(expected, results, check_names=False)
+
+    test_helpers.assert_dataset_like(ds, expected_ds)
 
 
 def test_query_multiple_variables_with_ethnicity():
@@ -124,16 +140,25 @@ def test_query_multiple_variables_with_ethnicity():
     variable_hispanic = dataclasses.replace(variable, ethnicity="hispanic")
 
     input_data = build_can_scraper_dataframe({variable: [100, 100], variable_hispanic: [40, 40]})
-    data = ccd_helpers.CanScraperLoader(input_data)
-    results, _ = data.query_multiple_variables([variable], source_type="MySource")
 
-    expected_buf = io.StringIO(
-        "fips,      date,cases\n"
-        f" 36,2021-01-01,  100\n"
-        f" 36,2021-01-02,  100\n".replace(" ", "")
+    class CANScraperForTest(data_source.CanScraperBase):
+        VARIABLES = [variable]
+        SOURCE_TYPE = "MySource"
+
+        @staticmethod
+        def _get_covid_county_dataset() -> ccd_helpers.CanScraperLoader:
+            return ccd_helpers.CanScraperLoader(input_data)
+
+    ds = CANScraperForTest.make_dataset()
+
+    cases = TimeseriesLiteral([100, 100], source=taglib.Source(type="MySource"))
+    expected_ds = test_helpers.build_default_region_dataset(
+        {CommonFields.CASES: cases},
+        region=Region.from_fips("36"),
+        static={CommonFields.STATE: "NY", CommonFields.FIPS: "36"},
     )
-    expected = common_df.read_csv(expected_buf, set_index=False)
-    pd.testing.assert_frame_equal(expected, results, check_names=False)
+
+    test_helpers.assert_dataset_like(ds, expected_ds)
 
 
 def test_query_source_url():
@@ -146,28 +171,27 @@ def test_query_source_url():
     )
     source_url = UrlStr("http://foo.com")
     input_data = build_can_scraper_dataframe({variable: [10, 20, 30]}, source_url=source_url)
-    data = ccd_helpers.CanScraperLoader(input_data)
-    results, tags = data.query_multiple_variables([variable], source_type="MySource")
 
-    expected_data_buf = io.StringIO(
-        "fips,      date,vaccinations_completed\n"
-        "  36,2021-01-01,                    10\n"
-        "  36,2021-01-02,                    20\n"
-        "  36,2021-01-03,                    30\n".replace(" ", "")
-    )
-    expected = common_df.read_csv(expected_data_buf, set_index=False)
-    pd.testing.assert_frame_equal(expected, results, check_names=False)
+    class CANScraperForTest(data_source.CanScraperBase):
+        VARIABLES = [variable]
+        SOURCE_TYPE = "MySource"
 
-    expected_tag_df = pd.DataFrame(
-        {
-            CommonFields.FIPS: expected[CommonFields.FIPS],
-            CommonFields.DATE: expected[CommonFields.DATE],
-            PdFields.VARIABLE: "vaccinations_completed",
-            taglib.TagField.TYPE: taglib.TagType.SOURCE,
-            taglib.TagField.CONTENT: taglib.Source(type="MySource", url=source_url).content,
-        }
+        @staticmethod
+        def _get_covid_county_dataset() -> ccd_helpers.CanScraperLoader:
+            return ccd_helpers.CanScraperLoader(input_data)
+
+    ds = CANScraperForTest.make_dataset()
+
+    vaccinations_completed = TimeseriesLiteral(
+        [10, 20, 30], source=taglib.Source(type="MySource", url=source_url)
     )
-    pd.testing.assert_frame_equal(expected_tag_df, tags, check_like=True, check_names=False)
+    expected_ds = test_helpers.build_default_region_dataset(
+        {CommonFields.VACCINATIONS_COMPLETED: vaccinations_completed},
+        region=Region.from_fips("36"),
+        static={CommonFields.STATE: "NY", CommonFields.FIPS: "36"},
+    )
+
+    test_helpers.assert_dataset_like(ds, expected_ds)
 
 
 def test_query_multiple_variables_extra_field():

--- a/tests/libs/datasets/taglib_test.py
+++ b/tests/libs/datasets/taglib_test.py
@@ -1,26 +1,11 @@
-import abc
-import inspect
-from typing import Iterable
-from typing import Type
-
 from libs.datasets import taglib
 from libs.datasets import timeseries
-
-
-def _get_subclasses(cls) -> Iterable[Type]:
-    """Yields all subclasses of `cls`."""
-    # From https://stackoverflow.com/a/33607093
-    for subclass in cls.__subclasses__():
-        yield from _get_subclasses(subclass)
-        yield subclass
+from tests import test_helpers
 
 
 def _get_subclass_tag_types(cls):
-    """Returns a list of all TAG_TYPE subclasses of concrete subclasses of cls. By concrete I
-    mean no abstract methods and not directly subclassing abc.ABC."""
-    not_abstract_subclasses = [k for k in _get_subclasses(cls) if not inspect.isabstract(k)]
-    not_abc = [k for k in not_abstract_subclasses if abc.ABC not in k.__bases__]
-    return [k.TAG_TYPE for k in not_abc]
+    """Returns a list of all TAG_TYPE subclasses of concrete subclasses of cls."""
+    return [k.TAG_TYPE for k in test_helpers.get_concrete_subclasses(cls)]
 
 
 def test_all_tag_subclasses_accounted_for():

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,7 @@
+import abc
 import dataclasses
+import inspect
+from typing import Iterable
 from typing import List
 
 from collections import UserList
@@ -6,6 +9,7 @@ from typing import Any
 from typing import Mapping
 from typing import Optional
 from typing import Sequence
+from typing import Type
 from typing import TypeVar
 from typing import Union
 
@@ -314,3 +318,19 @@ def assert_dataset_like(
         tag1 = ds1.tag.astype("string")
         tag2 = ds2.tag.astype("string")
         pd.testing.assert_series_equal(tag1, tag2)
+
+
+def get_subclasses(cls) -> Iterable[Type]:
+    """Yields all subclasses of `cls`."""
+    # From https://stackoverflow.com/a/33607093
+    for subclass in cls.__subclasses__():
+        yield from get_subclasses(subclass)
+        yield subclass
+
+
+def get_concrete_subclasses(cls) -> Iterable[Type]:
+    """Yields all subclasses of `cls` that have no abstract methods and do not directly subclass
+    abc.ABC."""
+    for subcls in get_subclasses(cls):
+        if not inspect.isabstract(subcls) and abc.ABC not in subcls.__bases__:
+            yield subcls

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -29,6 +29,8 @@ from libs.pipeline import Region
 DEFAULT_FIPS = "97222"
 DEFAULT_REGION = Region.from_fips(DEFAULT_FIPS)
 
+DEFAULT_START_DATE = "2020-04-01"
+
 
 T = TypeVar("T")
 
@@ -134,7 +136,7 @@ def build_dataset(
         Region, Mapping[FieldName, Union[Sequence[float], TimeseriesLiteral]]
     ],
     *,
-    start_date="2020-04-01",
+    start_date=DEFAULT_START_DATE,
     timeseries_columns: Optional[Sequence[FieldName]] = None,
     static_by_region_then_field_name: Optional[Mapping[Region, Mapping[FieldName, Any]]] = None,
 ) -> timeseries.MultiRegionDataset:
@@ -207,7 +209,7 @@ def build_default_region_dataset(
     metrics: Mapping[FieldName, Union[Sequence[float], TimeseriesLiteral]],
     *,
     region=DEFAULT_REGION,
-    start_date="2020-04-01",
+    start_date=DEFAULT_START_DATE,
     static: Optional[Mapping[FieldName, Any]] = None,
 ) -> timeseries.MultiRegionDataset:
     """Returns a `MultiRegionDataset` containing metrics in one region"""


### PR DESCRIPTION
This PR is part of https://trello.com/c/lvRFxC5y/932-get-dei-vaccination-data-into-api

* change can_scraper_helpers_test to call make_dataset instead of query_multiple_variables, so the value returned by query_multiple_variables can be modified without changing the tests.
* call _get_covid_county_dataset with cls so it can be overridden in subclasses, removing need to mock it
* change CanScraperBase to compute `EXPECTED_FIELDS` from `VARIABLES` with some funky metaclass stuff.
* add some unit tests checking the constants in subclasses of CanScraperBase

## Tested

Tests pass except for tests/libs/generate_api_v2_test.py::test_build_summary_for_fips, which is expected to be fixed by https://github.com/covid-projections/covid-data-model/pull/988