### PR TITLE
CDCTesting test coverage improvement, use None in test time-series

### DIFF
--- a/libs/datasets/sources/cdc_testing_dataset.py
+++ b/libs/datasets/sources/cdc_testing_dataset.py
@@ -56,30 +56,33 @@ class CDCTestingDataset(data_source.CanScraperBase):
     @classmethod
     @lru_cache(None)
     def make_dataset(cls) -> MultiRegionDataset:
-        # Test positivity should be a ratio
-        ds = super().make_dataset()
-        ts_copy = ds.timeseries.copy()
-        ts_copy.loc[:, CommonFields.TEST_POSITIVITY_7D] = (
-            ts_copy.loc[:, CommonFields.TEST_POSITIVITY_7D] / 100.0
-        )
+        return modify_dataset(super().make_dataset())
 
-        levels = set(
-            Region.from_location_id(l).level
-            for l in ds.timeseries.index.get_level_values(CommonFields.LOCATION_ID)
-        )
-        # Should only be picking up county all_df for now.  May need additional logic if states
-        # are included as well
-        assert levels == {AggregationLevel.COUNTY}
 
-        # Duplicating DC County results as state results because of a downstream
-        # use of how dc state data is used to override DC county data.
-        dc_results = ts_copy.xs(
-            DC_COUNTY_LOCATION_ID, axis=0, level=CommonFields.LOCATION_ID, drop_level=False
-        )
-        dc_results = dc_results.rename(
-            index={DC_COUNTY_LOCATION_ID: DC_STATE_LOCATION_ID}, level=CommonFields.LOCATION_ID
-        )
+def modify_dataset(ds: MultiRegionDataset) -> MultiRegionDataset:
+    ts_copy = ds.timeseries.copy()
+    # Test positivity should be a ratio
+    ts_copy.loc[:, CommonFields.TEST_POSITIVITY_7D] = (
+        ts_copy.loc[:, CommonFields.TEST_POSITIVITY_7D] / 100.0
+    )
 
-        ts_copy = ts_copy.append(dc_results, verify_integrity=True).sort_index()
+    levels = set(
+        Region.from_location_id(l).level
+        for l in ds.timeseries.index.get_level_values(CommonFields.LOCATION_ID)
+    )
+    # Should only be picking up county all_df for now.  May need additional logic if states
+    # are included as well
+    assert levels == {AggregationLevel.COUNTY}
 
-        return dataclasses.replace(ds, timeseries=remove_trailing_zeros(ts_copy))
+    # Duplicating DC County results as state results because of a downstream
+    # use of how dc state data is used to override DC county data.
+    dc_results = ts_copy.xs(
+        DC_COUNTY_LOCATION_ID, axis=0, level=CommonFields.LOCATION_ID, drop_level=False
+    )
+    dc_results = dc_results.rename(
+        index={DC_COUNTY_LOCATION_ID: DC_STATE_LOCATION_ID}, level=CommonFields.LOCATION_ID
+    )
+
+    ts_copy = ts_copy.append(dc_results, verify_integrity=True).sort_index()
+
+    return dataclasses.replace(ds, timeseries=remove_trailing_zeros(ts_copy))

--- a/tests/libs/datasets/sources/cdc_testing_dataset_test.py
+++ b/tests/libs/datasets/sources/cdc_testing_dataset_test.py
@@ -5,21 +5,19 @@ from libs.datasets.sources import cdc_testing_dataset
 from tests import test_helpers
 
 
-def test_remove_trailing_zeros():
+def test_cdc_testing_modify_dataset():
     region_dc_county = pipeline.Region.from_fips("11001")
     region_dc_state = pipeline.Region.from_state("DC")
-    region_sf = pipeline.Region.from_fips("06075")
+    region_other = pipeline.Region.from_fips("06075")
 
-    # Other data, in the test to make sure it isn't dropped
-    other_regions_data = {
-        region_sf: {CommonFields.TEST_POSITIVITY_7D: [10, 20, 30, 40, 50, 60]},
-    }
     dc_data_before_filter = {
         CommonFields.TEST_POSITIVITY_7D: [50, 60, 0, 0, 0, 0],
         CommonFields.CASES: [1, 2, 3, 4, 5, 6],
     }
+    # Check that test positivity is converted from percent to ratio in other regions.
+    other_data_before_filter = {CommonFields.TEST_POSITIVITY_7D: [10, 20, 30, 40, 50, 60]}
     ds_in = test_helpers.build_dataset(
-        {region_dc_county: dc_data_before_filter, **other_regions_data,}
+        {region_dc_county: dc_data_before_filter, region_other: other_data_before_filter}
     )
 
     ds_out = cdc_testing_dataset.modify_dataset(ds_in)
@@ -28,11 +26,12 @@ def test_remove_trailing_zeros():
         CommonFields.TEST_POSITIVITY_7D: [0.5, 0.6, None, None, None, None],
         CommonFields.CASES: [1, 2, 3, 4, 5, 6],
     }
+    other_data_after_filter = {CommonFields.TEST_POSITIVITY_7D: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]}
     ds_expected = test_helpers.build_dataset(
         {
             region_dc_county: dc_data_after_filter,
             region_dc_state: dc_data_after_filter,
-            **other_regions_data,
+            region_other: other_data_after_filter,
         }
     )
 

--- a/tests/libs/datasets/sources/cdc_testing_dataset_test.py
+++ b/tests/libs/datasets/sources/cdc_testing_dataset_test.py
@@ -1,23 +1,39 @@
-import dataclasses
-
 from covidactnow.datapublic.common_fields import CommonFields
 
+from libs import pipeline
 from libs.datasets.sources import cdc_testing_dataset
 from tests import test_helpers
 
 
 def test_remove_trailing_zeros():
+    region_dc_county = pipeline.Region.from_fips("11001")
+    region_dc_state = pipeline.Region.from_state("DC")
+    region_sf = pipeline.Region.from_fips("06075")
 
-    ds_in = test_helpers.build_default_region_dataset(
-        {CommonFields.TEST_POSITIVITY_7D: [0.5, 0.6, 0, 0, 0, 0]}
+    ds_in = test_helpers.build_dataset(
+        {
+            region_dc_county: {
+                CommonFields.TEST_POSITIVITY_7D: [50, 60, 0, 0, 0, 0],
+                CommonFields.CASES: [1, 2, 3, 4, 5, 6],
+            },
+            region_sf: {CommonFields.TEST_POSITIVITY_7D: [10, 20, 30, 40, 50, 60]},
+        }
     )
 
-    ds_out = dataclasses.replace(
-        ds_in, timeseries=cdc_testing_dataset.remove_trailing_zeros(ds_in.timeseries)
-    )
+    ds_out = cdc_testing_dataset.modify_dataset(ds_in)
 
-    ds_expected = test_helpers.build_default_region_dataset(
-        {CommonFields.TEST_POSITIVITY_7D: [0.5, 0.6]}
+    ds_expected = test_helpers.build_dataset(
+        {
+            region_dc_county: {
+                CommonFields.TEST_POSITIVITY_7D: [0.5, 0.6, None, None, None, None],
+                CommonFields.CASES: [1, 2, 3, 4, 5, 6],
+            },
+            region_dc_state: {
+                CommonFields.TEST_POSITIVITY_7D: [0.5, 0.6, None, None, None, None],
+                CommonFields.CASES: [1, 2, 3, 4, 5, 6],
+            },
+            region_sf: {CommonFields.TEST_POSITIVITY_7D: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]},
+        }
     )
 
     test_helpers.assert_dataset_like(ds_out, ds_expected, drop_na_dates=True)

--- a/tests/libs/datasets/sources/cdc_testing_dataset_test.py
+++ b/tests/libs/datasets/sources/cdc_testing_dataset_test.py
@@ -10,29 +10,29 @@ def test_remove_trailing_zeros():
     region_dc_state = pipeline.Region.from_state("DC")
     region_sf = pipeline.Region.from_fips("06075")
 
+    # Other data, in the test to make sure it isn't dropped
+    other_regions_data = {
+        region_sf: {CommonFields.TEST_POSITIVITY_7D: [10, 20, 30, 40, 50, 60]},
+    }
+    dc_data_before_filter = {
+        CommonFields.TEST_POSITIVITY_7D: [50, 60, 0, 0, 0, 0],
+        CommonFields.CASES: [1, 2, 3, 4, 5, 6],
+    }
     ds_in = test_helpers.build_dataset(
-        {
-            region_dc_county: {
-                CommonFields.TEST_POSITIVITY_7D: [50, 60, 0, 0, 0, 0],
-                CommonFields.CASES: [1, 2, 3, 4, 5, 6],
-            },
-            region_sf: {CommonFields.TEST_POSITIVITY_7D: [10, 20, 30, 40, 50, 60]},
-        }
+        {region_dc_county: dc_data_before_filter, **other_regions_data,}
     )
 
     ds_out = cdc_testing_dataset.modify_dataset(ds_in)
 
+    dc_data_after_filter = {
+        CommonFields.TEST_POSITIVITY_7D: [0.5, 0.6, None, None, None, None],
+        CommonFields.CASES: [1, 2, 3, 4, 5, 6],
+    }
     ds_expected = test_helpers.build_dataset(
         {
-            region_dc_county: {
-                CommonFields.TEST_POSITIVITY_7D: [0.5, 0.6, None, None, None, None],
-                CommonFields.CASES: [1, 2, 3, 4, 5, 6],
-            },
-            region_dc_state: {
-                CommonFields.TEST_POSITIVITY_7D: [0.5, 0.6, None, None, None, None],
-                CommonFields.CASES: [1, 2, 3, 4, 5, 6],
-            },
-            region_sf: {CommonFields.TEST_POSITIVITY_7D: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]},
+            region_dc_county: dc_data_after_filter,
+            region_dc_state: dc_data_after_filter,
+            **other_regions_data,
         }
     )
 

--- a/tests/libs/metrics/test_positivity_test.py
+++ b/tests/libs/metrics/test_positivity_test.py
@@ -3,7 +3,6 @@ import io
 from typing import List
 
 import pandas as pd
-import numpy as np
 import pytest
 from covidactnow.datapublic import common_df
 

--- a/tests/libs/metrics/test_positivity_test.py
+++ b/tests/libs/metrics/test_positivity_test.py
@@ -3,6 +3,7 @@ import io
 from typing import List
 
 import pandas as pd
+import numpy as np
 import pytest
 from covidactnow.datapublic import common_df
 
@@ -377,7 +378,7 @@ def test_recent_pos_neg_tests_has_positivity_ratio(pos_neg_tests_recent):
         # positive_tests and negative_tests are used
         expected_metrics = {
             CommonFields.TEST_POSITIVITY: TimeseriesLiteral(
-                [pd.NA, 0.0909, pd.NA, pd.NA, pd.NA, pd.NA], provenance="pos"
+                [None, 0.0909, None, None, None, None], provenance="pos"
             )
         }
         expected = test_helpers.build_default_region_dataset(


### PR DESCRIPTION
This PR makes https://github.com/covid-projections/covid-data-model/pull/1002 smaller and is part of https://trello.com/c/lvRFxC5y/932-get-dei-vaccination-data-into-api

* refactors CDCTesting data_source so all the interesting logic is easy to test
* tests all the interesting logic of CDCTesting
* changes tests/libs/metrics/test_positivity_test.py to be consistent with other tests using `None` in timeseries passed to build_default_region_dataset