### PR TITLE
timeseries_stats single DataFrame

### DIFF
--- a/dash_app/dashboard.py
+++ b/dash_app/dashboard.py
@@ -19,9 +19,7 @@ from libs.datasets import dataset_utils
 from libs.datasets import timeseries
 from libs.datasets.taglib import TagField
 from libs.datasets.tail_filter import TagType
-from libs.qa.timeseries_stats import PerRegionStats
-from libs.qa.timeseries_stats import RegionAggregationMethod
-from libs.qa.timeseries_stats import VariableAggregationMethod
+from libs.qa import timeseries_stats
 
 EXTERNAL_STYLESHEETS = ["https://codepen.io/chriddyp/pen/bWLwgP.css"]
 
@@ -35,7 +33,9 @@ TAG_TABLE_COLUMNS = [
 ]
 
 
-def region_table(stats: PerRegionStats, dataset: timeseries.MultiRegionDataset) -> pd.DataFrame:
+def region_table(
+    stats: timeseries_stats.PerVariable, dataset: timeseries.MultiRegionDataset
+) -> pd.DataFrame:
     # Use an index to preserve the order while keeping only columns actually present.
     static_columns = pd.Index(
         [
@@ -73,10 +73,10 @@ def init(server):
 
     variable_groups = ["all"] + list(common_fields.FieldGroup)
 
-    per_region_stats_all_vars = PerRegionStats.make(ds)
+    per_region_stats_all_vars = timeseries_stats.PerVariable.make(ds)
 
     agg_stats = per_region_stats_all_vars.aggregate(
-        RegionAggregationMethod.LEVEL, VariableAggregationMethod.FIELD_GROUP
+        timeseries_stats.RegionAggregation.LEVEL, timeseries_stats.VariableAggregation.FIELD_GROUP
     )
 
     source_url_value_counts = (
@@ -87,7 +87,7 @@ def init(server):
     )
 
     counties = ds.get_subset(aggregation_level=AggregationLevel.COUNTY)
-    county_stats = PerRegionStats.make(counties)
+    county_stats = timeseries_stats.PerVariable.make(counties)
     county_variable_population_ratio = pd.DataFrame(
         {
             "has_url": population_ratio_by_variable(counties, county_stats.has_url),
@@ -196,7 +196,7 @@ def population_ratio_by_variable(
 def _init_callbacks(
     dash_app,
     ds: timeseries.MultiRegionDataset,
-    per_region_stats_all_vars: PerRegionStats,
+    per_region_stats_all_vars: timeseries_stats.PerVariable,
     region_id_series: pd.Series,
 ):
     @dash_app.callback(

--- a/dash_app/dashboard.py
+++ b/dash_app/dashboard.py
@@ -1,7 +1,3 @@
-import enum
-from dataclasses import dataclass
-from typing import Collection
-
 import dash
 import dash_core_components as dcc
 import dash_html_components as html
@@ -9,14 +5,11 @@ import dash_table
 import git
 import more_itertools
 import pandas as pd
-import numpy as np
 from covidactnow.datapublic.common_fields import CommonFields
 from covidactnow.datapublic import common_fields
 from covidactnow.datapublic.common_fields import PdFields
-from covidactnow.datapublic.common_fields import ValueAsStrMixin
 from dash.dependencies import Input
 from dash.dependencies import Output
-from pandas.core.dtypes.common import is_numeric_dtype
 from plotly import express as px
 
 from libs import pipeline
@@ -26,6 +19,9 @@ from libs.datasets import dataset_utils
 from libs.datasets import timeseries
 from libs.datasets.taglib import TagField
 from libs.datasets.tail_filter import TagType
+from libs.qa.timeseries_stats import PerRegionStats
+from libs.qa.timeseries_stats import RegionAggregationMethod
+from libs.qa.timeseries_stats import VariableAggregationMethod
 
 EXTERNAL_STYLESHEETS = ["https://codepen.io/chriddyp/pen/bWLwgP.css"]
 
@@ -37,153 +33,6 @@ TAG_TABLE_COLUMNS = [
     TagField.TYPE,
     TagField.CONTENT,
 ]
-
-
-# TODO(tom): Move all the aggregation and statistics stuff to a different module and test it.
-
-
-def _location_id_to_agg(loc_id):
-    """Turns a location_id into a label used for aggregation. For now this is only the
-    AggregationLevel but future UI changes could let the user aggregate regions by state etc."""
-    region = pipeline.Region.from_location_id(loc_id)
-    return region.level.value
-
-
-def _location_id_to_agg_and_state(loc_id):
-    region = pipeline.Region.from_location_id(loc_id)
-    if region.is_county():
-        return region.state
-    else:
-        return region.level.value
-
-
-@enum.unique
-class RegionAggregationMethod(ValueAsStrMixin, str, enum.Enum):
-    LEVEL = "level"
-    LEVEL_AND_COUNTY_BY_STATE = "level_and_county_by_state"
-
-
-@enum.unique
-class VariableAggregationMethod(ValueAsStrMixin, str, enum.Enum):
-    FIELD_GROUP = "field_group"
-    NONE = "none"
-
-
-def _agg_wide_var_counts(
-    wide_vars: pd.DataFrame,
-    location_id_group_by: RegionAggregationMethod,
-    var_group_by: VariableAggregationMethod,
-) -> pd.DataFrame:
-    """Aggregate wide variable counts to make a smaller table."""
-    assert wide_vars.index.names == [CommonFields.LOCATION_ID]
-    assert wide_vars.columns.names == [PdFields.VARIABLE]
-    assert is_numeric_dtype(more_itertools.one(set(wide_vars.dtypes)))
-
-    if location_id_group_by == RegionAggregationMethod.LEVEL:
-        axis0_groupby = wide_vars.groupby(_location_id_to_agg)
-    elif location_id_group_by == RegionAggregationMethod.LEVEL_AND_COUNTY_BY_STATE:
-        axis0_groupby = wide_vars.groupby(_location_id_to_agg_and_state)
-    else:
-        raise ValueError("Bad location_id_group_by")
-
-    agg_counts = axis0_groupby.sum().rename_axis(index=CommonFields.AGGREGATE_LEVEL)
-
-    if var_group_by == VariableAggregationMethod.FIELD_GROUP:
-        agg_counts = agg_counts.groupby(
-            common_fields.COMMON_FIELD_TO_GROUP, axis=1, sort=False
-        ).sum()
-        # Reindex columns to match order of FieldGroup enum.
-        agg_counts = agg_counts.reindex(
-            columns=pd.Index(common_fields.FieldGroup).intersection(agg_counts.columns)
-        )
-
-    return agg_counts
-
-
-@dataclass(frozen=True, eq=False)  # Instances are large so compare by id instead of value
-class AggregatedStats:
-    """Aggregated statistics, where index are regions and columns are variables. Either axis may
-    be filtered to keep only a subset and/or aggregated."""
-
-    # TODO(tom): Move all these into one DataFrame so one vector operation can apply to all of them.
-
-    # A table of count of timeseries
-    has_timeseries: pd.DataFrame
-    # A table of count of URLs
-    has_url: pd.DataFrame
-    # A table of count of annotations
-    annotation_count: pd.DataFrame
-
-
-@dataclass(frozen=True, eq=False)  # Instances are large so compare by id instead of value
-class PerRegionStats(AggregatedStats):
-    """Instances of AggregatedStats where each row represents one region."""
-
-    @staticmethod
-    def make(ds: timeseries.MultiRegionDataset) -> "PerRegionStats":
-        wide_var_has_timeseries = (
-            ds.timeseries_not_bucketed_wide_dates.notnull()
-            .any(1)
-            .unstack(PdFields.VARIABLE, fill_value=False)
-            .astype(bool)
-        )
-        wide_var_has_url = (
-            ds.tag_all_bucket.loc[:, :, TagType.SOURCE_URL].unstack(PdFields.VARIABLE).notnull()
-        )
-        # Need to use pivot_table instead of unstack to aggregate using sum.
-        wide_var_annotation_count = pd.pivot_table(
-            ds.tag_all_bucket.loc[:, :, timeseries.ANNOTATION_TAG_TYPES].notnull().reset_index(),
-            values=TagField.CONTENT,
-            index=CommonFields.LOCATION_ID,
-            columns=PdFields.VARIABLE,
-            aggfunc=np.sum,
-            fill_value=0,
-        )
-
-        return PerRegionStats(
-            has_timeseries=wide_var_has_timeseries,
-            has_url=wide_var_has_url,
-            annotation_count=wide_var_annotation_count,
-        )
-
-    def aggregate(
-        self, regions: RegionAggregationMethod, variables: VariableAggregationMethod
-    ) -> AggregatedStats:
-        return AggregatedStats(
-            has_timeseries=_agg_wide_var_counts(self.has_timeseries, regions, variables),
-            has_url=_agg_wide_var_counts(self.has_url, regions, variables),
-            annotation_count=_agg_wide_var_counts(self.annotation_count, regions, variables),
-        )
-
-    def subset_variables(self, variables: Collection[CommonFields]) -> "PerRegionStats":
-        """Returns a new PerRegionStats with only `variables` in the columns."""
-        return PerRegionStats(
-            has_timeseries=self.has_timeseries.loc[
-                :, self.has_timeseries.columns.intersection(variables).rename(PdFields.VARIABLE)
-            ],
-            has_url=self.has_url.loc[
-                :, self.has_url.columns.intersection(variables).rename(PdFields.VARIABLE)
-            ],
-            annotation_count=self.annotation_count.loc[
-                :, self.annotation_count.columns.intersection(variables).rename(PdFields.VARIABLE)
-            ],
-        )
-
-    def stats_for_locations(self, location_ids: pd.Index) -> pd.DataFrame:
-        """Returns a DataFrame of statistics with `location_ids` as the index."""
-        assert location_ids.names == [CommonFields.LOCATION_ID]
-        # The stats likely don't have a value for every region. Replace any NAs with 0 so that
-        # subtracting them produces a real value.
-        df = pd.DataFrame(
-            {
-                "annotation_count": self.annotation_count.sum(axis=1),
-                "url_count": self.has_url.sum(axis=1),
-                "timeseries_count": self.has_timeseries.sum(axis=1),
-            },
-            index=location_ids,
-        ).fillna(0)
-        df["no_url_count"] = df["timeseries_count"] - df["url_count"]
-        return df
 
 
 def region_table(stats: PerRegionStats, dataset: timeseries.MultiRegionDataset) -> pd.DataFrame:

--- a/dash_app/dashboard.py
+++ b/dash_app/dashboard.py
@@ -182,13 +182,13 @@ def population_ratio_by_variable(
     """Finds the ratio of the population where df is True, broken down by column/variable."""
     assert df.index.names == [CommonFields.LOCATION_ID]
     assert df.columns.names == [PdFields.VARIABLE]
-    population_indexed = dataset.static[CommonFields.POPULATION].reindex(df.index)
+    population_indexed = dataset.static_and_geo_data[CommonFields.POPULATION].reindex(df.index)
     population_total = population_indexed.sum()
     # Make a DataFrame that is like df but filled with zeros.
     zeros = pd.DataFrame(0, index=df.index, columns=df.columns)
     # Where df is True add the population, otherwise add zero. The result is a series with
     # PdFields.VARIABLE index
-    population_where_true = zeros.mask(df, population_indexed, axis=0).sum(axis=0)
+    population_where_true = zeros.mask(df.astype(bool), population_indexed, axis=0).sum(axis=0)
     population_ratio = population_where_true / population_total
     return population_ratio.rename("population_ratio")
 

--- a/dash_app/dashboard.py
+++ b/dash_app/dashboard.py
@@ -182,7 +182,7 @@ def population_ratio_by_variable(
     """Finds the ratio of the population where df is True, broken down by column/variable."""
     assert df.index.names == [CommonFields.LOCATION_ID]
     assert df.columns.names == [PdFields.VARIABLE]
-    population_indexed = dataset.static_and_geo_data[CommonFields.POPULATION].reindex(df.index)
+    population_indexed = dataset.static[CommonFields.POPULATION].reindex(df.index)
     population_total = population_indexed.sum()
     # Make a DataFrame that is like df but filled with zeros.
     zeros = pd.DataFrame(0, index=df.index, columns=df.columns)

--- a/libs/qa/timeseries_stats.py
+++ b/libs/qa/timeseries_stats.py
@@ -1,0 +1,161 @@
+import enum
+from dataclasses import dataclass
+from typing import Collection
+
+import more_itertools
+import numpy as np
+import pandas as pd
+from covidactnow.datapublic import common_fields
+from covidactnow.datapublic.common_fields import CommonFields
+from covidactnow.datapublic.common_fields import PdFields
+from covidactnow.datapublic.common_fields import ValueAsStrMixin
+from pandas.core.dtypes.common import is_numeric_dtype
+
+from libs import pipeline
+from libs.datasets import timeseries
+from libs.datasets.taglib import TagField
+from libs.datasets.tail_filter import TagType
+
+
+def _location_id_to_agg(loc_id):
+    """Turns a location_id into a label used for aggregation. For now this is only the
+    AggregationLevel but future UI changes could let the user aggregate regions by state etc."""
+    region = pipeline.Region.from_location_id(loc_id)
+    return region.level.value
+
+
+def _location_id_to_agg_and_state(loc_id):
+    region = pipeline.Region.from_location_id(loc_id)
+    if region.is_county():
+        return region.state
+    else:
+        return region.level.value
+
+
+@enum.unique
+class RegionAggregationMethod(ValueAsStrMixin, str, enum.Enum):
+    LEVEL = "level"
+    LEVEL_AND_COUNTY_BY_STATE = "level_and_county_by_state"
+
+
+@enum.unique
+class VariableAggregationMethod(ValueAsStrMixin, str, enum.Enum):
+    FIELD_GROUP = "field_group"
+    NONE = "none"
+
+
+def _agg_wide_var_counts(
+    wide_vars: pd.DataFrame,
+    location_id_group_by: RegionAggregationMethod,
+    var_group_by: VariableAggregationMethod,
+) -> pd.DataFrame:
+    """Aggregate wide variable counts to make a smaller table."""
+    assert wide_vars.index.names == [CommonFields.LOCATION_ID]
+    assert wide_vars.columns.names == [PdFields.VARIABLE]
+    assert is_numeric_dtype(more_itertools.one(set(wide_vars.dtypes)))
+
+    if location_id_group_by == RegionAggregationMethod.LEVEL:
+        axis0_groupby = wide_vars.groupby(_location_id_to_agg)
+    elif location_id_group_by == RegionAggregationMethod.LEVEL_AND_COUNTY_BY_STATE:
+        axis0_groupby = wide_vars.groupby(_location_id_to_agg_and_state)
+    else:
+        raise ValueError("Bad location_id_group_by")
+
+    agg_counts = axis0_groupby.sum().rename_axis(index=CommonFields.AGGREGATE_LEVEL)
+
+    if var_group_by == VariableAggregationMethod.FIELD_GROUP:
+        agg_counts = agg_counts.groupby(
+            common_fields.COMMON_FIELD_TO_GROUP, axis=1, sort=False
+        ).sum()
+        # Reindex columns to match order of FieldGroup enum.
+        agg_counts = agg_counts.reindex(
+            columns=pd.Index(common_fields.FieldGroup).intersection(agg_counts.columns)
+        )
+
+    return agg_counts
+
+
+@dataclass(frozen=True, eq=False)  # Instances are large so compare by id instead of value
+class AggregatedStats:
+    """Aggregated statistics, where index are regions and columns are variables. Either axis may
+    be filtered to keep only a subset and/or aggregated."""
+
+    # TODO(tom): Move all these into one DataFrame so one vector operation can apply to all of them.
+
+    # A table of count of timeseries
+    has_timeseries: pd.DataFrame
+    # A table of count of URLs
+    has_url: pd.DataFrame
+    # A table of count of annotations
+    annotation_count: pd.DataFrame
+
+
+@dataclass(frozen=True, eq=False)  # Instances are large so compare by id instead of value
+class PerRegionStats(AggregatedStats):
+    """Instances of AggregatedStats where each row represents one region."""
+
+    @staticmethod
+    def make(ds: timeseries.MultiRegionDataset) -> "PerRegionStats":
+        wide_var_has_timeseries = (
+            ds.timeseries_not_bucketed_wide_dates.notnull()
+            .any(1)
+            .unstack(PdFields.VARIABLE, fill_value=False)
+            .astype(bool)
+        )
+        wide_var_has_url = (
+            ds.tag_all_bucket.loc[:, :, TagType.SOURCE_URL].unstack(PdFields.VARIABLE).notnull()
+        )
+        # Need to use pivot_table instead of unstack to aggregate using sum.
+        wide_var_annotation_count = pd.pivot_table(
+            ds.tag_all_bucket.loc[:, :, timeseries.ANNOTATION_TAG_TYPES].notnull().reset_index(),
+            values=TagField.CONTENT,
+            index=CommonFields.LOCATION_ID,
+            columns=PdFields.VARIABLE,
+            aggfunc=np.sum,
+            fill_value=0,
+        )
+
+        return PerRegionStats(
+            has_timeseries=wide_var_has_timeseries,
+            has_url=wide_var_has_url,
+            annotation_count=wide_var_annotation_count,
+        )
+
+    def aggregate(
+        self, regions: RegionAggregationMethod, variables: VariableAggregationMethod
+    ) -> AggregatedStats:
+        return AggregatedStats(
+            has_timeseries=_agg_wide_var_counts(self.has_timeseries, regions, variables),
+            has_url=_agg_wide_var_counts(self.has_url, regions, variables),
+            annotation_count=_agg_wide_var_counts(self.annotation_count, regions, variables),
+        )
+
+    def subset_variables(self, variables: Collection[CommonFields]) -> "PerRegionStats":
+        """Returns a new PerRegionStats with only `variables` in the columns."""
+        return PerRegionStats(
+            has_timeseries=self.has_timeseries.loc[
+                :, self.has_timeseries.columns.intersection(variables).rename(PdFields.VARIABLE)
+            ],
+            has_url=self.has_url.loc[
+                :, self.has_url.columns.intersection(variables).rename(PdFields.VARIABLE)
+            ],
+            annotation_count=self.annotation_count.loc[
+                :, self.annotation_count.columns.intersection(variables).rename(PdFields.VARIABLE)
+            ],
+        )
+
+    def stats_for_locations(self, location_ids: pd.Index) -> pd.DataFrame:
+        """Returns a DataFrame of statistics with `location_ids` as the index."""
+        assert location_ids.names == [CommonFields.LOCATION_ID]
+        # The stats likely don't have a value for every region. Replace any NAs with 0 so that
+        # subtracting them produces a real value.
+        df = pd.DataFrame(
+            {
+                "annotation_count": self.annotation_count.sum(axis=1),
+                "url_count": self.has_url.sum(axis=1),
+                "timeseries_count": self.has_timeseries.sum(axis=1),
+            },
+            index=location_ids,
+        ).fillna(0)
+        df["no_url_count"] = df["timeseries_count"] - df["url_count"]
+        return df

--- a/libs/qa/timeseries_stats.py
+++ b/libs/qa/timeseries_stats.py
@@ -35,13 +35,13 @@ def _location_id_to_agg_and_state(loc_id):
 
 
 @enum.unique
-class RegionAggregationMethod(ValueAsStrMixin, str, enum.Enum):
+class RegionAggregation(ValueAsStrMixin, str, enum.Enum):
     LEVEL = "level"
     LEVEL_AND_COUNTY_BY_STATE = "level_and_county_by_state"
 
 
 @enum.unique
-class VariableAggregationMethod(ValueAsStrMixin, str, enum.Enum):
+class VariableAggregation(ValueAsStrMixin, str, enum.Enum):
     FIELD_GROUP = "field_group"
     NONE = "none"
 
@@ -52,22 +52,22 @@ def _get_index_level_as_series(df: pd.DataFrame, level: FieldName) -> pd.Series:
 
 def _agg_counts(
     stats_df: pd.DataFrame,
-    location_id_group_by: RegionAggregationMethod,
-    var_group_by: VariableAggregationMethod,
+    location_id_group_by: RegionAggregation,
+    var_group_by: VariableAggregation,
 ) -> pd.DataFrame:
     """Aggregate counts to make a smaller table."""
     assert stats_df.index.names == [CommonFields.LOCATION_ID, PdFields.VARIABLE]
 
     groupby = []
     location_id_series = _get_index_level_as_series(stats_df, CommonFields.LOCATION_ID)
-    if location_id_group_by == RegionAggregationMethod.LEVEL:
+    if location_id_group_by == RegionAggregation.LEVEL:
         groupby.append(location_id_series.map(_location_id_to_agg).rename(LEVEL))
-    elif location_id_group_by == RegionAggregationMethod.LEVEL_AND_COUNTY_BY_STATE:
+    elif location_id_group_by == RegionAggregation.LEVEL_AND_COUNTY_BY_STATE:
         groupby.append(location_id_series.map(_location_id_to_agg_and_state).rename(LEVEL))
     else:
         raise ValueError("Bad location_id_group_by")
 
-    if var_group_by == VariableAggregationMethod.FIELD_GROUP:
+    if var_group_by == VariableAggregation.FIELD_GROUP:
         variable_series = _get_index_level_as_series(stats_df, PdFields.VARIABLE)
         groupby.append(
             variable_series.map(common_fields.COMMON_FIELD_TO_GROUP).rename(VARIABLE_GROUP)
@@ -91,9 +91,8 @@ class StatName(ValueAsStrMixin, str, enum.Enum):
 
 
 @dataclass(frozen=True, eq=False)  # Instances are large so compare by id instead of value
-class AggregatedStats:
-    """Aggregated statistics, where index are regions and columns are variables. Either axis may
-    be filtered to keep only a subset and/or aggregated."""
+class Aggregated:
+    """Aggregated statistics grouped by region and variable, or collections of them."""
 
     stats: pd.DataFrame
 
@@ -132,14 +131,14 @@ def _xs_or_empty(df: pd.DataFrame, key: Collection[str], level: str) -> pd.DataF
 
 
 @dataclass(frozen=True, eq=False)  # Instances are large so compare by id instead of value
-class PerRegionStats(AggregatedStats):
-    """Instances of AggregatedStats where each row represents one timeseries."""
+class PerVariable(Aggregated):
+    """An `Aggregated` where each row represents the values in one variable of one region."""
 
     def __post_init__(self):
         assert self.stats.index.names == [CommonFields.LOCATION_ID, PdFields.VARIABLE]
 
     @staticmethod
-    def make(ds: timeseries.MultiRegionDataset) -> "PerRegionStats":
+    def make(ds: timeseries.MultiRegionDataset) -> "PerVariable":
         # TODO(tom): Change to timeseries_bucketed
         all_timeseries_index = ds.timeseries_not_bucketed_wide_dates.index
         has_timeseries = (
@@ -169,16 +168,14 @@ class PerRegionStats(AggregatedStats):
             }
         )
 
-        return PerRegionStats(stats=stats)
+        return PerVariable(stats=stats)
 
-    def aggregate(
-        self, regions: RegionAggregationMethod, variables: VariableAggregationMethod
-    ) -> AggregatedStats:
-        return AggregatedStats(stats=_agg_counts(self.stats, regions, variables))
+    def aggregate(self, regions: RegionAggregation, variables: VariableAggregation) -> Aggregated:
+        return Aggregated(stats=_agg_counts(self.stats, regions, variables))
 
-    def subset_variables(self, variables: Collection[CommonFields]) -> "PerRegionStats":
-        """Returns a new PerRegionStats with only `variables` in the columns."""
-        return PerRegionStats(stats=_xs_or_empty(self.stats, variables, PdFields.VARIABLE))
+    def subset_variables(self, variables: Collection[CommonFields]) -> "PerVariable":
+        """Returns a new PerVariable with only `variables` in the columns."""
+        return PerVariable(stats=_xs_or_empty(self.stats, variables, PdFields.VARIABLE))
 
     def stats_for_locations(self, location_ids: pd.Index) -> pd.DataFrame:
         """Returns a DataFrame of statistics with `location_ids` as the index."""

--- a/tests/libs/qa/timeseries_states_test.py
+++ b/tests/libs/qa/timeseries_states_test.py
@@ -1,0 +1,62 @@
+from covidactnow.datapublic.common_fields import CommonFields
+from covidactnow.datapublic.common_fields import DemographicBucket
+
+from libs.datasets import AggregationLevel
+from libs.datasets import taglib
+from libs.datasets import timeseries
+from libs.datasets.taglib import UrlStr
+from libs.pipeline import Region
+from libs.qa import timeseries_stats
+from tests import test_helpers
+from tests.test_helpers import TimeseriesLiteral
+
+
+def test_make_from_dataset():
+    region_tx = Region.from_state("TX")
+    region_sf = Region.from_fips("06075")
+    region_la = Region.from_fips("06037")
+    bucket_40s = DemographicBucket("age:40-49")
+    tag1 = test_helpers.make_tag(date="2020-04-01")
+    tag2a = test_helpers.make_tag(date="2020-04-02")
+    tag2b = test_helpers.make_tag(date="2020-04-03")
+    source = taglib.Source("NYTimes", url=UrlStr("http://datasource.co/"))
+
+    dataset = test_helpers.build_dataset(
+        {
+            region_tx: {
+                CommonFields.CASES: [1, 2, 3],
+                CommonFields.VACCINATIONS_COMPLETED: {
+                    bucket_40s: TimeseriesLiteral([6, 7], annotation=[tag1]),
+                    DemographicBucket.ALL: [7, 8, 9],
+                },
+            },
+            # `PerRegionStats.make` crashes if there are no Source tags anywhere.
+            region_sf: {
+                CommonFields.CASES: (
+                    TimeseriesLiteral([4, 5], annotation=[tag2a, tag2b], source=source)
+                )
+            },
+            region_la: {CommonFields.CASES: [8, 9]},
+        }
+    )
+    dataset = timeseries.make_source_url_tags(dataset)
+
+    per_region = timeseries_stats.PerRegionStats.make(dataset)
+
+    # Currently only bucket 'all' is counted so bucket_40s is ignored. TODO(tom): support other
+    #  buckets.
+    assert (
+        per_region.has_timeseries.at[region_tx.location_id, CommonFields.VACCINATIONS_COMPLETED]
+        == 1
+    )
+    assert per_region.annotation_count.at[region_sf.location_id, CommonFields.CASES] == 2
+
+    cases_by_level = per_region.subset_variables([CommonFields.CASES]).aggregate(
+        timeseries_stats.RegionAggregationMethod.LEVEL,
+        timeseries_stats.VariableAggregationMethod.NONE,
+    )
+    assert cases_by_level.has_timeseries.at[AggregationLevel.COUNTY.value, CommonFields.CASES] == 2
+    assert cases_by_level.has_url.at[AggregationLevel.COUNTY.value, CommonFields.CASES] == 1
+    assert (
+        cases_by_level.annotation_count.at[AggregationLevel.COUNTY.value, CommonFields.CASES] == 2
+    )

--- a/tests/libs/qa/timeseries_states_test.py
+++ b/tests/libs/qa/timeseries_states_test.py
@@ -32,7 +32,7 @@ def test_make_from_dataset():
                     DemographicBucket.ALL: [7, 8, 9],
                 },
             },
-            # `PerRegionStats.make` crashes if there are no Source tags anywhere.
+            # `PerVariable.make` crashes if there are no Source tags anywhere.
             region_sf: {
                 CommonFields.CASES: (
                     TimeseriesLiteral([4, 5], annotation=[tag2a, tag2b], source=source)
@@ -48,7 +48,7 @@ def test_make_from_dataset():
     )
     dataset = timeseries.make_source_url_tags(dataset)
 
-    per_region = timeseries_stats.PerRegionStats.make(dataset)
+    per_region = timeseries_stats.PerVariable.make(dataset)
 
     # Currently only bucket 'all' is counted so bucket_40s is ignored. TODO(tom): support other
     #  buckets.
@@ -59,8 +59,7 @@ def test_make_from_dataset():
     assert per_region.annotation_count.at[region_sf.location_id, CommonFields.CASES] == 2
 
     cases_by_level = per_region.subset_variables([CommonFields.CASES]).aggregate(
-        timeseries_stats.RegionAggregationMethod.LEVEL,
-        timeseries_stats.VariableAggregationMethod.NONE,
+        timeseries_stats.RegionAggregation.LEVEL, timeseries_stats.VariableAggregation.NONE,
     )
     assert cases_by_level.has_timeseries.at[AggregationLevel.COUNTY.value, CommonFields.CASES] == 2
     assert cases_by_level.has_url.at[AggregationLevel.COUNTY.value, CommonFields.CASES] == 1
@@ -69,8 +68,7 @@ def test_make_from_dataset():
     )
 
     cases_by_group = per_region.subset_variables([CommonFields.CASES]).aggregate(
-        timeseries_stats.RegionAggregationMethod.LEVEL,
-        timeseries_stats.VariableAggregationMethod.FIELD_GROUP,
+        timeseries_stats.RegionAggregation.LEVEL, timeseries_stats.VariableAggregation.FIELD_GROUP,
     )
     assert (
         cases_by_group.has_timeseries.at[AggregationLevel.COUNTY.value, FieldGroup.CASES_DEATHS]
@@ -85,7 +83,7 @@ def test_make_from_dataset():
     per_region.stats_for_locations(dataset.location_ids)
 
     counties = dataset.get_subset(aggregation_level=AggregationLevel.COUNTY)
-    county_stats = timeseries_stats.PerRegionStats.make(counties)
+    county_stats = timeseries_stats.PerVariable.make(counties)
     pop_by_var_has_url = population_ratio_by_variable(counties, county_stats.has_url)
     assert not pop_by_var_has_url.empty
     pop_by_var_has_ts = population_ratio_by_variable(counties, county_stats.has_timeseries)

--- a/tests/libs/qa/timeseries_states_test.py
+++ b/tests/libs/qa/timeseries_states_test.py
@@ -1,6 +1,8 @@
 from covidactnow.datapublic.common_fields import CommonFields
 from covidactnow.datapublic.common_fields import DemographicBucket
+from covidactnow.datapublic.common_fields import FieldGroup
 
+from dash_app.dashboard import population_ratio_by_variable
 from libs.datasets import AggregationLevel
 from libs.datasets import taglib
 from libs.datasets import timeseries
@@ -37,7 +39,12 @@ def test_make_from_dataset():
                 )
             },
             region_la: {CommonFields.CASES: [8, 9]},
-        }
+        },
+        static_by_region_then_field_name={
+            region_tx: {CommonFields.POPULATION: 10_000},
+            region_sf: {CommonFields.POPULATION: 1_000},
+            region_la: {CommonFields.POPULATION: 5_000},
+        },
     )
     dataset = timeseries.make_source_url_tags(dataset)
 
@@ -60,3 +67,26 @@ def test_make_from_dataset():
     assert (
         cases_by_level.annotation_count.at[AggregationLevel.COUNTY.value, CommonFields.CASES] == 2
     )
+
+    cases_by_group = per_region.subset_variables([CommonFields.CASES]).aggregate(
+        timeseries_stats.RegionAggregationMethod.LEVEL,
+        timeseries_stats.VariableAggregationMethod.FIELD_GROUP,
+    )
+    assert (
+        cases_by_group.has_timeseries.at[AggregationLevel.COUNTY.value, FieldGroup.CASES_DEATHS]
+        == 2
+    )
+    assert cases_by_group.has_url.at[AggregationLevel.COUNTY.value, FieldGroup.CASES_DEATHS] == 1
+    assert (
+        cases_by_group.annotation_count.at[AggregationLevel.COUNTY.value, FieldGroup.CASES_DEATHS]
+        == 2
+    )
+
+    per_region.stats_for_locations(dataset.location_ids)
+
+    counties = dataset.get_subset(aggregation_level=AggregationLevel.COUNTY)
+    county_stats = timeseries_stats.PerRegionStats.make(counties)
+    pop_by_var_has_url = population_ratio_by_variable(counties, county_stats.has_url)
+    assert not pop_by_var_has_url.empty
+    pop_by_var_has_ts = population_ratio_by_variable(counties, county_stats.has_timeseries)
+    assert not pop_by_var_has_ts.empty


### PR DESCRIPTION
* Replaces the DataFrame object per stat in AggregatedStats with a single DataFrame with a column per stat, moving the CommonField variable to level 1 of the index. This simplifies methods `aggregate` and `subset_variables` and will make it easier to add other stats and support buckets.
* Adds some clunky but functional tests of timeseries_stats behavior called by the dashboard code
* Adds some `__post_init__` assert checks that document and enforce the expected structure of the stats DataFrame