### PR TITLE
More bucket support in MultiRegionDataset methods

### DIFF
--- a/libs/datasets/region_aggregation.py
+++ b/libs/datasets/region_aggregation.py
@@ -238,6 +238,9 @@ def _apply_scaling_factor(
         [CommonFields.LOCATION_ID, CommonFields.DATE],
         [CommonFields.LOCATION_ID],
     )
+    # Check that scale_factors has location index and CommonFields in columns.
+    assert scale_factors.index.names == [CommonFields.LOCATION_ID]
+    assert scale_factors.columns.difference(CommonFields).empty
 
     # Scaled fields are modified in-place
     df_out = df_in.copy()

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -978,7 +978,7 @@ class MultiRegionDataset:
 
     def drop_stale_timeseries(self, cutoff_date: datetime.date) -> "MultiRegionDataset":
         """Returns a new object containing only timeseries with a real value on or after cutoff_date."""
-        ts = self.timeseries_not_bucketed_wide_dates
+        ts = self.timeseries_bucketed_wide_dates
         recent_columns_mask = ts.columns >= cutoff_date
         recent_rows_mask = ts.loc[:, recent_columns_mask].notna().any(axis=1)
         timeseries_wide_dates = ts.loc[recent_rows_mask, :]
@@ -988,14 +988,12 @@ class MultiRegionDataset:
         timeseries_wide_variables = (
             timeseries_wide_dates.stack()
             .unstack(PdFields.VARIABLE)
-            .reindex(columns=self.timeseries.columns)
+            .reindex(columns=self.timeseries_bucketed.columns)
             .sort_index()
         )
         # Only keep tag information for timeseries in the new timeseries_wide_dates.
         tag = _slice_with_labels(self.tag, timeseries_wide_dates.index)
-        return dataclasses.replace(
-            self, timeseries=timeseries_wide_variables, tag=tag, timeseries_bucketed=None,
-        )
+        return dataclasses.replace(self, timeseries_bucketed=timeseries_wide_variables, tag=tag,)
 
     def to_csv(self, path: pathlib.Path, include_latest=True):
         """Persists timeseries to CSV.

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -1050,10 +1050,10 @@ class MultiRegionDataset:
 
     def drop_columns_if_present(self, columns: List[CommonFields]) -> "MultiRegionDataset":
         """Drops the specified columns from the timeseries if they exist"""
-        timeseries_df = self.timeseries.drop(columns, axis="columns", errors="ignore")
+        timeseries_df = self.timeseries_bucketed.drop(columns, axis="columns", errors="ignore")
         static_df = self.static.drop(columns, axis="columns", errors="ignore")
         tag = self.tag[~self.tag.index.get_level_values(PdFields.VARIABLE).isin(columns)]
-        return MultiRegionDataset(timeseries=timeseries_df, static=static_df, tag=tag)
+        return MultiRegionDataset(timeseries_bucketed=timeseries_df, static=static_df, tag=tag)
 
     def join_columns(self, other: "MultiRegionDataset") -> "MultiRegionDataset":
         """Joins the timeseries columns in `other` with those in `self`.

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -812,13 +812,13 @@ class MultiRegionDataset:
         # TODO(tom): check if rename_axis is needed once we have
         #  https://pandas.pydata.org/docs/whatsnew/v1.2.0.html#index-column-name-preservation-when-aggregating
         timeseries_df = (
-            pd.concat([self.timeseries, other.timeseries])
+            pd.concat([self.timeseries_bucketed, other.timeseries_bucketed])
             .sort_index()
             .rename_axis(columns=PdFields.VARIABLE)
         )
         static_df = pd.concat([self.static, other.static]).sort_index()
         tag = pd.concat([self.tag, other.tag]).sort_index()
-        return MultiRegionDataset(timeseries=timeseries_df, static=static_df, tag=tag)
+        return MultiRegionDataset(timeseries_bucketed=timeseries_df, static=static_df, tag=tag)
 
     def append_fips_tag_df(self, additional_tag_df: pd.DataFrame) -> "MultiRegionDataset":
         """Returns a new dataset with additional_tag_df, containing a fips column, appended."""

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -874,34 +874,34 @@ class MultiRegionDataset:
 
     def get_locations_subset(self, location_ids: Collection[str]) -> "MultiRegionDataset":
         # If these mask+loc operations show up as a performance issue try changing to xs.
-        timeseries_mask = self.timeseries.index.get_level_values(CommonFields.LOCATION_ID).isin(
-            location_ids
-        )
-        timeseries_df = self.timeseries.loc[timeseries_mask, :]
+        timeseries_mask = self.timeseries_bucketed.index.get_level_values(
+            CommonFields.LOCATION_ID
+        ).isin(location_ids)
+        timeseries_df = self.timeseries_bucketed.loc[timeseries_mask, :]
         static_mask = self.static.index.get_level_values(CommonFields.LOCATION_ID).isin(
             location_ids
         )
         static_df = self.static.loc[static_mask, :]
         tag_mask = self.tag.index.get_level_values(CommonFields.LOCATION_ID).isin(location_ids)
         tag = self.tag.loc[tag_mask, :]
-        return MultiRegionDataset(timeseries=timeseries_df, static=static_df, tag=tag)
+        return MultiRegionDataset(timeseries_bucketed=timeseries_df, static=static_df, tag=tag)
 
     def remove_regions(self, regions: Collection[Region]) -> "MultiRegionDataset":
         location_ids = pd.Index(sorted(r.location_id for r in regions))
         return self.remove_locations(location_ids)
 
     def remove_locations(self, location_ids: Collection[str]) -> "MultiRegionDataset":
-        timeseries_mask = self.timeseries.index.get_level_values(CommonFields.LOCATION_ID).isin(
-            location_ids
-        )
-        timeseries_df = self.timeseries.loc[~timeseries_mask, :]
+        timeseries_mask = self.timeseries_bucketed.index.get_level_values(
+            CommonFields.LOCATION_ID
+        ).isin(location_ids)
+        timeseries_df = self.timeseries_bucketed.loc[~timeseries_mask, :]
         static_mask = self.static.index.get_level_values(CommonFields.LOCATION_ID).isin(
             location_ids
         )
         static_df = self.static.loc[~static_mask, :]
         tag_mask = self.tag.index.get_level_values(CommonFields.LOCATION_ID).isin(location_ids)
         tag = self.tag.loc[~tag_mask, :]
-        return MultiRegionDataset(timeseries=timeseries_df, static=static_df, tag=tag)
+        return MultiRegionDataset(timeseries_bucketed=timeseries_df, static=static_df, tag=tag)
 
     def get_subset(
         self,

--- a/tests/libs/datasets/timeseries_test.py
+++ b/tests/libs/datasets/timeseries_test.py
@@ -1146,7 +1146,6 @@ def test_join_columns_with_tags():
 
 
 def test_drop_column_with_tags():
-    """Checks that join_columns preserves tags."""
     region = Region.from_state("TX")
     cases_values = [100, 200, 300, 400]
     ts_lit = TimeseriesLiteral(cases_values, annotation=[test_helpers.make_tag()])
@@ -1159,6 +1158,22 @@ def test_drop_column_with_tags():
 
     assert len(dataset_out.tag) == 1
     dataset_expected = test_helpers.build_dataset({region: {CommonFields.CASES: ts_lit}})
+    test_helpers.assert_dataset_like(dataset_out, dataset_expected)
+
+
+def test_drop_column_with_tags_and_bucket():
+    age_40s = DemographicBucket("age:40-49")
+    ts_lit = TimeseriesLiteral([10, 20, 30], annotation=[test_helpers.make_tag()])
+    data_cases = {CommonFields.CASES: {age_40s: ts_lit, DemographicBucket.ALL: ts_lit}}
+    data_deaths = {CommonFields.DEATHS: {age_40s: ts_lit}}
+
+    dataset_in = test_helpers.build_default_region_dataset({**data_cases, **data_deaths})
+    assert len(dataset_in.tag) == 3
+
+    dataset_out = dataset_in.drop_column_if_present(CommonFields.DEATHS)
+
+    assert len(dataset_out.tag) == 2
+    dataset_expected = test_helpers.build_default_region_dataset({**data_cases})
     test_helpers.assert_dataset_like(dataset_out, dataset_expected)
 
 


### PR DESCRIPTION
This PR addresses https://trello.com/c/lvRFxC5y/932-get-dei-vaccination-data-into-api

* Adds bucket support in `MultiRegionDataset.append_regions`, `drop_column_if_present`, `drop_stale_timeseries bucket`, `get_locations_subset`, `remove_locations`
* clarify scale_factors axis in region_aggregation with an assert

## Tested
    
Ran `./run.py data update` then `git difftool --no-prompt -t vimdiff main -- data/multiregion-wide-dates.csv` to see that this adds a bunch of rows for variables vaccinations_completed, vaccinations_initiated,vaccines_administered with buckets such as  age:16-49 or race:unknown;ethnicity:hispanic (and a bunch more buckets) for counties in PA and TX. I don't see any other changes in the data.
