### PR TITLE
Migrate hhs hospital importer to covid-data-model.

### DIFF
--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -21,7 +21,8 @@ from libs.datasets import dataset_pointer
 from libs.datasets.custom_aggregations import ALL_NYC_REGIONS
 from libs.datasets.dataset_pointer import DatasetPointer
 from libs.datasets.dataset_utils import DatasetType
-from libs.datasets.sources.hhs_hospital_dataset import HHSHospitalDataset
+from libs.datasets.sources.hhs_hospital_dataset import HHSHospitalStateDataset
+from libs.datasets.sources.hhs_hospital_dataset import HHSHospitalCountyDataset
 from libs.datasets.sources.texas_hospitalizations import TexasHospitalizations
 from libs.datasets.sources.test_and_trace import TestAndTraceData
 from libs.datasets.timeseries import MultiRegionDataset
@@ -163,23 +164,29 @@ ALL_TIMESERIES_FEATURE_DEFINITION: FeatureDataSourceMap = {
         CANScraperStateProviders,
         CovidTrackingDataSource,
         TexasHospitalizations,
-        HHSHospitalDataset,
+        HHSHospitalCountyDataset,
+        HHSHospitalStateDataset,
     ],
     CommonFields.CURRENT_ICU: [
         CANScraperStateProviders,
         CovidTrackingDataSource,
         TexasHospitalizations,
-        HHSHospitalDataset,
+        HHSHospitalCountyDataset,
+        HHSHospitalStateDataset,
     ],
-    CommonFields.CURRENT_ICU_TOTAL: [HHSHospitalDataset],
+    CommonFields.CURRENT_ICU_TOTAL: [HHSHospitalCountyDataset, HHSHospitalStateDataset],
     CommonFields.CURRENT_VENTILATED: [CovidTrackingDataSource],
     CommonFields.DEATHS: [
         CANScraperStateProviders,
         CANScraperUSAFactsProvider,
         NYTimesDatasetWithoutNYCOrIACounties,
     ],
-    CommonFields.HOSPITAL_BEDS_IN_USE_ANY: [HHSHospitalDataset],
-    CommonFields.ICU_BEDS: [CANScraperStateProviders, HHSHospitalDataset],
+    CommonFields.HOSPITAL_BEDS_IN_USE_ANY: [HHSHospitalCountyDataset, HHSHospitalStateDataset],
+    CommonFields.ICU_BEDS: [
+        CANScraperStateProviders,
+        HHSHospitalCountyDataset,
+        HHSHospitalStateDataset,
+    ],
     CommonFields.NEGATIVE_TESTS: [CovidTrackingDataSource, HHSTestingDataset],
     CommonFields.POSITIVE_TESTS: [CovidTrackingDataSource, HHSTestingDataset],
     CommonFields.TOTAL_TESTS: [CovidTrackingDataSource],
@@ -204,7 +211,7 @@ ALL_FIELDS_FEATURE_DEFINITION: FeatureDataSourceMap = {
     CommonFields.POPULATION: [FIPSPopulation],
     # TODO(michael): We don't really trust the CCM bed numbers and would ideally remove them entirely.
     CommonFields.ALL_BED_TYPICAL_OCCUPANCY_RATE: [CovidCareMapBeds],
-    CommonFields.ICU_BEDS: [CovidCareMapBeds, HHSHospitalDataset],
+    CommonFields.ICU_BEDS: [CovidCareMapBeds, HHSHospitalCountyDataset, HHSHospitalStateDataset],
     CommonFields.ICU_TYPICAL_OCCUPANCY_RATE: [CovidCareMapBeds],
     CommonFields.LICENSED_BEDS: [CovidCareMapBeds],
     CommonFields.MAX_BED_COUNT: [CovidCareMapBeds],

--- a/libs/datasets/sources/hhs_hospital_dataset.py
+++ b/libs/datasets/sources/hhs_hospital_dataset.py
@@ -26,7 +26,7 @@ CUSTOM_START_DATES = {
     "53": "2020-10-25",  # Washington
 }
 
-# Mapping of CAN scraper fields to common fields.
+# Mapping of ScraperVariable.variable_name to common fields.
 FIELD_MAPPING = {
     "adult_icu_beds_capacity": CommonFields.ICU_BEDS,
     "adult_icu_beds_in_use": CommonFields.CURRENT_ICU_TOTAL,
@@ -104,15 +104,13 @@ def modify_dataset(ds: MultiRegionDataset) -> MultiRegionDataset:
 def filter_early_data(df):
     """Filters out early data for each location based on DEFAULT_START_DATE and
     CUSTOM_START_DATES."""
-    keep_rows = df.index.get_level_values(CommonFields.DATE.value) >= pd.to_datetime(
-        DEFAULT_START_DATE
-    )
+    keep_rows = df.index.get_level_values(CommonFields.DATE) >= pd.to_datetime(DEFAULT_START_DATE)
     df = df.loc[keep_rows]
 
     for (fips, start_date) in CUSTOM_START_DATES.items():
         location_id = pipeline.fips_to_location_id(fips)
-        keep_rows = (df.index.get_level_values(CommonFields.LOCATION_ID.value) != location_id) | (
-            df.index.get_level_values(CommonFields.DATE.value) >= pd.to_datetime(start_date)
+        keep_rows = (df.index.get_level_values(CommonFields.LOCATION_ID) != location_id) | (
+            df.index.get_level_values(CommonFields.DATE) >= pd.to_datetime(start_date)
         )
         df = df.loc[keep_rows]
 

--- a/libs/datasets/sources/hhs_hospital_dataset.py
+++ b/libs/datasets/sources/hhs_hospital_dataset.py
@@ -49,11 +49,11 @@ def make_hhs_variable(can_scraper_field, common_field, measurement):
     )
 
 
-# NOTE: HHSHospitalStateDataset and HHSHospitalCountyDataset must be separate classes because they
-# use different measurements ("current" vs "rolling_average_7_day") on the same variables (e.g.
-# "adult_icu_beds_capacity"). CanScraperBase operates on a per-variable basis (instead of
-# per-variable+measurement) and so will not merge them properly if we try to use both in the same
-# dataset.
+# TODO(michael): HHSHospitalStateDataset and HHSHospitalCountyDataset must be separate classes
+# because they both have ScraperVariables that target the same CommonFields. This happens becaues
+# the state level and county level data use the same variable names but different measurements
+# ("current" and "rolling_average_7_day"). This causes CanScraperBase to overwrite itself as it's
+# extracting the variables. Using separate Dataset classes solves this.
 
 
 class HHSHospitalStateDataset(data_source.CanScraperBase):

--- a/libs/datasets/sources/hhs_hospital_dataset.py
+++ b/libs/datasets/sources/hhs_hospital_dataset.py
@@ -1,24 +1,119 @@
+import dataclasses
 from functools import lru_cache
+from libs import pipeline
+
 from covidactnow.datapublic.common_fields import CommonFields
+import pandas as pd
+from libs.datasets.sources import can_scraper_helpers as ccd_helpers
 from libs.datasets import data_source
 from libs.datasets.timeseries import MultiRegionDataset
 
 
-class HHSHospitalDataset(data_source.DataSource):
-    SOURCE_TYPE = "HHSHospital"
+# Early data is noisy due to lack of reporting, etc. so we just trim it off.
+DEFAULT_START_DATE = "2020-09-01"
+CUSTOM_START_DATES = {
+    "02": "2020-10-06",  # Alaska
+    "04": "2020-09-02",  # Arizona
+    "15": "2020-10-10",  # Hawaii
+    "16": "2020-10-17",  # Idaho
+    "19": "2020-09-05",  # Iowa
+    "21": "2020-10-15",  # Kentucky
+    "28": "2020-11-11",  # Mississippi
+    "34": "2020-09-01",  # New Jersey
+    "38": "2020-11-03",  # North Dakota
+    "46": "2020-11-02",  # South Dakota
+    "47": "2020-09-20",  # Tennessee
+    "53": "2020-10-25",  # Washington
+}
 
-    COMMON_DF_CSV_PATH = "data/hospital-hhs/timeseries-common.csv"
+# Mapping of CAN scraper fields to common fields.
+FIELD_MAPPING = {
+    "adult_icu_beds_capacity": CommonFields.ICU_BEDS,
+    "adult_icu_beds_in_use": CommonFields.CURRENT_ICU_TOTAL,
+    "adult_icu_beds_in_use_covid": CommonFields.CURRENT_ICU,
+    "hospital_beds_capacity": CommonFields.STAFFED_BEDS,
+    "hospital_beds_in_use": CommonFields.HOSPITAL_BEDS_IN_USE_ANY,
+    "hospital_beds_in_use_covid": CommonFields.CURRENT_HOSPITALIZED,
+}
 
-    EXPECTED_FIELDS = [
-        CommonFields.ICU_BEDS,
-        CommonFields.CURRENT_ICU_TOTAL,
-        CommonFields.CURRENT_ICU,
-        CommonFields.STAFFED_BEDS,
-        CommonFields.HOSPITAL_BEDS_IN_USE_ANY,
-        CommonFields.CURRENT_HOSPITALIZED,
+
+def make_hhs_variable(can_scraper_field, common_field, measurement):
+    """Helper to create a ScraperVariable, since we have a bunch of variables to deal with and
+    two different measurements to deal with (for county and state data)."""
+    return ccd_helpers.ScraperVariable(
+        variable_name=can_scraper_field,
+        measurement=measurement,
+        provider="hhs",
+        unit="beds",
+        common_field=common_field,
+    )
+
+
+# NOTE: HHSHospitalStateDataset and HHSHospitalCountyDataset must be separate classes because they
+# use different measurements ("current" vs "rolling_average_7_day") on the same variables (e.g.
+# "adult_icu_beds_capacity"). CanScraperBase operates on a per-variable basis (instead of
+# per-variable+measurement) and so will not merge them properly if we try to use both in the same
+# dataset.
+
+
+class HHSHospitalStateDataset(data_source.CanScraperBase):
+    """Data source for HHS state-level hospital data."""
+
+    SOURCE_TYPE = "HHSHospitalState"
+
+    VARIABLES = [
+        make_hhs_variable(can_field, common_field, "current")
+        for can_field, common_field in FIELD_MAPPING.items()
     ]
 
     @classmethod
     @lru_cache(None)
     def make_dataset(cls) -> MultiRegionDataset:
-        return super().make_dataset().latest_in_static(CommonFields.ICU_BEDS)
+        return modify_dataset(super().make_dataset())
+
+
+class HHSHospitalCountyDataset(data_source.CanScraperBase):
+    """Data source for HHS county-level hospital data."""
+
+    SOURCE_TYPE = "HHSHospitalCounty"
+
+    VARIABLES = [
+        make_hhs_variable(can_field, common_field, "rolling_average_7_day")
+        for can_field, common_field in FIELD_MAPPING.items()
+    ]
+
+    @classmethod
+    @lru_cache(None)
+    def make_dataset(cls) -> MultiRegionDataset:
+        return modify_dataset(super().make_dataset())
+
+
+def modify_dataset(ds: MultiRegionDataset) -> MultiRegionDataset:
+    """Post-processes the can scraper data as necessary."""
+    ts_copy = ds.timeseries.copy()
+
+    # Filter out some of the early noisy data.
+    filtered_ds = dataclasses.replace(
+        ds, timeseries=filter_early_data(ts_copy), timeseries_bucketed=None
+    )
+
+    # Ensure ICU_BEDS is included in the static fields as well.
+    return filtered_ds.latest_in_static(field=CommonFields.ICU_BEDS)
+
+
+def filter_early_data(df):
+    """Filters out early data for each location based on DEFAULT_START_DATE and
+    CUSTOM_START_DATES."""
+    keep_rows = df.index.get_level_values(CommonFields.DATE.value) >= pd.to_datetime(
+        DEFAULT_START_DATE
+    )
+    df = df.loc[keep_rows]
+
+    for (fips, start_date) in CUSTOM_START_DATES.items():
+        location_id = pipeline.fips_to_location_id(fips)
+        keep_rows = (df.index.get_level_values(CommonFields.LOCATION_ID.value) != location_id) | (
+            df.index.get_level_values(CommonFields.DATE.value) >= pd.to_datetime(start_date)
+        )
+        df = df.loc[keep_rows]
+
+    return df

--- a/tests/libs/datasets/sources/hhs_hospital_dataset_test.py
+++ b/tests/libs/datasets/sources/hhs_hospital_dataset_test.py
@@ -42,9 +42,8 @@ def test_hhs_hospital_dataset():
         {CommonFields.ICU_BEDS: icu_beds},
         region=pipeline.Region.from_fips("36"),
         start_date="2020-09-01",
+        static={CommonFields.ICU_BEDS: 30},
     )
-
-    expected_ds = expected_ds.latest_in_static(field=CommonFields.ICU_BEDS)
 
     test_helpers.assert_dataset_like(ds, expected_ds)
 
@@ -86,8 +85,7 @@ def test_hhs_hospital_dataset_non_default_start_date():
         {CommonFields.ICU_BEDS: icu_beds},
         region=pipeline.Region.from_fips("02"),
         start_date="2020-10-06",
+        static={CommonFields.ICU_BEDS: 30},
     )
-
-    expected_ds = expected_ds.latest_in_static(field=CommonFields.ICU_BEDS)
 
     test_helpers.assert_dataset_like(ds, expected_ds)

--- a/tests/libs/datasets/sources/hhs_hospital_dataset_test.py
+++ b/tests/libs/datasets/sources/hhs_hospital_dataset_test.py
@@ -1,0 +1,93 @@
+from covidactnow.datapublic.common_fields import CommonFields
+
+from libs import pipeline
+from libs.datasets import taglib
+from libs.datasets.sources import can_scraper_helpers as ccd_helpers
+from libs.datasets.sources import hhs_hospital_dataset
+from libs.datasets.taglib import UrlStr
+
+from tests import test_helpers
+from tests.libs.datasets.sources.can_scraper_helpers_test import build_can_scraper_dataframe
+
+
+def test_hhs_hospital_dataset():
+    """Tests HHSHopsitalStateDataset imports adult_icu_beds_capacity
+    correctly and data prior to 2020-09-01 is dropped."""
+    variable = ccd_helpers.ScraperVariable(
+        variable_name="adult_icu_beds_capacity",
+        measurement="current",
+        unit="beds",
+        provider="hhs",
+        common_field=CommonFields.ICU_BEDS,
+    )
+    source_url = UrlStr("http://foo.com")
+
+    # Start at 2020-08-31 to make sure that the first date gets dropped.
+    input_data = build_can_scraper_dataframe(
+        {variable: [10, 20, 30]}, source_url=source_url, start_date="2020-08-31"
+    )
+
+    class CANScraperForTest(hhs_hospital_dataset.HHSHospitalStateDataset):
+        @staticmethod
+        def _get_covid_county_dataset() -> ccd_helpers.CanScraperLoader:
+            return ccd_helpers.CanScraperLoader(input_data)
+
+    ds = CANScraperForTest.make_dataset()
+
+    # Data before 2020-09-01 should have been dropped, so we are left with [20, 30]
+    icu_beds = test_helpers.TimeseriesLiteral(
+        [20, 30], source=taglib.Source(type="HHSHospitalState", url=source_url)
+    )
+    expected_ds = test_helpers.build_default_region_dataset(
+        {CommonFields.ICU_BEDS: icu_beds},
+        region=pipeline.Region.from_fips("36"),
+        start_date="2020-09-01",
+    )
+
+    expected_ds = expected_ds.latest_in_static(field=CommonFields.ICU_BEDS)
+
+    test_helpers.assert_dataset_like(ds, expected_ds)
+
+
+def test_hhs_hospital_dataset_non_default_start_date():
+    """Tests HHSHopsitalStateDataset imports adult_icu_beds_capacity
+    correctly for a state with a non-default start date (Alaska) verifying
+    that data prior to its start date (2020-10-06) is dropped."""
+    variable = ccd_helpers.ScraperVariable(
+        variable_name="adult_icu_beds_capacity",
+        measurement="current",
+        unit="beds",
+        provider="hhs",
+        common_field=CommonFields.ICU_BEDS,
+    )
+    source_url = UrlStr("http://foo.com")
+
+    # Do location Alaska and start at 2020-10-05 so the first date gets dropped.
+    input_data = build_can_scraper_dataframe(
+        {variable: [10, 20, 30]},
+        source_url=source_url,
+        start_date="2020-10-05",
+        location=2,
+        location_id="iso1:us#iso2:us-ak",
+    )
+
+    class CANScraperForTest(hhs_hospital_dataset.HHSHospitalStateDataset):
+        @staticmethod
+        def _get_covid_county_dataset() -> ccd_helpers.CanScraperLoader:
+            return ccd_helpers.CanScraperLoader(input_data)
+
+    ds = CANScraperForTest.make_dataset()
+
+    # Data before 2020-10-05 should have been dropped, so we are left with [20, 30]
+    icu_beds = test_helpers.TimeseriesLiteral(
+        [20, 30], source=taglib.Source(type="HHSHospitalState", url=source_url)
+    )
+    expected_ds = test_helpers.build_default_region_dataset(
+        {CommonFields.ICU_BEDS: icu_beds},
+        region=pipeline.Region.from_fips("02"),
+        start_date="2020-10-06",
+    )
+
+    expected_ds = expected_ds.latest_in_static(field=CommonFields.ICU_BEDS)
+
+    test_helpers.assert_dataset_like(ds, expected_ds)


### PR DESCRIPTION
Tested via `./run.py data update` and `git difftool`.  The resulting multiregion dataset files were identical except for some rounding errors and the (desired) inclusion of source url / name information.