### PR TITLE
join_columns and new_cases with buckets

### DIFF
--- a/cli/data.py
+++ b/cli/data.py
@@ -130,19 +130,23 @@ def update(aggregate_to_country: bool, state: Optional[str], fips: Optional[str]
     multiregion_dataset = timeseries.drop_regions_without_population(
         multiregion_dataset, KNOWN_LOCATION_ID_WITHOUT_POPULATION, structlog.get_logger()
     )
+    multiregion_dataset.print_stats("drop_regions_without_population")
 
     multiregion_dataset = custom_aggregations.aggregate_puerto_rico_from_counties(
         multiregion_dataset
     )
+    multiregion_dataset.print_stats("aggregate_puerto_rico_from_counties")
     multiregion_dataset = custom_aggregations.aggregate_to_new_york_city(multiregion_dataset)
+    multiregion_dataset.print_stats("aggregate_to_new_york_city")
     multiregion_dataset = custom_aggregations.replace_dc_county_with_state_data(multiregion_dataset)
-    multiregion_dataset.print_stats("custom_aggregations")
+    multiregion_dataset.print_stats("replace_dc_county_with_state_data")
 
     aggregator = statistical_areas.CountyToCBSAAggregator.from_local_public_data()
     cbsa_dataset = aggregator.aggregate(
         multiregion_dataset, reporting_ratio_required_to_aggregate=DEFAULT_REPORTING_RATIO
     )
     multiregion_dataset = multiregion_dataset.append_regions(cbsa_dataset)
+    multiregion_dataset.print_stats("CountyToCBSAAggregator")
 
     if aggregate_to_country:
         country_dataset = region_aggregation.aggregate_regions(
@@ -151,6 +155,7 @@ def update(aggregate_to_country: bool, state: Optional[str], fips: Optional[str]
             reporting_ratio_required_to_aggregate=DEFAULT_REPORTING_RATIO,
         )
         multiregion_dataset = multiregion_dataset.append_regions(country_dataset)
+        multiregion_dataset.print_stats("aggregate_to_country")
 
     combined_dataset_utils.persist_dataset(multiregion_dataset, path_prefix)
     multiregion_dataset.print_stats("persist")

--- a/libs/datasets/new_cases_and_deaths.py
+++ b/libs/datasets/new_cases_and_deaths.py
@@ -8,40 +8,38 @@ import pandas as pd
 MultiRegionDataset = timeseries.MultiRegionDataset
 
 
-def _diff_preserving_first_value(
-    series: pd.Series, field_in: CommonFields, field_out: CommonFields
-):
-    cases = series.reset_index(CommonFields.LOCATION_ID, drop=True).loc[field_in, :]
+def _diff_preserving_first_value(cases: pd.Series):
     # cases is a pd.Series (a 1-D vector) with DATE index
     assert cases.index.names == [CommonFields.DATE]
     new_cases = cases.diff()
     first_date = cases.notna().idxmax()
     if pd.notna(first_date):
         new_cases[first_date] = cases[first_date]
-
-    # Return a DataFrame so NEW_CASES is a column with DATE index.
-    return pd.DataFrame({field_out: new_cases})
+    return new_cases
 
 
 def add_incident_column(
     dataset_in: MultiRegionDataset, field_in: CommonFields, field_out: CommonFields
 ) -> MultiRegionDataset:
+    assert field_out not in dataset_in.timeseries_bucketed_wide_dates.index.unique(
+        PdFields.VARIABLE
+    )
 
     # Get timeseries data from timeseries_wide_dates because it creates a date range that includes
     # every date, even those with NA cases. This keeps the output identical when empty rows are
     # dropped or added.
-    wide_dates_var = dataset_in.timeseries_not_bucketed_wide_dates.loc[(slice(None), field_in), :]
+    wide_dates_var = dataset_in.timeseries_bucketed_wide_dates.xs(
+        field_in, level=PdFields.VARIABLE, drop_level=False
+    )
     # Calculating new cases using diff will remove the first detected value from the case series.
     # We want to capture the first day a region reports a case. Since our data sources have
     # been capturing cases in all states from the beginning of the pandemic, we are treating
     # the first day as appropriate new case data.
     # We want as_index=True so that the DataFrame returned by each _diff_preserving_first_value call
     # has the location_id added as an index before being concat-ed.
-    new_cases = (
-        wide_dates_var.groupby(CommonFields.LOCATION_ID, as_index=True, sort=False)
-        .apply(lambda x: _diff_preserving_first_value(x, field_in, field_out))
-        .rename_axis(columns=PdFields.VARIABLE)
-    )
+    new_cases = wide_dates_var.apply(
+        _diff_preserving_first_value, axis=1, result_type="reduce"
+    ).rename({field_in: field_out}, axis="index", level=PdFields.VARIABLE)
 
     # Replacing days with single back tracking adjustments to be 0, reduces
     # number of na days in timeseries
@@ -50,9 +48,10 @@ def add_incident_column(
     # Remove the occasional negative case adjustments.
     # TODO: Add annotation
     new_cases[new_cases < 0] = pd.NA
-    new_cases = new_cases.dropna()
+    # Drop time-series (rows) that don't have any real values.
+    new_cases = new_cases.dropna(axis="index", how="all")
 
-    new_cases_dataset = MultiRegionDataset(timeseries=new_cases)
+    new_cases_dataset = MultiRegionDataset.from_timeseries_wide_dates_df(new_cases, bucketed=True)
 
     dataset_out = dataset_in.join_columns(new_cases_dataset)
     return dataset_out

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -1067,13 +1067,17 @@ class MultiRegionDataset:
             raise NotImplementedError(
                 f"join with other with attributes {other_non_geo_attributes} not supported"
             )
-        common_ts_columns = set(other.timeseries.columns) & set(self.timeseries.columns)
+        common_ts_columns = set(other.timeseries_bucketed.columns) & set(
+            self.timeseries_bucketed.columns
+        )
         if common_ts_columns:
             # columns to be joined need to be disjoint
             raise ValueError(f"Columns are in both dataset: {common_ts_columns}")
-        combined_df = pd.concat([self.timeseries, other.timeseries], axis=1)
+        combined_df = pd.concat([self.timeseries_bucketed, other.timeseries_bucketed], axis=1)
         combined_tag = pd.concat([self.tag, other.tag]).sort_index()
-        return MultiRegionDataset(timeseries=combined_df, static=self.static, tag=combined_tag)
+        return MultiRegionDataset(
+            timeseries_bucketed=combined_df, static=self.static, tag=combined_tag
+        )
 
     def iter_one_regions(self) -> Iterable[Tuple[Region, OneRegionTimeseriesDataset]]:
         """Iterates through all the regions in this object"""

--- a/tests/libs/datasets/new_cases_and_deaths_test.py
+++ b/tests/libs/datasets/new_cases_and_deaths_test.py
@@ -1,4 +1,7 @@
 import io
+
+from covidactnow.datapublic.common_fields import DemographicBucket
+
 from libs.datasets import timeseries
 from libs.datasets import new_cases_and_deaths
 from tests import test_helpers
@@ -61,6 +64,23 @@ def test_calculate_new_deaths():
         {
             ma_region: {CommonFields.DEATHS: [0, 1, 1], CommonFields.NEW_DEATHS: [0, 1, 0]},
             ny_region: {CommonFields.DEATHS: [None, 5, 7], CommonFields.NEW_DEATHS: [None, 5, 2]},
+        }
+    )
+    test_helpers.assert_dataset_like(dataset_after, dataset_expected)
+
+
+def test_calculate_new_deaths_preserve_buckets():
+    age_40s = DemographicBucket("age:40-49")
+    metrics_before = {
+        CommonFields.DEATHS: {DemographicBucket.ALL: [0, 1, 1], age_40s: [None, 5, 7]}
+    }
+    dataset_before = test_helpers.build_default_region_dataset(metrics_before)
+
+    dataset_after = new_cases_and_deaths.add_new_deaths(dataset_before)
+    dataset_expected = test_helpers.build_default_region_dataset(
+        {
+            CommonFields.NEW_DEATHS: {DemographicBucket.ALL: [0, 1, 0], age_40s: [None, 5, 2]},
+            **metrics_before,
         }
     )
     test_helpers.assert_dataset_like(dataset_after, dataset_expected)

--- a/tests/libs/datasets/timeseries_test.py
+++ b/tests/libs/datasets/timeseries_test.py
@@ -960,6 +960,25 @@ def test_join_columns_missing_regions():
     test_helpers.assert_dataset_like(ts_joined, ts_expected, drop_na_latest=True)
 
 
+def test_join_columns_with_buckets():
+    m1 = FieldName("m1")
+    m2 = FieldName("m2")
+    age20s = DemographicBucket("age:20-29")
+
+    m1_data = {m1: {age20s: [1, 2, 3]}}
+    ds_1 = test_helpers.build_default_region_dataset(m1_data)
+    m2_data = {m2: {age20s: [4, 5, 6], DemographicBucket.ALL: [7, 8, 9]}}
+    ds_2 = test_helpers.build_default_region_dataset(m2_data)
+
+    with pytest.raises(ValueError):
+        ds_1.join_columns(ds_1)
+
+    ds_expected = test_helpers.build_default_region_dataset({**m1_data, **m2_data})
+
+    ds_joined = ds_1.join_columns(ds_2)
+    test_helpers.assert_dataset_like(ds_joined, ds_expected)
+
+
 def test_iter_one_region():
     ts = timeseries.MultiRegionDataset.from_csv(
         io.StringIO(


### PR DESCRIPTION
This PR addresses https://trello.com/c/lvRFxC5y/932-get-dei-vaccination-data-into-api

* join_columns bucket support
* new_cases_and_deaths bucket support
* data.py bucket stat printing at more steps

## Tested

`./run.py data update` produced identical output.

