### PR TITLE
Submit hubspot form instead of normal contact creation

### DIFF
--- a/api/awsauth/awsauth/auth_app.py
+++ b/api/awsauth/awsauth/auth_app.py
@@ -115,7 +115,7 @@ def _get_or_create_api_key(email: str, is_crs_user: bool) -> Tuple[bool, str]:
 
     # attempt to add hubspot contact, but don't block reg on failure.
     try:
-        registry.hubspot_client.create_contact(email)
+        registry.hubspot_client.submit_reg_form(email)
     except hubspot_client.HubSpotAPICallFailed:
         _logger.error("HubSpot call failed")
         sentry_sdk.capture_exception()

--- a/api/awsauth/awsauth/config.py
+++ b/api/awsauth/awsauth/config.py
@@ -25,6 +25,13 @@ class EnvConstants(pydantic.BaseSettings):
 
     HUBSPOT_ENABLED: bool
 
+    # Hubspot portal id differs between environments. We have a separate
+    # hubspot portal for our dev environment.
+    HUBSPOT_PORTAL_ID: str
+
+    # GUID of hubspot form used for API signup
+    HUBSPOT_REG_FORM_GUID: str
+
     EMAIL_BLOCKLIST: List[str]
 
     class Config:

--- a/api/awsauth/awsauth/hubspot_client.py
+++ b/api/awsauth/awsauth/hubspot_client.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import requests
 from awsauth.config import Config
 
@@ -7,7 +8,7 @@ class HubSpotAPICallFailed(Exception):
 
 
 class HubSpotClient:
-    def create_contact(self, email: str) -> dict:
+    def create_contact(self, email: str) -> Optional[dict]:
         """Creates a contact in hubspot for a given email.
 
         Args:
@@ -30,5 +31,33 @@ class HubSpotClient:
 
         if not response.ok:
             raise HubSpotAPICallFailed("Hubspot contact creation failed")
+
+        return response.json()
+
+    def submit_reg_form(self, email: str) -> Optional[dict]:
+        """Submit hubspot registration form.
+
+        Args:
+            email: Email of user creating account.
+
+        Returns: Successful form submission response.
+
+        Raises: HubSpotAPICallFailed on Hubspot error.
+        """
+        if not Config.Constants.HUBSPOT_ENABLED:
+            return
+
+        portal_id = Config.Constants.HUBSPOT_PORTAL_ID
+        form_guid = Config.Constants.HUBSPOT_REG_FORM_GUID
+
+        # https://legacydocs.hubspot.com/docs/methods/forms/submit_form
+        url = f"https://api.hsforms.com/submissions/v3/integration/submit/{portal_id}/{form_guid}"
+
+        form_data = {"fields": [{"name": "email", "value": email}]}
+
+        response = requests.post(url, json=form_data)
+
+        if not response.ok:
+            raise HubSpotAPICallFailed("Hubspot form submission failed")
 
         return response.json()

--- a/api/awsauth/awsauth/hubspot_client.py
+++ b/api/awsauth/awsauth/hubspot_client.py
@@ -8,39 +8,13 @@ class HubSpotAPICallFailed(Exception):
 
 
 class HubSpotClient:
-    def create_contact(self, email: str) -> Optional[dict]:
-        """Creates a contact in hubspot for a given email.
-
-        Args:
-            email: Email address of contact.
-
-        Returns: Successful contact creation response.
-
-        Raises: HubSpotAPICallFailed on Hubspot error.
-        """
-        if not Config.Constants.HUBSPOT_ENABLED:
-            return
-
-        # https://pypi.org/project/hubspot-api-client/
-        url = "https://api.hubapi.com/crm/v3/objects/contacts"
-
-        querystring = {"hapikey": Config.Constants.HUBSPOT_API_KEY}
-        data = {"properties": {"email": email}}
-
-        response = requests.post(url, json=data, params=querystring)
-
-        if not response.ok:
-            raise HubSpotAPICallFailed("Hubspot contact creation failed")
-
-        return response.json()
-
     def submit_reg_form(self, email: str) -> Optional[dict]:
         """Submit hubspot registration form.
 
         Args:
             email: Email of user creating account.
 
-        Returns: Successful form submission response.
+        Returns: Successful form submission response if hubspot enabled. None if hubspot disable.
 
         Raises: HubSpotAPICallFailed on Hubspot error.
         """


### PR DESCRIPTION
This is a first step to improving the signup form - we will be using a hubspot form to pass additional signup data through.  

This will then be added to the contact created in hubspot.

As we add in more data that will be passed up through the sign up form, we can add more properties here