### PR TITLE
Truncate old dates. Add test_helpers.read_csv_str.

### DIFF
--- a/data/multiregion-wide-dates.csv
+++ b/data/multiregion-wide-dates.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2006bbfb536973403bac5114bd783aa3eb6d16bd321495bdc40d9130475c5c06
-size 49636103
+oid sha256:b7d150048f7fc74c136caa57ec37aa2cbd056516a0a4301c6696d21830eb072e
+size 45907977

--- a/data/multiregion-wide-dates.csv
+++ b/data/multiregion-wide-dates.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c706a11f8d11eee67dcfe7c0ba0b146b955388ef305aa2ca37e57d2125a1a51d
-size 49623997
+oid sha256:5fa8ac19132002d6b246b2107cdd354fdacaad6f8ef03216e7f0009e9f863406
+size 45661088

--- a/data/multiregion.json
+++ b/data/multiregion.json
@@ -7,9 +7,9 @@
     "is_dirty": false
   },
   "model_git_info": {
-    "sha": "dccc8eb6cb87da09655d01907db95447911510c0",
-    "branch": "main",
-    "is_dirty": false
+    "sha": "33a63b696f43b57b6306c5388576894ffe2d4909",
+    "branch": "tgb-truncate-old-dates",
+    "is_dirty": true
   },
-  "updated_at": "2021-03-23T19:51:36.262814"
+  "updated_at": "2021-03-23T20:56:33.862887"
 }

--- a/libs/datasets/data_source.py
+++ b/libs/datasets/data_source.py
@@ -57,7 +57,7 @@ class DataSource(object):
         return taglib.Source(type=cls.SOURCE_TYPE, url=cls.SOURCE_URL, name=cls.SOURCE_NAME)
 
     @classmethod
-    def _check_data(cls, data: pd.DataFrame):
+    def _check_and_removed_unexpected_data(cls, data: pd.DataFrame):
         # data may be indexed by location_id,date (in CanSraperBase, ready for MultiRegionDataset)
         # or not (in DataSource, which calls from_fips_timeseries_df). TODO(tom): reduce the
         #  number of code paths.
@@ -110,7 +110,7 @@ class DataSource(object):
     def make_dataset(cls) -> timeseries.MultiRegionDataset:
         """Default implementation of make_dataset that loads timeseries data from a CSV."""
         data = cls._load_data()
-        data = cls._check_data(data)
+        data = cls._check_and_removed_unexpected_data(data)
         return MultiRegionDataset.from_fips_timeseries_df(data).add_tag_all_bucket(cls.source_tag())
 
 
@@ -146,7 +146,7 @@ class CanScraperBase(DataSource, abc.ABC, metaclass=_CanScraperBaseMeta):
             source_type=cls.SOURCE_TYPE,
         )
         data = rows.unstack(PdFields.VARIABLE)
-        data = cls._check_data(data)
+        data = cls._check_and_removed_unexpected_data(data)
         ds = MultiRegionDataset(timeseries_bucketed=data)
         if not source_df.empty:
             # For each FIPS-VARIABLE pair keep the source_url row with the last DATE.

--- a/libs/datasets/data_source.py
+++ b/libs/datasets/data_source.py
@@ -70,7 +70,11 @@ class DataSource(object):
             old_dates_mask = dates_sequence < "2020-01-01"
             if old_dates_mask.any():
                 _log.warning(
-                    "Dropping old data", cls=cls.SOURCE_TYPE, dropped_df=data.loc[old_dates_mask]
+                    "Dropping old data",
+                    cls=cls.SOURCE_TYPE,
+                    dropped_df=data.loc[old_dates_mask].to_string(
+                        line_width=200, max_rows=10, max_colwidth=40
+                    ),
                 )
                 data = data.loc[~old_dates_mask]
         expected_fields = pd.Index({*cls.EXPECTED_FIELDS, *TIMESERIES_INDEX_FIELDS})

--- a/libs/datasets/data_source.py
+++ b/libs/datasets/data_source.py
@@ -23,6 +23,13 @@ import pandas as pd
 _log = structlog.get_logger()
 
 
+def format_sample_of_df(df: pd.DataFrame) -> str:
+    """Formats a sample of a DataFrame as a string, suitable for dumping to a log."""
+    return df.to_string(
+        line_width=120, max_rows=10, max_cols=5, max_colwidth=40, show_dimensions=True
+    )
+
+
 class DataSource(object):
     """Represents a single dataset source; loads data and produces a MultiRegionDataset."""
 
@@ -72,9 +79,7 @@ class DataSource(object):
                 _log.warning(
                     "Dropping old data",
                     cls=cls.SOURCE_TYPE,
-                    dropped_df=data.loc[old_dates_mask].to_string(
-                        line_width=200, max_rows=10, max_colwidth=40
-                    ),
+                    dropped_df=format_sample_of_df(data.loc[old_dates_mask]),
                 )
                 data = data.loc[~old_dates_mask]
         expected_fields = pd.Index({*cls.EXPECTED_FIELDS, *TIMESERIES_INDEX_FIELDS})

--- a/tests/libs/datasets/timeseries_test.py
+++ b/tests/libs/datasets/timeseries_test.py
@@ -394,15 +394,13 @@ def test_timeseries_long():
         start_date="2020-04-02",
     )
 
-    expected = pd.read_csv(
-        io.StringIO(
-            "       location_id,      date,variable,value\n"
-            "iso1:us#cbsa:10100,2020-04-02,      m2,    2\n"
-            "iso1:us#cbsa:10100,2020-04-03,      m2,    3\n"
-            "iso1:us#fips:97111,2020-04-02,      m1,    2\n"
-            "iso1:us#fips:97111,2020-04-04,      m1,    4\n".replace(" ", "")
-        ),
-        parse_dates=[CommonFields.DATE],
+    expected = test_helpers.read_csv_str(
+        "       location_id,      date,variable,value\n"
+        "iso1:us#cbsa:10100,2020-04-02,      m2,    2\n"
+        "iso1:us#cbsa:10100,2020-04-03,      m2,    3\n"
+        "iso1:us#fips:97111,2020-04-02,      m1,    2\n"
+        "iso1:us#fips:97111,2020-04-04,      m1,    4\n",
+        skip_spaces=True,
         dtype={"value": float},
     )
     long_series = ds.timeseries_bucketed_long
@@ -437,19 +435,17 @@ def test_timeseries_bucketed_long():
         start_date="2020-04-02",
     )
 
-    expected = pd.read_csv(
-        io.StringIO(
-            "       location_id,demographic_bucket,      date,variable,value\n"
-            "iso1:us#cbsa:10100,               all,2020-04-02,      m2,    2\n"
-            "iso1:us#cbsa:10100,               all,2020-04-03,      m2,    3\n"
-            "iso1:us#fips:97111,           age:0-9,2020-04-02,      m1,    4\n"
-            "iso1:us#fips:97111,           age:0-9,2020-04-03,      m1,    5\n"
-            "iso1:us#fips:97111,           age:0-9,2020-04-04,      m1,    6\n"
-            "iso1:us#fips:97111,         age:10-19,2020-04-04,      m1,    7\n"
-            "iso1:us#fips:97111,               all,2020-04-02,      m1,    2\n"
-            "iso1:us#fips:97111,               all,2020-04-04,      m1,    4\n".replace(" ", "")
-        ),
-        parse_dates=[CommonFields.DATE],
+    expected = test_helpers.read_csv_str(
+        "       location_id,demographic_bucket,      date,variable,value\n"
+        "iso1:us#cbsa:10100,               all,2020-04-02,      m2,    2\n"
+        "iso1:us#cbsa:10100,               all,2020-04-03,      m2,    3\n"
+        "iso1:us#fips:97111,           age:0-9,2020-04-02,      m1,    4\n"
+        "iso1:us#fips:97111,           age:0-9,2020-04-03,      m1,    5\n"
+        "iso1:us#fips:97111,           age:0-9,2020-04-04,      m1,    6\n"
+        "iso1:us#fips:97111,         age:10-19,2020-04-04,      m1,    7\n"
+        "iso1:us#fips:97111,               all,2020-04-02,      m1,    2\n"
+        "iso1:us#fips:97111,               all,2020-04-04,      m1,    4\n",
+        skip_spaces=True,
         dtype={"value": float},
     )
     long_series = ds.timeseries_bucketed_long
@@ -1218,55 +1214,43 @@ def test_timeseries_empty_static_not_empty():
 
 
 def test_from_timeseries_df_fips_location_id_mismatch():
-    df = pd.read_csv(
-        io.StringIO(
-            "                  location_id, fips,      date,m1\n"
-            "iso1:us#iso2:us-tx#fips:48197,48201,2020-04-02, 2\n"
-            "iso1:us#iso2:us-tx#fips:48201,48201,2020-04-02, 2\n".replace(" ", "")
-        ),
-        parse_dates=[CommonFields.DATE],
-        dtype={"fips": str},
+    df = test_helpers.read_csv_str(
+        "                  location_id, fips,      date,m1\n"
+        "iso1:us#iso2:us-tx#fips:48197,48201,2020-04-02, 2\n"
+        "iso1:us#iso2:us-tx#fips:48201,48201,2020-04-02, 2\n",
+        skip_spaces=True,
     )
     with pytest.warns(timeseries.ExtraColumnWarning, match="48201"):
         timeseries.MultiRegionDataset.from_timeseries_df(df)
 
 
 def test_from_timeseries_df_no_fips_no_warning():
-    df = pd.read_csv(
-        io.StringIO(
-            " location_id, fips,      date,m1\n"
-            "     iso1:us,     ,2020-04-02, 2\n".replace(" ", "")
-        ),
-        parse_dates=[CommonFields.DATE],
-        dtype={"fips": str},
+    df = test_helpers.read_csv_str(
+        "            location_id, fips,      date,m1\n"
+        "                iso1:us,     ,2020-04-02, 2\n",
+        skip_spaces=True,
     )
     timeseries.MultiRegionDataset.from_timeseries_df(df)
 
 
 def test_from_timeseries_df_fips_state_mismatch():
-    df = pd.read_csv(
-        io.StringIO(
-            "                  location_id,state,      date,m1\n"
-            "iso1:us#iso2:us-tx#fips:48197,   TX,2020-04-02, 2\n"
-            "iso1:us#iso2:us-tx#fips:48201,   IL,2020-04-02, 2\n".replace(" ", "")
-        ),
-        parse_dates=[CommonFields.DATE],
-        dtype={"fips": str},
+    df = test_helpers.read_csv_str(
+        "                  location_id,state,      date,m1\n"
+        "iso1:us#iso2:us-tx#fips:48197,   TX,2020-04-02, 2\n"
+        "iso1:us#iso2:us-tx#fips:48201,   IL,2020-04-02, 2\n",
+        skip_spaces=True,
     )
     with pytest.warns(timeseries.ExtraColumnWarning, match="48201"):
         timeseries.MultiRegionDataset.from_timeseries_df(df)
 
 
 def test_from_timeseries_df_bad_level():
-    df = pd.read_csv(
-        io.StringIO(
-            "                  location_id, aggregate_level,      date,m1\n"
-            "iso1:us#iso2:us-tx#fips:48201,          county,2020-04-02, 2\n"
-            "iso1:us#iso2:us-tx#fips:48197,           state,2020-04-02, 2\n"
-            "           iso1:us#iso2:us-tx,           state,2020-04-02, 2\n".replace(" ", "")
-        ),
-        parse_dates=[CommonFields.DATE],
-        dtype={"fips": str},
+    df = test_helpers.read_csv_str(
+        "                  location_id, aggregate_level,      date,m1\n"
+        "iso1:us#iso2:us-tx#fips:48201,          county,2020-04-02, 2\n"
+        "iso1:us#iso2:us-tx#fips:48197,           state,2020-04-02, 2\n"
+        "           iso1:us#iso2:us-tx,           state,2020-04-02, 2\n",
+        skip_spaces=True,
     )
     with pytest.warns(timeseries.ExtraColumnWarning, match="48197"):
         timeseries.MultiRegionDataset.from_timeseries_df(df)
@@ -1415,16 +1399,13 @@ def test_timeseries_rows():
     )
 
     rows = ts.timeseries_rows()
-    expected = pd.read_csv(
-        io.StringIO(
-            "       location_id,variable,demographic_bucket,2020-04-02,2020-04-01\n"
-            "iso1:us#iso2:us-az,      m1,               all,        12,         8\n"
-            "iso1:us#iso2:us-az,      m2,               all,        40,        20\n"
-            "iso1:us#iso2:us-tx,      m1,               all,         4,         4\n"
-            "iso1:us#iso2:us-tx,      m2,               all,         4,         2\n".replace(
-                " ", ""
-            )
-        )
+    expected = test_helpers.read_csv_str(
+        "       location_id,variable,demographic_bucket,2020-04-02,2020-04-01\n"
+        "iso1:us#iso2:us-az,      m1,               all,        12,         8\n"
+        "iso1:us#iso2:us-az,      m2,               all,        40,        20\n"
+        "iso1:us#iso2:us-tx,      m1,               all,         4,         4\n"
+        "iso1:us#iso2:us-tx,      m2,               all,         4,         2\n",
+        skip_spaces=True,
     ).set_index([CommonFields.LOCATION_ID, PdFields.VARIABLE, PdFields.DEMOGRAPHIC_BUCKET])
     pd.testing.assert_frame_equal(rows, expected, check_dtype=False, check_exact=False)
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,7 @@
 import abc
 import dataclasses
 import inspect
+import io
 from typing import Iterable
 from typing import List
 
@@ -321,3 +322,25 @@ def get_concrete_subclasses(cls) -> Iterable[Type]:
     for subcls in get_subclasses(cls):
         if not inspect.isabstract(subcls) and abc.ABC not in subcls.__bases__:
             yield subcls
+
+
+def read_csv_str(
+    csv: str, *, skip_spaces: bool = False, parse_dates: Optional[List] = None
+) -> pd.DataFrame:
+    """Reads a CSV passed as a string.
+
+    Args:
+        skip_spaces: If True, removes all " " from csv
+        parse_dates: Passed to pd.read_csv. If None and 'date' is in the header then ['date'].
+    """
+    if skip_spaces:
+        csv = csv.replace(" ", "")
+    if parse_dates is None:
+        header = more_itertools.first(csv.splitlines()).split(",")
+        if CommonFields.DATE in header:
+            parse_dates = [CommonFields.DATE]
+        else:
+            parse_dates = []
+    return pd.read_csv(
+        io.StringIO(csv), parse_dates=parse_dates, dtype={CommonFields.FIPS: str}, low_memory=True
+    )

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -325,22 +325,32 @@ def get_concrete_subclasses(cls) -> Iterable[Type]:
 
 
 def read_csv_str(
-    csv: str, *, skip_spaces: bool = False, parse_dates: Optional[List] = None
+    csv: str,
+    *,
+    skip_spaces: bool = False,
+    parse_dates: Optional[List] = None,
+    dtype: Optional[Mapping] = None,
 ) -> pd.DataFrame:
     """Reads a CSV passed as a string.
 
     Args:
+        csv: String content to parse as a CSV
         skip_spaces: If True, removes all " " from csv
         parse_dates: Passed to pd.read_csv. If None and 'date' is in the header then ['date'].
+        dtype: Passed to pd.read_csv. If None and 'fips' is in the header it is parsed as a str.
     """
     if skip_spaces:
         csv = csv.replace(" ", "")
+    header = more_itertools.first(csv.splitlines()).split(",")
     if parse_dates is None:
-        header = more_itertools.first(csv.splitlines()).split(",")
         if CommonFields.DATE in header:
             parse_dates = [CommonFields.DATE]
         else:
             parse_dates = []
-    return pd.read_csv(
-        io.StringIO(csv), parse_dates=parse_dates, dtype={CommonFields.FIPS: str}, low_memory=True
-    )
+    if dtype is None:
+        if CommonFields.FIPS in header:
+            dtype = {CommonFields.FIPS: str}
+        else:
+            dtype = {}
+
+    return pd.read_csv(io.StringIO(csv), parse_dates=parse_dates, dtype=dtype, low_memory=True)


### PR DESCRIPTION
* Expands `DataSource._check_data` to truncate data from before 2020-01-01 and rename it to `_check_and_removed_unexpected_data`
* Expands DataSource.IGNORED_FIELDS to include more fields that are okay to be ignored now that geo data is loaded from elsewhere
* Adds `test_helpers.read_csv_str` to produce data for testing _check_data and use it in timeseries_test

This PR includes an updated `multiregion-wide-dates.csv` because the current main has data going back to 1970 and uses > 9GB of memory.

## Tested

Ran `./run.py data update`, saw the log output of data being dropped and checked for sensible header row in `data/multiregion-wide-dates.csv`
