### PR TITLE
Fix case where values for a bucket dont exist

### DIFF
--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -180,7 +180,7 @@ class OneRegionTimeseriesDataset:
                 bucket = DistributionBucket.from_str(short_name)
                 result[field][bucket.distribution][bucket.name] = value
 
-        return dict(result)
+        return result
 
     @cached_property
     def tag_objects_series(self) -> pd.Series:

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -157,20 +157,30 @@ class OneRegionTimeseriesDataset:
     def demographic_distributions_by_field(
         self,
     ) -> Dict[CommonFields, Dict[str, demographics.ScalarDistribution]]:
-        """Returns demographic distributions by field."""
-        result = defaultdict(lambda: defaultdict(dict))
+        """Returns demographic distributions by field.
 
-        for field in self.bucketed_latest.columns:
-            field_data = self.bucketed_latest.loc[:, field].to_dict()
+        Only returns distributions where at least one value exists.
+        """
+        result = defaultdict(lambda: defaultdict(dict))
+        bucketed_latest = self.bucketed_latest.where(pd.notnull(self.bucketed_latest), None)
+
+        for field in bucketed_latest.columns:
+            field_data = bucketed_latest.loc[:, field].to_dict()
             for short_name, value in field_data.items():
                 # Skipping 'all' it as it does not have multiple values per distribution.
                 if short_name == "all":
                     continue
 
+                # Only adding real-valued data to distributions.  If there are multiple
+                # variables with different buckets for a given distribution, including none's
+                # will mix buckets.  To properly fix, consider passing latest in a long format
+                # rather than a wide variables format.
+                if value is None:
+                    continue
                 bucket = DistributionBucket.from_str(short_name)
                 result[field][bucket.distribution][bucket.name] = value
 
-        return result
+        return dict(result)
 
     @cached_property
     def tag_objects_series(self) -> pd.Series:

--- a/tests/libs/datasets/timeseries_test.py
+++ b/tests/libs/datasets/timeseries_test.py
@@ -1752,6 +1752,27 @@ def test_one_region_demographic_distributions():
     assert one_region.demographic_distributions_by_field == expected
 
 
+def test_one_region_demographic_distributions():
+    m1 = FieldName("m1")
+    m2 = FieldName("m2")
+    age20s = DemographicBucket("age:20-29")
+    age30s = DemographicBucket("age:30-39")
+    # Presumably 25 to 29 is from a different age distribution as it overlaps with age bucket above.
+    # Make sure that different age bucketing doesn't polute other variables.
+    age25to29 = DemographicBucket("age:25-29")
+
+    dataset = test_helpers.build_default_region_dataset(
+        {
+            m1: {age20s: [21, 22, 23], age30s: [31, 32, 33], DemographicBucket.ALL: [20, 21, 22]},
+            m2: {DemographicBucket.ALL: [20, 21, 22], age25to29: [20, 21, 22]},
+        },
+    )
+    one_region = dataset.get_one_region(test_helpers.DEFAULT_REGION)
+    expected = {m1: {"age": {"20-29": 23, "30-39": 33}}, m2: {"age": {"25-29": 22}}}
+
+    assert one_region.demographic_distributions_by_field == expected
+
+
 def test_print_stats():
     all_bucket = DemographicBucket("all")
     age_20s = DemographicBucket("age:20-29")

--- a/tests/libs/datasets/timeseries_test.py
+++ b/tests/libs/datasets/timeseries_test.py
@@ -1752,7 +1752,7 @@ def test_one_region_demographic_distributions():
     assert one_region.demographic_distributions_by_field == expected
 
 
-def test_one_region_demographic_distributions():
+def test_one_region_demographic_distributions_overlapping_buckets():
     m1 = FieldName("m1")
     m2 = FieldName("m2")
     age20s = DemographicBucket("age:20-29")


### PR DESCRIPTION
https://sentry.io/organizations/covidactnow/issues/2295671173/?project=5203044&referrer=slack was a bit surprising to me, but it turns out that because latest is stored in a wide variables way, it somewhat pollutes the bucket name space.

The proper fix is to make `_timeseries_bucketed_latest_values` work from wide dates, but this is a quicker fix that should be alright for now.  