### PR TITLE
Remove CanScraperBase.transform

### DIFF
--- a/libs/datasets/data_source.py
+++ b/libs/datasets/data_source.py
@@ -98,11 +98,6 @@ class CanScraperBase(DataSource, abc.ABC, metaclass=_CanScraperBaseMeta):
     # Must be set in subclasses.
     VARIABLES: List[ccd_helpers.ScraperVariable]
 
-    @classmethod
-    def transform_data(cls, data: pd.DataFrame) -> pd.DataFrame:
-        """Subclasses may override this to transform the data DataFrame."""
-        return data
-
     @staticmethod
     @lru_cache(None)
     def _get_covid_county_dataset() -> ccd_helpers.CanScraperLoader:
@@ -119,7 +114,6 @@ class CanScraperBase(DataSource, abc.ABC, metaclass=_CanScraperBaseMeta):
             log_provider_coverage_warnings=True,
             source_type=cls.SOURCE_TYPE,
         )
-        data = cls.transform_data(data)
         data = cls._check_data(data)
         ds = MultiRegionDataset.from_fips_timeseries_df(data)
         if not source_df.empty:

--- a/libs/datasets/sources/cdc_testing_dataset.py
+++ b/libs/datasets/sources/cdc_testing_dataset.py
@@ -1,16 +1,21 @@
+import dataclasses
+from functools import lru_cache
+
+from libs.datasets import AggregationLevel
 from libs.datasets import data_source
 import pandas as pd
 from covidactnow.datapublic.common_fields import CommonFields
 from libs.datasets.sources import can_scraper_helpers as ccd_helpers
+from libs.datasets.timeseries import MultiRegionDataset
+from libs.pipeline import Region
 
-
-DC_COUNTY_FIPS = "11001"
-DC_STATE_FIPS = "11"
+DC_COUNTY_LOCATION_ID = Region.from_fips("11001").location_id
+DC_STATE_LOCATION_ID = Region.from_state("DC").location_id
 
 
 def _remove_trailing_zeros(series: pd.Series) -> pd.Series:
 
-    series = series.copy()
+    series = pd.Series(series.values.copy(), index=series.index.get_level_values(CommonFields.DATE))
 
     index = series.loc[series != 0].last_valid_index()
 
@@ -27,12 +32,12 @@ def _remove_trailing_zeros(series: pd.Series) -> pd.Series:
 def remove_trailing_zeros(data: pd.DataFrame) -> pd.DataFrame:
     # TODO(tom): See if TailFilter+zeros_filter produce the same data and if so, remove this
     #  function.
-    data = data.sort_values([CommonFields.FIPS, CommonFields.DATE]).set_index(CommonFields.DATE)
-    test_pos = data.groupby(CommonFields.FIPS)[CommonFields.TEST_POSITIVITY_7D].apply(
+    data = data.sort_index()
+    test_pos = data.groupby(CommonFields.LOCATION_ID)[CommonFields.TEST_POSITIVITY_7D].apply(
         _remove_trailing_zeros
     )
     data[CommonFields.TEST_POSITIVITY_7D] = test_pos
-    return data.reset_index()
+    return data
 
 
 class CDCTestingDataset(data_source.CanScraperBase):
@@ -49,21 +54,32 @@ class CDCTestingDataset(data_source.CanScraperBase):
     ]
 
     @classmethod
-    def transform_data(cls, results: pd.DataFrame) -> pd.DataFrame:
+    @lru_cache(None)
+    def make_dataset(cls) -> MultiRegionDataset:
         # Test positivity should be a ratio
-        results.loc[:, CommonFields.TEST_POSITIVITY_7D] = (
-            results.loc[:, CommonFields.TEST_POSITIVITY_7D] / 100.0
+        ds = super().make_dataset()
+        ts_copy = ds.timeseries.copy()
+        ts_copy.loc[:, CommonFields.TEST_POSITIVITY_7D] = (
+            ts_copy.loc[:, CommonFields.TEST_POSITIVITY_7D] / 100.0
+        )
+
+        levels = set(
+            Region.from_location_id(l).level
+            for l in ds.timeseries.index.get_level_values(CommonFields.LOCATION_ID)
         )
         # Should only be picking up county all_df for now.  May need additional logic if states
         # are included as well
-        assert (results[CommonFields.FIPS].str.len() == 5).all()
+        assert levels == {AggregationLevel.COUNTY}
 
         # Duplicating DC County results as state results because of a downstream
         # use of how dc state data is used to override DC county data.
-        dc_results = results.loc[results[CommonFields.FIPS] == DC_COUNTY_FIPS, :].copy()
-        dc_results.loc[:, CommonFields.FIPS] = DC_STATE_FIPS
-        dc_results.loc[:, CommonFields.AGGREGATE_LEVEL] = "state"
+        dc_results = ts_copy.xs(
+            DC_COUNTY_LOCATION_ID, axis=0, level=CommonFields.LOCATION_ID, drop_level=False
+        )
+        dc_results = dc_results.rename(
+            index={DC_COUNTY_LOCATION_ID: DC_STATE_LOCATION_ID}, level=CommonFields.LOCATION_ID
+        )
 
-        results = pd.concat([results, dc_results])
+        ts_copy = ts_copy.append(dc_results, verify_integrity=True).sort_index()
 
-        return remove_trailing_zeros(results)
+        return dataclasses.replace(ds, timeseries=remove_trailing_zeros(ts_copy))

--- a/tests/libs/datasets/sources/cdc_testing_dataset_test.py
+++ b/tests/libs/datasets/sources/cdc_testing_dataset_test.py
@@ -1,33 +1,23 @@
-import io
+import dataclasses
 
-import pandas as pd
-from covidactnow.datapublic import common_df
+from covidactnow.datapublic.common_fields import CommonFields
 
 from libs.datasets.sources import cdc_testing_dataset
+from tests import test_helpers
 
 
 def test_remove_trailing_zeros():
 
-    data_buf = io.StringIO(
-        "fips,date,test_positivity_7d\n"
-        f"48112,2020-08-17,0.5\n"
-        f"48112,2020-08-18,0.6\n"
-        f"48112,2020-08-19,0.0\n"
-        f"48113,2020-08-16,0.0\n"
-        f"48113,2020-08-17,0.0\n"
-        f"48113,2020-08-18,0.0\n"
+    ds_in = test_helpers.build_default_region_dataset(
+        {CommonFields.TEST_POSITIVITY_7D: [0.5, 0.6, 0, 0, 0, 0]}
     )
-    data = common_df.read_csv(data_buf, set_index=False)
-    results = cdc_testing_dataset.remove_trailing_zeros(data)
 
-    expected_buf = io.StringIO(
-        "fips,date,test_positivity_7d\n"
-        f"48112,2020-08-17,0.5\n"
-        f"48112,2020-08-18,0.6\n"
-        f"48112,2020-08-19,\n"
-        f"48113,2020-08-16,\n"
-        f"48113,2020-08-17,\n"
-        f"48113,2020-08-18,\n"
+    ds_out = dataclasses.replace(
+        ds_in, timeseries=cdc_testing_dataset.remove_trailing_zeros(ds_in.timeseries)
     )
-    expected = common_df.read_csv(expected_buf, set_index=False)
-    pd.testing.assert_frame_equal(expected.sort_index(axis=1), results.sort_index(axis=1))
+
+    ds_expected = test_helpers.build_default_region_dataset(
+        {CommonFields.TEST_POSITIVITY_7D: [0.5, 0.6]}
+    )
+
+    test_helpers.assert_dataset_like(ds_out, ds_expected, drop_na_dates=True)


### PR DESCRIPTION
This PR
* Removes `transform_data(cls, data: pd.DataFrame) -> pd.DataFrame` which was only used by CDCTesting, replacing it with make_dataset override, which is used by other DataSource subclasses. This simplifies changes to CanScraperBase, making it easier to add demographic buckets
* Changes test from parsing hard-coded CSV to using `test_helpers.build_default_region_dataset`

## Tested

`./run.py data update` reproduces the same output