### PR TITLE
Faster Source creation

### DIFF
--- a/libs/dataclass_utils.py
+++ b/libs/dataclass_utils.py
@@ -1,0 +1,31 @@
+import dataclasses
+
+
+# TODO(tom): Remove dataclass_with_default_init once we are using Python 3.9. See
+#  https://stackoverflow.com/a/58336722
+def dataclass_with_default_init(_cls=None, *args, **kwargs):
+    def wrap(cls):
+        # Save the current __init__ and remove it so dataclass will
+        # create the default __init__.
+        user_init = getattr(cls, "__init__")
+        delattr(cls, "__init__")
+
+        # let dataclass process our class.
+        result = dataclasses.dataclass(cls, *args, **kwargs)
+
+        # Restore the user's __init__ save the default init to __default_init__.
+        setattr(result, "__default_init__", result.__init__)
+        setattr(result, "__init__", user_init)
+
+        # Just in case that dataclass will return a new instance,
+        # (currently, does not happen), restore cls's __init__.
+        if result is not cls:
+            setattr(cls, "__init__", user_init)
+
+        return result
+
+    # Support both dataclass_with_default_init() and dataclass_with_default_init
+    if _cls is None:
+        return wrap
+    else:
+        return wrap(_cls)

--- a/libs/datasets/data_source.py
+++ b/libs/datasets/data_source.py
@@ -1,6 +1,5 @@
 import abc
 import pathlib
-from typing import Collection
 from typing import List
 from typing import Optional
 from typing import Union
@@ -85,7 +84,8 @@ class DataSource(object):
 
 
 # TODO(tom): Once using Python 3.9 replace all this metaclass stuff with @classmethod and
-#  @property on an EXPECTED_FIELDS method in CanScraperBase
+#  @property on an EXPECTED_FIELDS method in CanScraperBase. Also try to remove the disable=E1101
+#  in many places in the code.
 class _CanScraperBaseMeta(type(abc.ABC)):
     @property
     def EXPECTED_FIELDS(cls):
@@ -114,7 +114,10 @@ class CanScraperBase(DataSource, abc.ABC, metaclass=_CanScraperBaseMeta):
         """Default implementation of make_dataset that loads data from the parquet file."""
         ccd_dataset = cls._get_covid_county_dataset()
         data, source_df = ccd_dataset.query_multiple_variables(
-            cls.VARIABLES, log_provider_coverage_warnings=True, source_type=cls.SOURCE_TYPE
+            # pylint: disable=E1101
+            cls.VARIABLES,
+            log_provider_coverage_warnings=True,
+            source_type=cls.SOURCE_TYPE,
         )
         data = cls.transform_data(data)
         data = cls._check_data(data)

--- a/libs/datasets/taglib.py
+++ b/libs/datasets/taglib.py
@@ -21,6 +21,8 @@ from covidactnow.datapublic.common_fields import GetByValueMixin
 from covidactnow.datapublic.common_fields import PdFields
 from covidactnow.datapublic.common_fields import ValueAsStrMixin
 
+from libs.dataclass_utils import dataclass_with_default_init
+
 
 @enum.unique
 class TagField(GetByValueMixin, ValueAsStrMixin, FieldName, enum.Enum):
@@ -133,13 +135,16 @@ class SourceUrl(TagInTimeseries):
         return self.source
 
 
-@dataclass(frozen=True)
+@dataclass_with_default_init(frozen=True)
 class Source(TagInTimeseries):
     type: str
     url: Optional[UrlStr] = None
     name: Optional[str] = None
 
     TAG_TYPE = TagType.SOURCE
+
+    def __init__(self, type, *, url=None, name=None):
+        self.__default_init__(type=type, url=(url or None), name=(name or None))
 
     @staticmethod
     def rename_and_make_tag_df(

--- a/libs/datasets/taglib.py
+++ b/libs/datasets/taglib.py
@@ -144,6 +144,7 @@ class Source(TagInTimeseries):
     TAG_TYPE = TagType.SOURCE
 
     def __init__(self, type, *, url=None, name=None):
+        # pylint: disable=E1101
         self.__default_init__(type=type, url=(url or None), name=(name or None))
 
     @staticmethod

--- a/tests/combined_dataset_test.py
+++ b/tests/combined_dataset_test.py
@@ -220,6 +220,7 @@ def test_dataclass_include_exclude():
     ny_source = combined_datasets.datasource_regions(
         orig_data_source_cls, RegionMask(states=["NY"])
     )
+    # pylint: disable=E1101
     assert ny_source.SOURCE_TYPE == orig_data_source_cls.SOURCE_TYPE
     assert ny_source.EXPECTED_FIELDS == orig_data_source_cls.EXPECTED_FIELDS
     ny_ds = ny_source.make_dataset()

--- a/tests/libs/api_v2_pipeline_test.py
+++ b/tests/libs/api_v2_pipeline_test.py
@@ -202,20 +202,20 @@ def test_source(rt_dataset, icu_dataset):
     deaths_url = UrlStr("http://can.com/death_source")
     cases_urls = [UrlStr("http://can.com/one"), UrlStr("http://can.com/two")]
     new_cases_url = UrlStr("http://can.com/new_cases")
-    deaths_source = taglib.Source("USAFacts", deaths_url, "*The* USA Facts")
+    deaths_source = taglib.Source("USAFacts", url=deaths_url, name="*The* USA Facts")
 
     ds = test_helpers.build_default_region_dataset(
         {
             CommonFields.CASES: TimeseriesLiteral(
                 [100, 200, 300],
                 source=[
-                    taglib.Source("NYTimes", cases_urls[0]),
-                    taglib.Source("NYTimes", cases_urls[1]),
+                    taglib.Source("NYTimes", url=cases_urls[0]),
+                    taglib.Source("NYTimes", url=cases_urls[1]),
                 ],
             ),
             # NEW_CASES has only source_url set, to make sure that an annotation is still output.
             CommonFields.NEW_CASES: TimeseriesLiteral(
-                [100, 100, 100], source=taglib.Source("NYTimes", new_cases_url)
+                [100, 100, 100], source=taglib.Source("NYTimes", url=new_cases_url)
             ),
             CommonFields.CONTACT_TRACERS_COUNT: [10] * 3,
             CommonFields.ICU_BEDS: TimeseriesLiteral(

--- a/tests/libs/datasets/sources/can_scraper_helpers_test.py
+++ b/tests/libs/datasets/sources/can_scraper_helpers_test.py
@@ -1,7 +1,6 @@
 import dataclasses
 import itertools
 from typing import Dict, List
-import io
 import datetime
 from typing import Iterable
 from typing import Iterator
@@ -10,22 +9,19 @@ from typing import Union
 
 import pytest
 from covidactnow.datapublic.common_fields import CommonFields
-from covidactnow.datapublic import common_df
 import pandas as pd
-from covidactnow.datapublic.common_fields import PdFields
 
 from libs.datasets import data_source
 from libs.datasets import taglib
 from libs.datasets.sources import can_scraper_helpers as ccd_helpers
 
-
-# Match fields in the CAN Scraper DB
-from libs.datasets.sources import can_scraper_usafacts
 from libs.datasets.taglib import UrlStr
 from libs.pipeline import Region
 from tests import test_helpers
 from tests.test_helpers import TimeseriesLiteral
 
+
+# Match fields in the CAN Scraper DB
 DEFAULT_LOCATION = "36"
 DEFAULT_LOCATION_TYPE = "state"
 DEFAULT_START_DATE = test_helpers.DEFAULT_START_DATE

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -20,6 +20,7 @@ from covidactnow.datapublic.common_fields import CommonFields
 from covidactnow.datapublic.common_fields import FieldName
 from covidactnow.datapublic.common_fields import PdFields
 
+from libs.dataclass_utils import dataclass_with_default_init
 from libs.datasets import taglib
 from libs.datasets import timeseries
 from libs.datasets.taglib import TagField
@@ -47,36 +48,6 @@ def _to_list(list_or_scalar: Union[None, T, List[T]]) -> List[T]:
         return [list_or_scalar]
     else:
         return []
-
-
-# TODO(tom): Remove dataclass_with_default_init once we are using Python 3.9. See
-#  https://stackoverflow.com/a/58336722
-def dataclass_with_default_init(_cls=None, *args, **kwargs):
-    def wrap(cls):
-        # Save the current __init__ and remove it so dataclass will
-        # create the default __init__.
-        user_init = getattr(cls, "__init__")
-        delattr(cls, "__init__")
-
-        # let dataclass process our class.
-        result = dataclasses.dataclass(cls, *args, **kwargs)
-
-        # Restore the user's __init__ save the default init to __default_init__.
-        setattr(result, "__default_init__", result.__init__)
-        setattr(result, "__init__", user_init)
-
-        # Just in case that dataclass will return a new instance,
-        # (currently, does not happen), restore cls's __init__.
-        if result is not cls:
-            setattr(cls, "__init__", user_init)
-
-        return result
-
-    # Support both dataclass_with_default_init() and dataclass_with_default_init
-    if _cls is None:
-        return wrap
-    else:
-        return wrap(_cls)
 
 
 @dataclass_with_default_init(frozen=True)


### PR DESCRIPTION
I noticed that when importing more data `data update`, which I run a lot, slowed down a lot. `py-spy` pointed to creation of `Source` objects as lots of the time. This PR reduces `time pytest tests/libs/datasets/data_source_test.py::test_state_providers_smoke_test` from 2 minutes to 45 seconds.

Clean lint errors that got in with some recent commits.