### PR TITLE
Add additional checks on API infra deploy

### DIFF
--- a/.github/workflows/deploy_aws_api_infrastructure_dev.yml
+++ b/.github/workflows/deploy_aws_api_infrastructure_dev.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         python-version: 3.7
     - name: Install test requirements
-      run: pip install -r requirements_test.txt
+      run: pip install -r requirements_test.txt -r requirements.txt
     - name: Install Serverless Framework and NPM dependencies
       run: |
         npm install -g serverless
@@ -84,7 +84,7 @@ jobs:
       with:
         python-version: 3.7
     - name: Install test requirements
-      run: pip install -r requirements_test.txt
+      run: pip install -r requirements_test.txt -r requirements.txt
     - name: Install Serverless Framework and NPM dependencies
       run: |
         npm install -g serverless

--- a/.github/workflows/deploy_aws_api_infrastructure_dev.yml
+++ b/.github/workflows/deploy_aws_api_infrastructure_dev.yml
@@ -32,7 +32,7 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
-    - name: Install test requirements
+    - name: Install python requirements
       run: pip install -r requirements_test.txt -r requirements.txt
     - name: Install Serverless Framework and NPM dependencies
       run: |
@@ -83,7 +83,7 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
-    - name: Install test requirements
+    - name: Install python requirements
       run: pip install -r requirements_test.txt -r requirements.txt
     - name: Install Serverless Framework and NPM dependencies
       run: |

--- a/.github/workflows/deploy_aws_api_infrastructure_dev.yml
+++ b/.github/workflows/deploy_aws_api_infrastructure_dev.yml
@@ -32,6 +32,8 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
+    - name: Install test requirements
+      run: pip install -r requirements_test.txt
     - name: Install Serverless Framework and NPM dependencies
       run: |
         npm install -g serverless
@@ -43,6 +45,7 @@ jobs:
         CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
         DOTENV: ${{ secrets.DOTENV }}
         AWS_REGION: us-east-1
+        API_URL: https://api-dev.covidactnow.org/v2
       run: tools/deploy-api-infrastructure.sh dev
 
   TestDev:
@@ -80,6 +83,8 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
+    - name: Install test requirements
+      run: pip install -r requirements_test.txt
     - name: Install Serverless Framework and NPM dependencies
       run: |
         npm install -g serverless
@@ -91,4 +96,5 @@ jobs:
         CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
         DOTENV: ${{ secrets.DOTENV }}
         AWS_REGION: us-east-1
+        API_URL: https://api.covidactnow.org/v2
       run: tools/deploy-api-infrastructure.sh prod

--- a/api/awsauth/awsauth/auth_app.py
+++ b/api/awsauth/awsauth/auth_app.py
@@ -44,7 +44,6 @@ CORS_OPTIONS_HEADERS = {
 
 
 def init():
-    global FIREHOSE_CLIENT
     Config.init()
     registry.initialize()
 

--- a/api/awsauth/end_to_end_test.py
+++ b/api/awsauth/end_to_end_test.py
@@ -1,45 +1,69 @@
+import os
 import requests
 import uuid
 
-DEV_API_URL = "https://api-dev.covidactnow.org/v2"
+API_URL = os.getenv("API_URL", "https://api-dev.covidactnow.org/v2")
 
 
 def test_api_flow():
     randomness = uuid.uuid4().hex[:8]
     test_email = f"testEmail+{randomness}@covidactnow.org"
-    response = requests.post(DEV_API_URL + "/register", json={"email": test_email})
+    response = requests.post(API_URL + "/register", json={"email": test_email})
     assert response.ok
 
     data = response.json()
     api_key = data["api_key"]
     assert data["new_user"]
 
-    response = requests.get(f"{DEV_API_URL}/state/MA.json", {"apiKey": api_key})
+    response = requests.get(f"{API_URL}/state/MA.json", {"apiKey": api_key})
     assert response.ok
 
-    response = requests.get(f"{DEV_API_URL}/states.json", {"apiKey": api_key})
+    response = requests.get(f"{API_URL}/states.json", {"apiKey": api_key})
     assert response.ok
 
-    response = requests.get(f"{DEV_API_URL}/county/36061.json", {"apiKey": api_key})
+    response = requests.get(f"{API_URL}/county/36061.json", {"apiKey": api_key})
     assert response.ok
 
 
 def test_blocked_email():
     # Should be set in .env file for local environment
     test_email = "blocked@covidactnow.org"
-    response = requests.post(DEV_API_URL + "/register", json={"email": test_email})
+    response = requests.post(API_URL + "/register", json={"email": test_email})
     assert response.ok
     data = response.json()
     api_key = data["api_key"]
 
-    response = requests.get(f"{DEV_API_URL}/state/MA.json", {"apiKey": api_key})
+    response = requests.get(f"{API_URL}/state/MA.json", {"apiKey": api_key})
     assert response.status_code == 403
     assert "error" in response.json()
 
 
 def test_invalid_api_key():
-    response = requests.get(f"{DEV_API_URL}/states.json", {"apiKey": "fake api key"})
+    response = requests.get(f"{API_URL}/states.json", {"apiKey": "fake api key"})
     assert response.status_code == 403
     response = response.json()
     expected_error = {"error": "Invalid API key."}
     assert response == expected_error
+
+
+def test_api_flow_existing_user():
+    # Tests to make sure that endpoints work with an account that should already be in the
+    # database. Can be used on on dev or prod url
+    email = "chris+testing@covidactnow.org"
+    response = requests.post(API_URL + "/register", json={"email": email})
+    assert response.ok
+
+    data = response.json()
+    api_key = data["api_key"]
+
+    # User should not be new, should be pulled from existing user.
+    assert not data["new_user"]
+
+    response = requests.get(f"{API_URL}/state/MA.json", {"apiKey": api_key})
+    assert response.ok
+
+    response = requests.get(f"{API_URL}/states.json", {"apiKey": api_key})
+    assert response.ok
+
+    response = requests.get(f"{API_URL}/county/36061.json", {"apiKey": api_key})
+    assert response.ok

--- a/api/awsauth/tools/deploy-api-infrastructure.sh
+++ b/api/awsauth/tools/deploy-api-infrastructure.sh
@@ -29,6 +29,10 @@ execute() {
 $DOTENV
 EOF
 
+  # Run test to make sure that config properly loads - do not want to deploy code if config file
+  # does not work.
+  pytest unit_test.py::test_aws_auth_config_loads
+
   sls config credentials \
       --provider aws \
       --key $AWS_ACCESS_KEY_ID \

--- a/api/awsauth/tools/deploy-api-infrastructure.sh
+++ b/api/awsauth/tools/deploy-api-infrastructure.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-#
 # deploy-api-infrastructure.sh - Deploys API infrastructure to cloudfront lambda function.
+
+set -o nounset
+set -o errexit
 
 # Checks command-line arguments, sets variables, etc.
 prepare () {

--- a/api/awsauth/tools/deploy-api-infrastructure.sh
+++ b/api/awsauth/tools/deploy-api-infrastructure.sh
@@ -42,6 +42,10 @@ EOF
   sls deploy -s $ENV
 
   aws cloudfront wait distribution-deployed --id $CLOUDFRONT_DISTRIBUTION_ID
+
+  # Make sure API endpoints are working after deploy. Pulls from existing user and makes
+  # sure that API returns results.
+  pytest end_to_end_test.py::test_api_flow_existing_user
 }
 
 prepare "$@"

--- a/api/awsauth/unit_test.py
+++ b/api/awsauth/unit_test.py
@@ -4,4 +4,3 @@ from awsauth.config import Config
 def test_aws_auth_config_loads():
     Config.init()
     assert Config.Constants.API_KEY_TABLE_NAME is not None
-    assert 0

--- a/api/awsauth/unit_test.py
+++ b/api/awsauth/unit_test.py
@@ -4,3 +4,4 @@ from awsauth.config import Config
 def test_aws_auth_config_loads():
     Config.init()
     assert Config.Constants.API_KEY_TABLE_NAME is not None
+    assert 0

--- a/api/awsauth/unit_test.py
+++ b/api/awsauth/unit_test.py
@@ -1,0 +1,6 @@
+from awsauth.config import Config
+
+
+def test_aws_auth_config_loads():
+    Config.init()
+    assert Config.Constants.API_KEY_TABLE_NAME is not None


### PR DESCRIPTION
This adds in a couple sanity checks before and after the lambda deploy.

I think this could potentially belong in a separate step, but because they are lightweight and broad checks, it doesn't feel like it steps on the toes of other types of testing.  

Checks added:
 * Unit test to load config object - this protects against a bad .env file
 * Simple request checking that api endpoints work