### PR TITLE
change can_scraper_helpers BadLocationId warning to raises

### DIFF
--- a/libs/datasets/sources/can_scraper_helpers.py
+++ b/libs/datasets/sources/can_scraper_helpers.py
@@ -1,6 +1,5 @@
 """Helpers to access and query data loaded from the CAN Scraper parquet file.
 """
-import warnings
 from typing import List
 import enum
 import dataclasses

--- a/libs/datasets/sources/can_scraper_helpers.py
+++ b/libs/datasets/sources/can_scraper_helpers.py
@@ -136,10 +136,6 @@ class CanScraperLoader:
             .rename(PdFields.DEMOGRAPHIC_BUCKET)
         )
         CanScraperLoader._check_location_id(all_df)
-        # Hack fix for bad location_ids.
-        all_df[Fields.LOCATION_ID] = _fips_from_int(all_df[Fields.LOCATION]).apply(
-            pipeline.fips_to_location_id
-        )
         # Use `join(other, on=...)` because it preserves the indexed_df index
         rv = (
             all_df.join(bucket_short_names, on=DEMOGRAPHIC_FIELDS)
@@ -176,12 +172,8 @@ class CanScraperLoader:
                 bad_location_id_mask, [Fields.LOCATION_ID, COMPUTED_LOCATION_ID]
             ]
             bad_rows = bad_location_ids.merge(all_df, how="left", on=Fields.LOCATION_ID)
-            # TODO(tom): Have this raise when location_id are fixed
-            warnings.warn(
-                BadLocationId(
-                    f"Bad location_id. Examples:\n"
-                    f"{bad_rows.to_string(line_width=200, max_rows=20)}"
-                )
+            raise BadLocationId(
+                f"Bad location_id. Examples:\n" f"{bad_rows.to_string(line_width=200, max_rows=20)}"
             )
 
     def query_multiple_variables(

--- a/tests/libs/datasets/sources/can_scraper_helpers_test.py
+++ b/tests/libs/datasets/sources/can_scraper_helpers_test.py
@@ -230,5 +230,5 @@ def test_bad_location_id():
     )
     input_data = build_can_scraper_dataframe({variable: [10, 20, 30]})
     input_data.iat[0, input_data.columns.get_loc(ccd_helpers.Fields.LOCATION_ID)] = "iso1:us#nope"
-    with pytest.warns(ccd_helpers.BadLocationId, match=r"\#nope"):
+    with pytest.raises(ccd_helpers.BadLocationId, match=r"\#nope"):
         ccd_helpers.CanScraperLoader(input_data)


### PR DESCRIPTION
This PR follows up on https://github.com/covid-projections/covid-data-model/pull/987 and https://covidactnow.slack.com/archives/C015V4JS952/p1615408720113400 

## Tested

`./run.py data update` produced identical `data/multiregion-wide-dates.csv`