### PR TITLE
add support for reading and writing with bucket.

### DIFF
--- a/dash_app/dashboard.py
+++ b/dash_app/dashboard.py
@@ -31,7 +31,12 @@ EXTERNAL_STYLESHEETS = ["https://codepen.io/chriddyp/pen/bWLwgP.css"]
 
 # These columns match the OneRegion tag attribute. Unlike timeseries.TAG_INDEX_FIELDS it does
 # not contain LOCATION_ID.
-TAG_TABLE_COLUMNS = [TagField.VARIABLE, TagField.TYPE, TagField.CONTENT]
+TAG_TABLE_COLUMNS = [
+    TagField.VARIABLE,
+    TagField.DEMOGRAPHIC_BUCKET,
+    TagField.TYPE,
+    TagField.CONTENT,
+]
 
 
 # TODO(tom): Move all the aggregation and statistics stuff to a different module and test it.

--- a/libs/datasets/tail_filter.py
+++ b/libs/datasets/tail_filter.py
@@ -19,7 +19,7 @@ TagField = taglib.TagField
 # The Series.name in apply is a tuple copied from the index. Make an assert fail when the index
 # names change so we know to update access to the tuple elements.
 # https://stackoverflow.com/questions/26658240/getting-the-index-of-a-row-in-a-pandas-apply-function
-_EXPECTED_INDEX_NAMES = [CommonFields.LOCATION_ID, PdFields.DEMOGRAPHIC_BUCKET, PdFields.VARIABLE]
+_EXPECTED_INDEX_NAMES = [CommonFields.LOCATION_ID, PdFields.VARIABLE, PdFields.DEMOGRAPHIC_BUCKET]
 
 
 @dataclasses.dataclass
@@ -132,8 +132,8 @@ class TailFilter:
                 ),
                 # `name` is a tuple with elements _EXPECTED_INDEX_NAMES
                 location_id=series_in.name[0],
-                variable=series_in.name[2],
-                bucket=series_in.name[1],
+                variable=series_in.name[1],
+                bucket=series_in.name[2],
             )
             # TODO(tom): add count of removed observations or list of all removed or one
             #  annotation per removed observations

--- a/tests/libs/datasets/timeseries_test.py
+++ b/tests/libs/datasets/timeseries_test.py
@@ -511,6 +511,8 @@ def test_write_read_wide_dates_csv_compare_literal(tmpdir):
     dataset_read = timeseries.MultiRegionDataset.read_from_pointer(pointer)
     test_helpers.assert_dataset_like(dataset_read, dataset_in)
 
+    # Check that a file without the demographic_bucket column (as written before
+    # https://github.com/covid-projections/covid-data-model/pull/1021) can be read.
     pointer.path_wide_dates().write_text(
         "                  location_id,variable,provenance,2020-04-03,2020-04-02,2020-04-01\n"
         "           iso1:us#iso2:us-as,   cases,          ,       300,       200,       100\n"
@@ -562,6 +564,39 @@ def test_write_read_dataset_pointer_with_provenance_list(tmpdir):
             CommonFields.CASES: [100, 200, 300],
         }
     )
+
+    dataset_in.write_to_dataset_pointer(pointer)
+    dataset_read = timeseries.MultiRegionDataset.read_from_pointer(pointer)
+
+    test_helpers.assert_dataset_like(dataset_read, dataset_in)
+
+
+def test_write_read_wide_with_buckets(tmpdir):
+    pointer = _make_dataset_pointer(tmpdir)
+
+    all_bucket = DemographicBucket("all")
+    age_20s = DemographicBucket("age:20-29")
+    age_30s = DemographicBucket("age:30-39")
+    region_as = Region.from_state("AS")
+    region_sf = Region.from_fips("06075")
+    metrics_as = {
+        CommonFields.ICU_BEDS: TimeseriesLiteral(
+            [0, 2, 4],
+            annotation=[
+                test_helpers.make_tag(date="2020-04-01"),
+                test_helpers.make_tag(TagType.ZSCORE_OUTLIER, date="2020-04-02"),
+            ],
+        ),
+        CommonFields.CASES: [100, 200, 300],
+    }
+    metrics_sf = {
+        CommonFields.CASES: {
+            age_20s: TimeseriesLiteral([3, 4, 5], source=taglib.Source(type="MySource")),
+            age_30s: [4, 5, 6],
+            all_bucket: [1, 2, 3],
+        }
+    }
+    dataset_in = test_helpers.build_dataset({region_as: metrics_as, region_sf: metrics_sf})
 
     dataset_in.write_to_dataset_pointer(pointer)
     dataset_read = timeseries.MultiRegionDataset.read_from_pointer(pointer)


### PR DESCRIPTION
This PR is part of https://trello.com/c/lvRFxC5y/932-get-dei-vaccination-data-into-api.

* Changes `timeseries_bucketed_wide_dates` to return bucket as inner/right index level to be more consistent with idea that a set of time-series form a distribution within one metric/variable.
* Changes `read_from_pointer` to load the bucket if the column is present and assume `all` if not
* Changes `timeseries_rows` (which is called by `write_to_dataset_pointer`) to include bucket in the index

## Tested

`./run.py data update` adds demographic_bucket column always containing "all". 

Confirmed that nothing else changed with
```
mv data/multiregion-wide-dates.csv data/multiregion-wide-dates-demo.csv
csvcut -C demographic_bucket data/multiregion-wide-dates-demo.csv | perl -np -e 's/,+$//' > data/multiregion-wide-dates.csv
git status
```