### PR TITLE
Time-series bucketed long

### DIFF
--- a/dash_app/dashboard.py
+++ b/dash_app/dashboard.py
@@ -117,7 +117,7 @@ class PerRegionStats(AggregatedStats):
     @staticmethod
     def make(ds: timeseries.MultiRegionDataset) -> "PerRegionStats":
         wide_var_has_timeseries = (
-            ds.timeseries_wide_dates_no_buckets.notnull()
+            ds.timeseries_not_bucketed_wide_dates.notnull()
             .any(1)
             .unstack(PdFields.VARIABLE, fill_value=False)
             .astype(bool)

--- a/dash_app/dashboard.py
+++ b/dash_app/dashboard.py
@@ -117,7 +117,7 @@ class PerRegionStats(AggregatedStats):
     @staticmethod
     def make(ds: timeseries.MultiRegionDataset) -> "PerRegionStats":
         wide_var_has_timeseries = (
-            ds.timeseries_wide_dates()
+            ds.timeseries_wide_dates_no_buckets()
             .notnull()
             .any(1)
             .unstack(PdFields.VARIABLE, fill_value=False)

--- a/dash_app/dashboard.py
+++ b/dash_app/dashboard.py
@@ -117,8 +117,7 @@ class PerRegionStats(AggregatedStats):
     @staticmethod
     def make(ds: timeseries.MultiRegionDataset) -> "PerRegionStats":
         wide_var_has_timeseries = (
-            ds.timeseries_wide_dates_no_buckets()
-            .notnull()
+            ds.timeseries_wide_dates_no_buckets.notnull()
             .any(1)
             .unstack(PdFields.VARIABLE, fill_value=False)
             .astype(bool)

--- a/libs/datasets/ca_vaccination_backfill.py
+++ b/libs/datasets/ca_vaccination_backfill.py
@@ -12,7 +12,7 @@ def derive_ca_county_vaccine_pct(ds_in: MultiRegionDataset) -> MultiRegionDatase
     """Derives vaccination metrics for CA counties based on State 1st vs 2nd dose reporting."""
 
     ca_county_dataset = ds_in.get_subset(aggregation_level=AggregationLevel.COUNTY, state="CA")
-    ca_county_wide = ca_county_dataset.timeseries_wide_dates_no_buckets()
+    ca_county_wide = ca_county_dataset.timeseries_wide_dates_no_buckets
     fields_to_check = [
         CommonFields.VACCINATIONS_INITIATED,
         CommonFields.VACCINATIONS_COMPLETED,
@@ -25,7 +25,7 @@ def derive_ca_county_vaccine_pct(ds_in: MultiRegionDataset) -> MultiRegionDatase
 
     ca_state_wide = ds_in.get_regions_subset(
         [Region.from_state("CA")]
-    ).timeseries_wide_dates_no_buckets()
+    ).timeseries_wide_dates_no_buckets
 
     # Drop location index because not used to apply to county level data
     ca_state_wide = ca_state_wide.reset_index(CommonFields.LOCATION_ID, drop=True)
@@ -70,7 +70,7 @@ def derive_ca_county_vaccine_pct(ds_in: MultiRegionDataset) -> MultiRegionDatase
         level=PdFields.VARIABLE,
     )
 
-    all_wide = ds_in.timeseries_wide_dates_no_buckets()
+    all_wide = ds_in.timeseries_wide_dates_no_buckets
     # Because we assert that existing dataset does not have CA county VACCINATIONS_COMPLETED_PCT
     # or VACCINATIONS_INITIATED_PCT we can safely combine the existing rows with new derived rows
     combined = pd.concat([vaccines_completed_pct, vaccines_initiated_pct, all_wide])

--- a/libs/datasets/ca_vaccination_backfill.py
+++ b/libs/datasets/ca_vaccination_backfill.py
@@ -12,7 +12,7 @@ def derive_ca_county_vaccine_pct(ds_in: MultiRegionDataset) -> MultiRegionDatase
     """Derives vaccination metrics for CA counties based on State 1st vs 2nd dose reporting."""
 
     ca_county_dataset = ds_in.get_subset(aggregation_level=AggregationLevel.COUNTY, state="CA")
-    ca_county_wide = ca_county_dataset.timeseries_wide_dates_no_buckets
+    ca_county_wide = ca_county_dataset.timeseries_not_bucketed_wide_dates
     fields_to_check = [
         CommonFields.VACCINATIONS_INITIATED,
         CommonFields.VACCINATIONS_COMPLETED,
@@ -25,7 +25,7 @@ def derive_ca_county_vaccine_pct(ds_in: MultiRegionDataset) -> MultiRegionDatase
 
     ca_state_wide = ds_in.get_regions_subset(
         [Region.from_state("CA")]
-    ).timeseries_wide_dates_no_buckets
+    ).timeseries_not_bucketed_wide_dates
 
     # Drop location index because not used to apply to county level data
     ca_state_wide = ca_state_wide.reset_index(CommonFields.LOCATION_ID, drop=True)
@@ -70,7 +70,7 @@ def derive_ca_county_vaccine_pct(ds_in: MultiRegionDataset) -> MultiRegionDatase
         level=PdFields.VARIABLE,
     )
 
-    all_wide = ds_in.timeseries_wide_dates_no_buckets
+    all_wide = ds_in.timeseries_not_bucketed_wide_dates
     # Because we assert that existing dataset does not have CA county VACCINATIONS_COMPLETED_PCT
     # or VACCINATIONS_INITIATED_PCT we can safely combine the existing rows with new derived rows
     combined = pd.concat([vaccines_completed_pct, vaccines_initiated_pct, all_wide])

--- a/libs/datasets/ca_vaccination_backfill.py
+++ b/libs/datasets/ca_vaccination_backfill.py
@@ -12,7 +12,7 @@ def derive_ca_county_vaccine_pct(ds_in: MultiRegionDataset) -> MultiRegionDatase
     """Derives vaccination metrics for CA counties based on State 1st vs 2nd dose reporting."""
 
     ca_county_dataset = ds_in.get_subset(aggregation_level=AggregationLevel.COUNTY, state="CA")
-    ca_county_wide = ca_county_dataset.timeseries_wide_dates()
+    ca_county_wide = ca_county_dataset.timeseries_wide_dates_no_buckets()
     fields_to_check = [
         CommonFields.VACCINATIONS_INITIATED,
         CommonFields.VACCINATIONS_COMPLETED,
@@ -23,7 +23,9 @@ def derive_ca_county_vaccine_pct(ds_in: MultiRegionDataset) -> MultiRegionDatase
     # not NA, likely do not need to estimate anymore and this methodology can be removed.
     assert ca_county_wide.loc[(slice(None), fields_to_check), :].isna().all().all()
 
-    ca_state_wide = ds_in.get_regions_subset([Region.from_state("CA")]).timeseries_wide_dates()
+    ca_state_wide = ds_in.get_regions_subset(
+        [Region.from_state("CA")]
+    ).timeseries_wide_dates_no_buckets()
 
     # Drop location index because not used to apply to county level data
     ca_state_wide = ca_state_wide.reset_index(CommonFields.LOCATION_ID, drop=True)
@@ -68,7 +70,7 @@ def derive_ca_county_vaccine_pct(ds_in: MultiRegionDataset) -> MultiRegionDatase
         level=PdFields.VARIABLE,
     )
 
-    all_wide = ds_in.timeseries_wide_dates()
+    all_wide = ds_in.timeseries_wide_dates_no_buckets()
     # Because we assert that existing dataset does not have CA county VACCINATIONS_COMPLETED_PCT
     # or VACCINATIONS_INITIATED_PCT we can safely combine the existing rows with new derived rows
     combined = pd.concat([vaccines_completed_pct, vaccines_initiated_pct, all_wide])

--- a/libs/datasets/new_cases_and_deaths.py
+++ b/libs/datasets/new_cases_and_deaths.py
@@ -30,7 +30,7 @@ def add_incident_column(
     # Get timeseries data from timeseries_wide_dates because it creates a date range that includes
     # every date, even those with NA cases. This keeps the output identical when empty rows are
     # dropped or added.
-    wide_dates_var = dataset_in.timeseries_wide_dates().loc[(slice(None), field_in), :]
+    wide_dates_var = dataset_in.timeseries_wide_dates_no_buckets().loc[(slice(None), field_in), :]
     # Calculating new cases using diff will remove the first detected value from the case series.
     # We want to capture the first day a region reports a case. Since our data sources have
     # been capturing cases in all states from the beginning of the pandemic, we are treating

--- a/libs/datasets/new_cases_and_deaths.py
+++ b/libs/datasets/new_cases_and_deaths.py
@@ -30,7 +30,7 @@ def add_incident_column(
     # Get timeseries data from timeseries_wide_dates because it creates a date range that includes
     # every date, even those with NA cases. This keeps the output identical when empty rows are
     # dropped or added.
-    wide_dates_var = dataset_in.timeseries_wide_dates_no_buckets.loc[(slice(None), field_in), :]
+    wide_dates_var = dataset_in.timeseries_not_bucketed_wide_dates.loc[(slice(None), field_in), :]
     # Calculating new cases using diff will remove the first detected value from the case series.
     # We want to capture the first day a region reports a case. Since our data sources have
     # been capturing cases in all states from the beginning of the pandemic, we are treating

--- a/libs/datasets/new_cases_and_deaths.py
+++ b/libs/datasets/new_cases_and_deaths.py
@@ -30,7 +30,7 @@ def add_incident_column(
     # Get timeseries data from timeseries_wide_dates because it creates a date range that includes
     # every date, even those with NA cases. This keeps the output identical when empty rows are
     # dropped or added.
-    wide_dates_var = dataset_in.timeseries_wide_dates_no_buckets().loc[(slice(None), field_in), :]
+    wide_dates_var = dataset_in.timeseries_wide_dates_no_buckets.loc[(slice(None), field_in), :]
     # Calculating new cases using diff will remove the first detected value from the case series.
     # We want to capture the first day a region reports a case. Since our data sources have
     # been capturing cases in all states from the beginning of the pandemic, we are treating

--- a/libs/datasets/sources/zeros_filter.py
+++ b/libs/datasets/sources/zeros_filter.py
@@ -25,7 +25,7 @@ def drop_all_zero_timeseries(
     locations with a population over some threshold. Or perhaps an automatic filter isn't worth
     the trouble after all :-(
     """
-    ts_wide = ds_in.timeseries_wide_dates_no_buckets
+    ts_wide = ds_in.timeseries_not_bucketed_wide_dates
 
     # Separate into timeseries in `fields` and all others.
     variable_mask = ts_wide.index.get_level_values(PdFields.VARIABLE).isin(fields)

--- a/libs/datasets/sources/zeros_filter.py
+++ b/libs/datasets/sources/zeros_filter.py
@@ -25,7 +25,7 @@ def drop_all_zero_timeseries(
     locations with a population over some threshold. Or perhaps an automatic filter isn't worth
     the trouble after all :-(
     """
-    ts_wide = ds_in.timeseries_wide_dates()
+    ts_wide = ds_in.timeseries_wide_dates_no_buckets()
 
     # Separate into timeseries in `fields` and all others.
     variable_mask = ts_wide.index.get_level_values(PdFields.VARIABLE).isin(fields)

--- a/libs/datasets/sources/zeros_filter.py
+++ b/libs/datasets/sources/zeros_filter.py
@@ -25,7 +25,7 @@ def drop_all_zero_timeseries(
     locations with a population over some threshold. Or perhaps an automatic filter isn't worth
     the trouble after all :-(
     """
-    ts_wide = ds_in.timeseries_wide_dates_no_buckets()
+    ts_wide = ds_in.timeseries_wide_dates_no_buckets
 
     # Separate into timeseries in `fields` and all others.
     variable_mask = ts_wide.index.get_level_values(PdFields.VARIABLE).isin(fields)

--- a/libs/datasets/tail_filter.py
+++ b/libs/datasets/tail_filter.py
@@ -39,7 +39,7 @@ class TailFilter:
         dataset: timeseries.MultiRegionDataset, fields: List[FieldName]
     ) -> Tuple["TailFilter", timeseries.MultiRegionDataset]:
         """Returns a dataset with recent data that looks bad removed from cumulative fields."""
-        timeseries_wide_dates = dataset.timeseries_wide_dates_no_buckets()
+        timeseries_wide_dates = dataset.timeseries_wide_dates_no_buckets
 
         fields_mask = timeseries_wide_dates.index.get_level_values(PdFields.VARIABLE).isin(fields)
         to_filter = timeseries_wide_dates.loc[pd.IndexSlice[:, fields_mask], :]

--- a/libs/datasets/tail_filter.py
+++ b/libs/datasets/tail_filter.py
@@ -39,7 +39,7 @@ class TailFilter:
         dataset: timeseries.MultiRegionDataset, fields: List[FieldName]
     ) -> Tuple["TailFilter", timeseries.MultiRegionDataset]:
         """Returns a dataset with recent data that looks bad removed from cumulative fields."""
-        timeseries_wide_dates = dataset.timeseries_wide_dates_no_buckets
+        timeseries_wide_dates = dataset.timeseries_not_bucketed_wide_dates
 
         fields_mask = timeseries_wide_dates.index.get_level_values(PdFields.VARIABLE).isin(fields)
         to_filter = timeseries_wide_dates.loc[pd.IndexSlice[:, fields_mask], :]

--- a/libs/datasets/tail_filter.py
+++ b/libs/datasets/tail_filter.py
@@ -39,7 +39,7 @@ class TailFilter:
         dataset: timeseries.MultiRegionDataset, fields: List[FieldName]
     ) -> Tuple["TailFilter", timeseries.MultiRegionDataset]:
         """Returns a dataset with recent data that looks bad removed from cumulative fields."""
-        timeseries_wide_dates = dataset.timeseries_wide_dates()
+        timeseries_wide_dates = dataset.timeseries_wide_dates_no_buckets()
 
         fields_mask = timeseries_wide_dates.index.get_level_values(PdFields.VARIABLE).isin(fields)
         to_filter = timeseries_wide_dates.loc[pd.IndexSlice[:, fields_mask], :]

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -283,10 +283,21 @@ EMPTY_REGIONAL_ATTRIBUTES_DF = pd.DataFrame([], index=pd.Index([], name=CommonFi
 
 # An empty DataFrame with the expected index names for a timeseries with row labels <location_id,
 # variable> and column labels <date>.
-EMPTY_TIMESERIES_WIDE_DATES_DF = pd.DataFrame(
+EMPTY_TIMESERIES_NOT_BUCKETED_WIDE_DATES_DF = pd.DataFrame(
     [],
     dtype="float",
     index=pd.MultiIndex.from_tuples([], names=[CommonFields.LOCATION_ID, PdFields.VARIABLE]),
+    columns=pd.DatetimeIndex([], name=CommonFields.DATE),
+)
+
+# An empty DataFrame with the expected index names for a timeseries with row labels <location_id,
+# variable, bucket> and column labels <date>.
+EMPTY_TIMESERIES_BUCKETED_WIDE_DATES_DF = pd.DataFrame(
+    [],
+    dtype="float",
+    index=pd.MultiIndex.from_tuples(
+        [], names=[CommonFields.LOCATION_ID, PdFields.VARIABLE, PdFields.DEMOGRAPHIC_BUCKET]
+    ),
     columns=pd.DatetimeIndex([], name=CommonFields.DATE),
 )
 
@@ -440,14 +451,15 @@ class MultiRegionDataset:
         return self.timeseries_bucketed.stack(dropna=True).rename(PdFields.VALUE).sort_index()
 
     @cached_property
-    def timeseries_wide_dates_no_buckets(self) -> pd.DataFrame:
-        """Returns the timeseries in a DataFrame with LOCATION_ID, VARIABLE index and DATE columns."""
-        if self.timeseries.empty:
-            return EMPTY_TIMESERIES_WIDE_DATES_DF
-        timeseries_long = self._timeseries_long()
-        dates = timeseries_long.index.get_level_values(CommonFields.DATE)
+    def timeseries_bucketed_wide_dates(self) -> pd.DataFrame:
+        """Returns the timeseries in a DataFrame with LOCATION_ID, VARIABLE, BUCKET index and DATE
+        columns."""
+        if self.timeseries_bucketed.empty:
+            return EMPTY_TIMESERIES_BUCKETED_WIDE_DATES_DF
+        timeseries_long = self.timeseries_bucketed_long
+        dates = timeseries_long.index.unique(CommonFields.DATE)
         if dates.empty:
-            return EMPTY_TIMESERIES_WIDE_DATES_DF
+            return EMPTY_TIMESERIES_BUCKETED_WIDE_DATES_DF
         start_date = dates.min()
         end_date = dates.max()
         date_range = pd.date_range(start=start_date, end=end_date)
@@ -459,6 +471,16 @@ class MultiRegionDataset:
         if not timeseries_wide.columns.is_all_dates:
             raise ValueError(f"Problem with {start_date} to {end_date}... {str(self.timeseries)}")
         return timeseries_wide
+
+    @cached_property
+    def timeseries_not_bucketed_wide_dates(self) -> pd.DataFrame:
+        """Returns the timeseries in a DataFrame with LOCATION_ID, VARIABLE index and DATE columns."""
+        try:
+            return self.timeseries_bucketed_wide_dates.xs(
+                "all", level=PdFields.DEMOGRAPHIC_BUCKET, axis=0
+            )
+        except KeyError:
+            return EMPTY_TIMESERIES_NOT_BUCKETED_WIDE_DATES_DF
 
     def _timeseries_latest_values(self) -> pd.DataFrame:
         """Returns the latest value for every region and metric, derived from timeseries."""
@@ -564,7 +586,7 @@ class MultiRegionDataset:
         """Returns a new object with given provenance string for every timeseries."""
         return self.add_provenance_series(
             pd.Series([], dtype=str, name=PdFields.PROVENANCE).reindex(
-                self.timeseries_wide_dates_no_buckets.index, fill_value=provenance
+                self.timeseries_not_bucketed_wide_dates.index, fill_value=provenance
             )
         )
 
@@ -572,7 +594,7 @@ class MultiRegionDataset:
         """Returns a new object with given tag copied for every timeseries."""
         tag_df = pd.DataFrame(
             {taglib.TagField.CONTENT: tag.content, taglib.TagField.TYPE: tag.tag_type},
-            index=self.timeseries_wide_dates_no_buckets.index,
+            index=self.timeseries_not_bucketed_wide_dates.index,
         ).reset_index()
         return self.append_tag_df(tag_df)
 
@@ -858,7 +880,7 @@ class MultiRegionDataset:
         """Returns a DataFrame containing timeseries values and tag, suitable for writing
         to a CSV."""
         # Make a copy to avoid modifying the cached DataFrame
-        wide_dates = self.timeseries_wide_dates_no_buckets.copy()
+        wide_dates = self.timeseries_not_bucketed_wide_dates.copy()
         # Format as a string here because to_csv includes a full timestamp.
         wide_dates.columns = wide_dates.columns.strftime("%Y-%m-%d")
         # When I look at the CSV I'm usually looking for the most recent values so reverse the
@@ -887,7 +909,7 @@ class MultiRegionDataset:
 
     def drop_stale_timeseries(self, cutoff_date: datetime.date) -> "MultiRegionDataset":
         """Returns a new object containing only timeseries with a real value on or after cutoff_date."""
-        ts = self.timeseries_wide_dates_no_buckets
+        ts = self.timeseries_not_bucketed_wide_dates
         recent_columns_mask = ts.columns >= cutoff_date
         recent_rows_mask = ts.loc[:, recent_columns_mask].notna().any(axis=1)
         timeseries_wide_dates = ts.loc[recent_rows_mask, :]
@@ -1051,7 +1073,7 @@ def _to_datasets_wide_dates_map(
 
     The mapping depends on MultiRegionDataset being hashable by id.
     """
-    datasets_wide = {ds: ds.timeseries_wide_dates_no_buckets for ds in datasets}
+    datasets_wide = {ds: ds.timeseries_not_bucketed_wide_dates for ds in datasets}
     if not datasets_wide:
         return {}
     # Find the earliest and latest dates to make a range covering all timeseries.

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -440,7 +440,7 @@ class MultiRegionDataset:
         return self.timeseries_bucketed.stack(dropna=True).rename(PdFields.VALUE).sort_index()
 
     @lru_cache(maxsize=None)
-    def timeseries_wide_dates(self) -> pd.DataFrame:
+    def timeseries_wide_dates_no_buckets(self) -> pd.DataFrame:
         """Returns the timeseries in a DataFrame with LOCATION_ID, VARIABLE index and DATE columns."""
         if self.timeseries.empty:
             return EMPTY_TIMESERIES_WIDE_DATES_DF
@@ -564,7 +564,7 @@ class MultiRegionDataset:
         """Returns a new object with given provenance string for every timeseries."""
         return self.add_provenance_series(
             pd.Series([], dtype=str, name=PdFields.PROVENANCE).reindex(
-                self.timeseries_wide_dates().index, fill_value=provenance
+                self.timeseries_wide_dates_no_buckets().index, fill_value=provenance
             )
         )
 
@@ -572,7 +572,7 @@ class MultiRegionDataset:
         """Returns a new object with given tag copied for every timeseries."""
         tag_df = pd.DataFrame(
             {taglib.TagField.CONTENT: tag.content, taglib.TagField.TYPE: tag.tag_type},
-            index=self.timeseries_wide_dates().index,
+            index=self.timeseries_wide_dates_no_buckets().index,
         ).reset_index()
         return self.append_tag_df(tag_df)
 
@@ -858,7 +858,7 @@ class MultiRegionDataset:
         """Returns a DataFrame containing timeseries values and tag, suitable for writing
         to a CSV."""
         # Make a copy to avoid modifying the cached DataFrame
-        wide_dates = self.timeseries_wide_dates().copy()
+        wide_dates = self.timeseries_wide_dates_no_buckets().copy()
         # Format as a string here because to_csv includes a full timestamp.
         wide_dates.columns = wide_dates.columns.strftime("%Y-%m-%d")
         # When I look at the CSV I'm usually looking for the most recent values so reverse the
@@ -887,7 +887,7 @@ class MultiRegionDataset:
 
     def drop_stale_timeseries(self, cutoff_date: datetime.date) -> "MultiRegionDataset":
         """Returns a new object containing only timeseries with a real value on or after cutoff_date."""
-        ts = self.timeseries_wide_dates()
+        ts = self.timeseries_wide_dates_no_buckets()
         recent_columns_mask = ts.columns >= cutoff_date
         recent_rows_mask = ts.loc[:, recent_columns_mask].notna().any(axis=1)
         timeseries_wide_dates = ts.loc[recent_rows_mask, :]
@@ -1051,7 +1051,7 @@ def _to_datasets_wide_dates_map(
 
     The mapping depends on MultiRegionDataset being hashable by id.
     """
-    datasets_wide = {ds: ds.timeseries_wide_dates() for ds in datasets}
+    datasets_wide = {ds: ds.timeseries_wide_dates_no_buckets() for ds in datasets}
     if not datasets_wide:
         return {}
     # Find the earliest and latest dates to make a range covering all timeseries.

--- a/libs/datasets/vaccine_backfills.py
+++ b/libs/datasets/vaccine_backfills.py
@@ -17,7 +17,7 @@ def derive_vaccine_pct(ds_in: MultiRegionDataset) -> MultiRegionDataset:
         CommonFields.VACCINATIONS_INITIATED: CommonFields.VACCINATIONS_INITIATED_PCT,
         CommonFields.VACCINATIONS_COMPLETED: CommonFields.VACCINATIONS_COMPLETED_PCT,
     }
-    ds_in_wide_dates = ds_in.timeseries_wide_dates_no_buckets
+    ds_in_wide_dates = ds_in.timeseries_not_bucketed_wide_dates
     ds_in_wide_dates = ds_in_wide_dates.loc[
         ds_in_wide_dates.index.get_level_values(PdFields.VARIABLE).isin(field_map.keys())
     ]
@@ -62,7 +62,7 @@ def backfill_vaccination_initiated(dataset: MultiRegionDataset) -> MultiRegionDa
         CommonFields.VACCINATIONS_INITIATED,
         CommonFields.VACCINATIONS_COMPLETED,
     ]
-    df = dataset.timeseries_wide_dates_no_buckets.loc[(slice(None), fields), :]
+    df = dataset.timeseries_not_bucketed_wide_dates.loc[(slice(None), fields), :]
     df_var_first = df.reorder_levels([PdFields.VARIABLE, CommonFields.LOCATION_ID])
 
     administered = df_var_first.loc[CommonFields.VACCINES_ADMINISTERED]

--- a/libs/datasets/vaccine_backfills.py
+++ b/libs/datasets/vaccine_backfills.py
@@ -17,7 +17,7 @@ def derive_vaccine_pct(ds_in: MultiRegionDataset) -> MultiRegionDataset:
         CommonFields.VACCINATIONS_INITIATED: CommonFields.VACCINATIONS_INITIATED_PCT,
         CommonFields.VACCINATIONS_COMPLETED: CommonFields.VACCINATIONS_COMPLETED_PCT,
     }
-    ds_in_wide_dates = ds_in.timeseries_wide_dates()
+    ds_in_wide_dates = ds_in.timeseries_wide_dates_no_buckets()
     ds_in_wide_dates = ds_in_wide_dates.loc[
         ds_in_wide_dates.index.get_level_values(PdFields.VARIABLE).isin(field_map.keys())
     ]
@@ -62,7 +62,7 @@ def backfill_vaccination_initiated(dataset: MultiRegionDataset) -> MultiRegionDa
         CommonFields.VACCINATIONS_INITIATED,
         CommonFields.VACCINATIONS_COMPLETED,
     ]
-    df = dataset.timeseries_wide_dates().loc[(slice(None), fields), :]
+    df = dataset.timeseries_wide_dates_no_buckets().loc[(slice(None), fields), :]
     df_var_first = df.reorder_levels([PdFields.VARIABLE, CommonFields.LOCATION_ID])
 
     administered = df_var_first.loc[CommonFields.VACCINES_ADMINISTERED]

--- a/libs/datasets/vaccine_backfills.py
+++ b/libs/datasets/vaccine_backfills.py
@@ -17,7 +17,7 @@ def derive_vaccine_pct(ds_in: MultiRegionDataset) -> MultiRegionDataset:
         CommonFields.VACCINATIONS_INITIATED: CommonFields.VACCINATIONS_INITIATED_PCT,
         CommonFields.VACCINATIONS_COMPLETED: CommonFields.VACCINATIONS_COMPLETED_PCT,
     }
-    ds_in_wide_dates = ds_in.timeseries_wide_dates_no_buckets()
+    ds_in_wide_dates = ds_in.timeseries_wide_dates_no_buckets
     ds_in_wide_dates = ds_in_wide_dates.loc[
         ds_in_wide_dates.index.get_level_values(PdFields.VARIABLE).isin(field_map.keys())
     ]
@@ -62,7 +62,7 @@ def backfill_vaccination_initiated(dataset: MultiRegionDataset) -> MultiRegionDa
         CommonFields.VACCINATIONS_INITIATED,
         CommonFields.VACCINATIONS_COMPLETED,
     ]
-    df = dataset.timeseries_wide_dates_no_buckets().loc[(slice(None), fields), :]
+    df = dataset.timeseries_wide_dates_no_buckets.loc[(slice(None), fields), :]
     df_var_first = df.reorder_levels([PdFields.VARIABLE, CommonFields.LOCATION_ID])
 
     administered = df_var_first.loc[CommonFields.VACCINES_ADMINISTERED]

--- a/libs/metrics/test_positivity.py
+++ b/libs/metrics/test_positivity.py
@@ -169,7 +169,7 @@ class DivisionMethod(Method, _DivisionMethodAttributes):
         self, dataset: MultiRegionDataset, diff_days: int, most_recent_date: pd.Timestamp
     ) -> MethodOutput:
         delta_df = (
-            dataset.timeseries_wide_dates()
+            dataset.timeseries_wide_dates_no_buckets()
             .reorder_levels([PdFields.VARIABLE, CommonFields.LOCATION_ID])
             .diff(periods=diff_days, axis=1)
         )
@@ -213,7 +213,7 @@ class PassThruMethod(Method, _PassThruMethodAttributes):
     def calculate(
         self, dataset: MultiRegionDataset, diff_days: int, most_recent_date: pd.Timestamp
     ) -> MethodOutput:
-        df = dataset.timeseries_wide_dates().reorder_levels(
+        df = dataset.timeseries_wide_dates_no_buckets().reorder_levels(
             [PdFields.VARIABLE, CommonFields.LOCATION_ID]
         )
         assert df.columns.names == [CommonFields.DATE]
@@ -340,7 +340,7 @@ class AllMethods:
         if not relevant_columns:
             raise NoMethodsWithRelevantColumns()
 
-        input_wide = dataset_in.timeseries_wide_dates()
+        input_wide = dataset_in.timeseries_wide_dates_no_buckets()
         if input_wide.empty:
             raise NoRealTimeseriesValuesException()
         dates = input_wide.columns.get_level_values(CommonFields.DATE)

--- a/libs/metrics/test_positivity.py
+++ b/libs/metrics/test_positivity.py
@@ -168,7 +168,7 @@ class DivisionMethod(Method, _DivisionMethodAttributes):
     def calculate(
         self, dataset: MultiRegionDataset, diff_days: int, most_recent_date: pd.Timestamp
     ) -> MethodOutput:
-        delta_df = dataset.timeseries_wide_dates_no_buckets.reorder_levels(
+        delta_df = dataset.timeseries_not_bucketed_wide_dates.reorder_levels(
             [PdFields.VARIABLE, CommonFields.LOCATION_ID]
         ).diff(periods=diff_days, axis=1)
         assert delta_df.columns.names == [CommonFields.DATE]
@@ -211,7 +211,7 @@ class PassThruMethod(Method, _PassThruMethodAttributes):
     def calculate(
         self, dataset: MultiRegionDataset, diff_days: int, most_recent_date: pd.Timestamp
     ) -> MethodOutput:
-        df = dataset.timeseries_wide_dates_no_buckets.reorder_levels(
+        df = dataset.timeseries_not_bucketed_wide_dates.reorder_levels(
             [PdFields.VARIABLE, CommonFields.LOCATION_ID]
         )
         assert df.columns.names == [CommonFields.DATE]
@@ -338,7 +338,7 @@ class AllMethods:
         if not relevant_columns:
             raise NoMethodsWithRelevantColumns()
 
-        input_wide = dataset_in.timeseries_wide_dates_no_buckets
+        input_wide = dataset_in.timeseries_not_bucketed_wide_dates
         if input_wide.empty:
             raise NoRealTimeseriesValuesException()
         dates = input_wide.columns.get_level_values(CommonFields.DATE)

--- a/libs/metrics/test_positivity.py
+++ b/libs/metrics/test_positivity.py
@@ -168,11 +168,9 @@ class DivisionMethod(Method, _DivisionMethodAttributes):
     def calculate(
         self, dataset: MultiRegionDataset, diff_days: int, most_recent_date: pd.Timestamp
     ) -> MethodOutput:
-        delta_df = (
-            dataset.timeseries_wide_dates_no_buckets()
-            .reorder_levels([PdFields.VARIABLE, CommonFields.LOCATION_ID])
-            .diff(periods=diff_days, axis=1)
-        )
+        delta_df = dataset.timeseries_wide_dates_no_buckets.reorder_levels(
+            [PdFields.VARIABLE, CommonFields.LOCATION_ID]
+        ).diff(periods=diff_days, axis=1)
         assert delta_df.columns.names == [CommonFields.DATE]
         assert delta_df.index.names == [PdFields.VARIABLE, CommonFields.LOCATION_ID]
         # delta_df has the field name as the first level of the index. delta_df.loc[field, :] returns a
@@ -213,7 +211,7 @@ class PassThruMethod(Method, _PassThruMethodAttributes):
     def calculate(
         self, dataset: MultiRegionDataset, diff_days: int, most_recent_date: pd.Timestamp
     ) -> MethodOutput:
-        df = dataset.timeseries_wide_dates_no_buckets().reorder_levels(
+        df = dataset.timeseries_wide_dates_no_buckets.reorder_levels(
             [PdFields.VARIABLE, CommonFields.LOCATION_ID]
         )
         assert df.columns.names == [CommonFields.DATE]
@@ -340,7 +338,7 @@ class AllMethods:
         if not relevant_columns:
             raise NoMethodsWithRelevantColumns()
 
-        input_wide = dataset_in.timeseries_wide_dates_no_buckets()
+        input_wide = dataset_in.timeseries_wide_dates_no_buckets
         if input_wide.empty:
             raise NoRealTimeseriesValuesException()
         dates = input_wide.columns.get_level_values(CommonFields.DATE)

--- a/tests/libs/datasets/timeseries_test.py
+++ b/tests/libs/datasets/timeseries_test.py
@@ -393,7 +393,7 @@ def test_timeseries_wide_dates():
         )
     )
 
-    ds_wide = ds.timeseries_wide_dates()
+    ds_wide = ds.timeseries_wide_dates_no_buckets()
     assert ds_wide.index.names == [CommonFields.LOCATION_ID, PdFields.VARIABLE]
     assert ds_wide.columns.names == [CommonFields.DATE]
 
@@ -429,7 +429,7 @@ def test_timeseries_wide_dates_empty():
         )
     )
 
-    timeseries_wide = ts.timeseries_wide_dates()
+    timeseries_wide = ts.timeseries_wide_dates_no_buckets()
     assert timeseries_wide.index.names == [CommonFields.LOCATION_ID, PdFields.VARIABLE]
     assert timeseries_wide.columns.names == [CommonFields.DATE]
     assert timeseries_wide.empty

--- a/tests/libs/datasets/timeseries_test.py
+++ b/tests/libs/datasets/timeseries_test.py
@@ -346,6 +346,7 @@ def test_append_regions_duplicate_region_raises():
 
 
 def test_timeseries_long():
+    """Test timeseries_long where all data has bucket `all`"""
     region_cbsa = Region.from_cbsa_code("10100")
     region_county = Region.from_fips("97111")
     ds = test_helpers.build_dataset(
@@ -358,24 +359,71 @@ def test_timeseries_long():
 
     expected = pd.read_csv(
         io.StringIO(
-            "location_id,date,variable,value\n"
-            "iso1:us#cbsa:10100,2020-04-02,m2,2\n"
-            "iso1:us#cbsa:10100,2020-04-03,m2,3\n"
-            "iso1:us#fips:97111,2020-04-02,m1,2\n"
-            "iso1:us#fips:97111,2020-04-04,m1,4\n"
+            "       location_id,      date,variable,value\n"
+            "iso1:us#cbsa:10100,2020-04-02,      m2,    2\n"
+            "iso1:us#cbsa:10100,2020-04-03,      m2,    3\n"
+            "iso1:us#fips:97111,2020-04-02,      m1,    2\n"
+            "iso1:us#fips:97111,2020-04-04,      m1,    4\n".replace(" ", "")
         ),
         parse_dates=[CommonFields.DATE],
         dtype={"value": float},
     )
-    long_series = ds._timeseries_long()
+    long_series = ds.timeseries_bucketed_long
     assert long_series.index.names == [
         CommonFields.LOCATION_ID,
+        PdFields.DEMOGRAPHIC_BUCKET,
         CommonFields.DATE,
         PdFields.VARIABLE,
     ]
     assert long_series.name == PdFields.VALUE
-    long_df = long_series.reset_index()
+    long_df = long_series.xs("all", level=PdFields.DEMOGRAPHIC_BUCKET).reset_index()
     pd.testing.assert_frame_equal(long_df, expected, check_like=True)
+
+
+def test_timeseries_bucketed_long():
+    region_cbsa = Region.from_cbsa_code("10100")
+    region_county = Region.from_fips("97111")
+    bucket_age_0 = DemographicBucket("age:0-9")
+    bucket_age_10 = DemographicBucket("age:10-19")
+    bucket_all = DemographicBucket("all")
+    ds = test_helpers.build_dataset(
+        {
+            region_county: {
+                FieldName("m1"): {
+                    bucket_age_0: [4, 5, 6],
+                    bucket_age_10: [None, None, 7],
+                    bucket_all: [2, None, 4],
+                }
+            },
+            region_cbsa: {FieldName("m2"): [2, 3, None]},
+        },
+        start_date="2020-04-02",
+    )
+
+    expected = pd.read_csv(
+        io.StringIO(
+            "       location_id,demographic_bucket,      date,variable,value\n"
+            "iso1:us#cbsa:10100,               all,2020-04-02,      m2,    2\n"
+            "iso1:us#cbsa:10100,               all,2020-04-03,      m2,    3\n"
+            "iso1:us#fips:97111,           age:0-9,2020-04-02,      m1,    4\n"
+            "iso1:us#fips:97111,           age:0-9,2020-04-03,      m1,    5\n"
+            "iso1:us#fips:97111,           age:0-9,2020-04-04,      m1,    6\n"
+            "iso1:us#fips:97111,         age:10-19,2020-04-04,      m1,    7\n"
+            "iso1:us#fips:97111,               all,2020-04-02,      m1,    2\n"
+            "iso1:us#fips:97111,               all,2020-04-04,      m1,    4\n".replace(" ", "")
+        ),
+        parse_dates=[CommonFields.DATE],
+        dtype={"value": float},
+    )
+    long_series = ds.timeseries_bucketed_long
+    assert long_series.index.names == [
+        CommonFields.LOCATION_ID,
+        PdFields.DEMOGRAPHIC_BUCKET,
+        CommonFields.DATE,
+        PdFields.VARIABLE,
+    ]
+    assert long_series.name == PdFields.VALUE
+    pd.testing.assert_frame_equal(long_series.reset_index(), expected, check_like=True)
 
 
 def test_timeseries_wide_dates():

--- a/tests/libs/datasets/timeseries_test.py
+++ b/tests/libs/datasets/timeseries_test.py
@@ -393,7 +393,7 @@ def test_timeseries_wide_dates():
         )
     )
 
-    ds_wide = ds.timeseries_wide_dates_no_buckets()
+    ds_wide = ds.timeseries_wide_dates_no_buckets
     assert ds_wide.index.names == [CommonFields.LOCATION_ID, PdFields.VARIABLE]
     assert ds_wide.columns.names == [CommonFields.DATE]
 
@@ -429,7 +429,7 @@ def test_timeseries_wide_dates_empty():
         )
     )
 
-    timeseries_wide = ts.timeseries_wide_dates_no_buckets()
+    timeseries_wide = ts.timeseries_wide_dates_no_buckets
     assert timeseries_wide.index.names == [CommonFields.LOCATION_ID, PdFields.VARIABLE]
     assert timeseries_wide.columns.names == [CommonFields.DATE]
     assert timeseries_wide.empty


### PR DESCRIPTION
This PR is part of https://trello.com/c/lvRFxC5y/932-get-dei-vaccination-data-into-api. It makes bucketed and not bucketed more explicit.

* Changes method `timeseries_wide_dates()` to property `timeseries_not_bucketed_wide_dates` and adds `timeseries_bucketed_wide_dates` which will gradually replace it.
* Changes `test_timeseries_long` to use test_helpers instead of CSV in a string to create input dataset
* Removes unused `_timeseries_long`

## Tested

`./run.py data update` produced identical output.