### PR TITLE
print bucket stats, fix zeros filter

### DIFF
--- a/libs/datasets/data_source.py
+++ b/libs/datasets/data_source.py
@@ -114,8 +114,6 @@ class CanScraperBase(DataSource, abc.ABC, metaclass=_CanScraperBaseMeta):
             log_provider_coverage_warnings=True,
             source_type=cls.SOURCE_TYPE,
         )
-        # TODO(tom): Once downstream can handle it return all buckets, not just 'all'.
-        rows = rows.xs("all", level=PdFields.DEMOGRAPHIC_BUCKET, drop_level=False)
         data = rows.unstack(PdFields.VARIABLE)
         data = cls._check_data(data)
         ds = MultiRegionDataset(timeseries_bucketed=data)

--- a/libs/datasets/sources/zeros_filter.py
+++ b/libs/datasets/sources/zeros_filter.py
@@ -25,7 +25,7 @@ def drop_all_zero_timeseries(
     locations with a population over some threshold. Or perhaps an automatic filter isn't worth
     the trouble after all :-(
     """
-    ts_wide = ds_in.timeseries_not_bucketed_wide_dates
+    ts_wide = ds_in.timeseries_bucketed_wide_dates
 
     # Separate into timeseries in `fields` and all others.
     variable_mask = ts_wide.index.get_level_values(PdFields.VARIABLE).isin(fields)
@@ -49,7 +49,5 @@ def drop_all_zero_timeseries(
     # be cleaner to add a method 'MultiRegionDataset.drop_timeseries' similar to 'remove_regions' or
     # move this into 'MultiRegionDataset' similar to 'drop_stale_timeseries'.
     return dataclasses.replace(
-        ds_in,
-        timeseries=ts_wide_out.stack().unstack(PdFields.VARIABLE).sort_index(),
-        timeseries_bucketed=None,
+        ds_in, timeseries_bucketed=ts_wide_out.stack().unstack(PdFields.VARIABLE).sort_index(),
     )

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -526,6 +526,14 @@ class MultiRegionDataset:
             raise ValueError(f"Problem with {start_date} to {end_date}... {str(self.timeseries)}")
         return timeseries_wide
 
+    def print_stats(self, name: str):
+        buckets = self.timeseries_bucketed_long.index.get_level_values(PdFields.DEMOGRAPHIC_BUCKET)
+        all_bucket_count = (buckets == DemographicBucket.ALL).sum()
+        print(
+            f"Dataset {name}:\nBucket count 'all':{all_bucket_count}\nOthers:"
+            f"{len(buckets) - all_bucket_count}"
+        )
+
     @cached_property
     def timeseries_not_bucketed_wide_dates(self) -> pd.DataFrame:
         """Returns the timeseries in a DataFrame with LOCATION_ID, VARIABLE index and DATE columns."""

--- a/tests/libs/datasets/sources/can_scraper_helpers_test.py
+++ b/tests/libs/datasets/sources/can_scraper_helpers_test.py
@@ -10,6 +10,7 @@ from typing import Union
 import pytest
 from covidactnow.datapublic.common_fields import CommonFields
 import pandas as pd
+from covidactnow.datapublic.common_fields import DemographicBucket
 
 from libs.datasets import data_source
 from libs.datasets import taglib
@@ -151,7 +152,14 @@ def test_query_multiple_variables_with_ethnicity():
 
     cases = TimeseriesLiteral([100, 100], source=taglib.Source(type="MySource"))
     expected_ds = test_helpers.build_default_region_dataset(
-        {CommonFields.CASES: cases}, region=Region.from_fips("36"),
+        {
+            CommonFields.CASES: {
+                # bucket="all" has a taglib.Source with it; other buckets have only the numbers
+                DemographicBucket.ALL: cases,
+                DemographicBucket("ethnicity:hispanic"): [40, 40],
+            }
+        },
+        region=Region.from_fips("36"),
     )
 
     test_helpers.assert_dataset_like(ds, expected_ds)

--- a/tests/libs/datasets/timeseries_test.py
+++ b/tests/libs/datasets/timeseries_test.py
@@ -1570,3 +1570,28 @@ def test_combine_demographic_data_multiple_distributions():
         }
     )
     test_helpers.assert_dataset_like(combined, ds_expected)
+
+
+def test_print_stats():
+    all_bucket = DemographicBucket("all")
+    age_20s = DemographicBucket("age:20-29")
+    age_30s = DemographicBucket("age:30-39")
+
+    test_helpers.build_default_region_dataset(
+        {
+            CommonFields.ICU_BEDS: TimeseriesLiteral(
+                [0, 2, 4], annotation=[test_helpers.make_tag(date="2020-04-01"),],
+            ),
+            CommonFields.CASES: [100, 200, 300],
+        }
+    ).print_stats("DS1")
+
+    test_helpers.build_default_region_dataset(
+        {
+            CommonFields.CASES: {
+                age_20s: TimeseriesLiteral([3, 4, 5], source=taglib.Source(type="MySource")),
+                age_30s: [4, 5, 6],
+                all_bucket: [1, 2, 3],
+            }
+        }
+    ).print_stats("DS2")

--- a/tests/libs/datasets/zeros_filter_test.py
+++ b/tests/libs/datasets/zeros_filter_test.py
@@ -42,8 +42,8 @@ def test_basic():
     assert log["event"] == zeros_filter.DROPPING_TIMESERIES_WITH_ONLY_ZEROS
     assert pd.MultiIndex.from_tuples(
         [
-            (region_hi.location_id, CommonFields.VACCINES_DISTRIBUTED),
-            (region_tx.location_id, CommonFields.VACCINES_DISTRIBUTED),
+            (region_hi.location_id, CommonFields.VACCINES_DISTRIBUTED, DemographicBucket.ALL),
+            (region_tx.location_id, CommonFields.VACCINES_DISTRIBUTED, DemographicBucket.ALL),
         ]
     ).equals(log["dropped"])
     test_helpers.assert_dataset_like(ds_expected, ds_out)


### PR DESCRIPTION
This PR addresses https://trello.com/c/lvRFxC5y/932-get-dei-vaccination-data-into-api

* Prints some really ugly but useful stats about buckets at a bunch of places down the pipeline so I can see where they get dropped
* Fixes zeros filter to preserve buckets
* Changes `CanScraperBase` to include buckets beyond "all"

Example output:
```
Dataset TailFilter:
                    all   not_all
tests         1581211.0       0.0
hospitals      545252.0       0.0
cases_deaths  2273802.0       0.0
vaccines       185519.0  133777.0
```

## Tested

`./run.py data update` produced identical output.
