### PR TITLE
Adding hubspot token to form

### DIFF
--- a/api/awsauth/awsauth/auth_app.py
+++ b/api/awsauth/awsauth/auth_app.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Dict, Optional
+from typing import Dict, Optional
 import uuid
 import dataclasses
 import urllib.parse
@@ -151,7 +151,9 @@ def _create_new_user(args: RegistrationArguments) -> str:
 
     # attempt to add hubspot contact, but don't block reg on failure.
     try:
-        registry.hubspot_client.submit_reg_form(email)
+        registry.hubspot_client.submit_reg_form(
+            email, hubspot_token=args.hubspot_token, page_uri=args.page_uri
+        )
     except hubspot_client.HubSpotAPICallFailed:
         _logger.error("HubSpot call failed")
         sentry_sdk.capture_exception()

--- a/api/awsauth/awsauth/auth_app.py
+++ b/api/awsauth/awsauth/auth_app.py
@@ -70,6 +70,8 @@ class RegistrationArguments:
 
     hubspot_token: Optional[str]
 
+    page_uri: Optional[str]
+
     @staticmethod
     def make_from_json_body(data: Dict) -> "RegistrationArguments":
         if "email" not in data:
@@ -84,8 +86,10 @@ class RegistrationArguments:
 
         hubspot_token = data.get("hubspot_token")
 
+        page_uri = data.get("page_uri")
+
         return RegistrationArguments(
-            email=email, is_crs_user=is_crs_user, hubspot_token=hubspot_token
+            email=email, is_crs_user=is_crs_user, hubspot_token=hubspot_token, page_uri=page_uri
         )
 
 

--- a/api/awsauth/awsauth/auth_app.py
+++ b/api/awsauth/awsauth/auth_app.py
@@ -61,6 +61,10 @@ if IS_LAMBDA:
     init()
 
 
+class InvalidInputError(Exception):
+    """Error raised on invalid input for registration form parameters."""
+
+
 @dataclasses.dataclass(frozen=True)
 class RegistrationArguments:
 
@@ -75,12 +79,12 @@ class RegistrationArguments:
     @staticmethod
     def make_from_json_body(data: Dict) -> "RegistrationArguments":
         if "email" not in data:
-            raise ValueError("Missing email parameter")
+            raise InvalidInputError("Missing email parameter")
 
         email = data["email"]
 
         if not re.match(EMAIL_REGEX, email):
-            raise ValueError("Invalid email")
+            raise InvalidInputError("Invalid email")
 
         is_crs_user = data.get("is_crs_user", False)
 
@@ -242,7 +246,7 @@ def register_edge(event, context):
 
     try:
         args = RegistrationArguments.make_from_json_body(data)
-    except ValueError as exn:
+    except InvalidInputError as exn:
         return {"status": 400, "errorMessage": str(exn), "headers": headers}
 
     api_key = _get_api_key(args.email, args.is_crs_user)

--- a/api/awsauth/awsauth/auth_app.py
+++ b/api/awsauth/awsauth/auth_app.py
@@ -61,6 +61,34 @@ if IS_LAMBDA:
     init()
 
 
+@dataclasses.dataclass(frozen=True)
+class RegistrationArguments:
+
+    email: str
+
+    is_crs_user: bool
+
+    hubspot_token: Optional[str]
+
+    @staticmethod
+    def make_from_input_data(data: Dict) -> "RegistrationArguments":
+        if "email" not in data:
+            raise ValueError("Missing email parameter")
+
+        email = data["email"]
+
+        if not re.match(EMAIL_REGEX, email):
+            raise ValueError("Invalid email")
+
+        is_crs_user = data.get("is_crs_usr", False)
+
+        hubspot_token = data.get("hubspot_token")
+
+        return RegistrationArguments(
+            email=email, is_crs_user=is_crs_user, hubspot_token=hubspot_token
+        )
+
+
 # Fairly permissive email regex taken from
 # https://stackoverflow.com/questions/8022530/how-to-check-for-valid-email-address#comment52453093_8022584
 EMAIL_REGEX = r"[^@\s]+@[^@\s]+\.[a-zA-Z0-9]+$"
@@ -179,34 +207,6 @@ def check_api_key_edge(event, context):
 
     # Return request, which forwards to S3 backend.
     return request
-
-
-@dataclasses.dataclass(frozen=True)
-class RegistrationArguments:
-
-    email: str
-
-    is_crs_user: bool
-
-    hubspot_token: Optional[str]
-
-    @staticmethod
-    def make_from_input_data(data: Dict) -> "RegistrationArguments":
-        if "email" not in data:
-            raise ValueError("Missing email parameter")
-
-        email = data["email"]
-
-        if not re.match(EMAIL_REGEX, email):
-            raise ValueError("Invalid email")
-
-        is_crs_user = data.get("is_crs_usr", False)
-
-        hubspot_token = data.get("hubspot_token")
-
-        return RegistrationArguments(
-            email=email, is_crs_user=is_crs_user, hubspot_token=hubspot_token
-        )
 
 
 def register_edge(event, context):

--- a/api/awsauth/awsauth/auth_app.py
+++ b/api/awsauth/awsauth/auth_app.py
@@ -82,7 +82,7 @@ class RegistrationArguments:
         if not re.match(EMAIL_REGEX, email):
             raise ValueError("Invalid email")
 
-        is_crs_user = data.get("is_crs_usr", False)
+        is_crs_user = data.get("is_crs_user", False)
 
         hubspot_token = data.get("hubspot_token")
 

--- a/api/awsauth/awsauth/auth_app.py
+++ b/api/awsauth/awsauth/auth_app.py
@@ -71,7 +71,7 @@ class RegistrationArguments:
     hubspot_token: Optional[str]
 
     @staticmethod
-    def make_from_input_data(data: Dict) -> "RegistrationArguments":
+    def make_from_json_body(data: Dict) -> "RegistrationArguments":
         if "email" not in data:
             raise ValueError("Missing email parameter")
 

--- a/api/awsauth/awsauth/hubspot_client.py
+++ b/api/awsauth/awsauth/hubspot_client.py
@@ -8,7 +8,7 @@ class HubSpotAPICallFailed(Exception):
 
 
 class HubSpotClient:
-    def submit_reg_form(self, email: str) -> Optional[dict]:
+    def submit_reg_form(self, email: str, hubspot_token: Optional[str] = None) -> Optional[dict]:
         """Submit hubspot registration form.
 
         Args:
@@ -28,6 +28,9 @@ class HubSpotClient:
         url = f"https://api.hsforms.com/submissions/v3/integration/submit/{portal_id}/{form_guid}"
 
         form_data = {"fields": [{"name": "email", "value": email}]}
+
+        if hubspot_token:
+            form_data["context"] = {"hutk": hubspot_token}
 
         response = requests.post(url, json=form_data)
 

--- a/api/awsauth/awsauth/hubspot_client.py
+++ b/api/awsauth/awsauth/hubspot_client.py
@@ -8,11 +8,15 @@ class HubSpotAPICallFailed(Exception):
 
 
 class HubSpotClient:
-    def submit_reg_form(self, email: str, hubspot_token: Optional[str] = None) -> Optional[dict]:
+    def submit_reg_form(
+        self, email: str, hubspot_token: Optional[str] = None, page_uri: Optional[str] = None
+    ) -> Optional[dict]:
         """Submit hubspot registration form.
 
         Args:
             email: Email of user creating account.
+            hubspot_token: Hubspot token passed from browser cookie.
+            page_uri: URI of page where reg submission happened.
 
         Returns: Successful form submission response if hubspot enabled. None if hubspot disable.
 
@@ -29,8 +33,15 @@ class HubSpotClient:
 
         form_data = {"fields": [{"name": "email", "value": email}]}
 
+        context = {}
+
         if hubspot_token:
-            form_data["context"] = {"hutk": hubspot_token}
+            context["hutk"] = hubspot_token
+        if page_uri:
+            context["pageUri"] = page_uri
+
+        if context:
+            form_data["context"] = context
 
         response = requests.post(url, json=form_data)
 

--- a/api/docs/src/components/SignupForm.jsx
+++ b/api/docs/src/components/SignupForm.jsx
@@ -12,6 +12,19 @@ import {
 // Taken from https://ui.dev/validate-email-address-javascript/
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+const HUBSPOT_COOKIE_NAME = "hubspotutk";
+
+// Taken from
+// https://gist.github.com/joduplessis/7b3b4340353760e945f972a69e855d11
+function getCookie(name) {
+  const value = "; " + document.cookie;
+  const parts = value.split("; " + name + "=");
+
+  if (parts.length == 2) {
+    return parts.pop().split(";").shift();
+  }
+}
+
 const trackEmailSignupSuccess = (isNewUser) => {
   ga('send', {
     hitType: 'event',
@@ -37,9 +50,11 @@ const SignupForm = () => {
       setErrorMessage("Must supply a valid email address");
       return;
     }
+    const hubspotToken = getCookie(HUBSPOT_COOKIE_NAME);
+
     fetch(siteConfig.customFields.registerUrl, {
       method: "POST",
-      body: JSON.stringify({ email }),
+      body: JSON.stringify({ email, hubspot_token: hubspotToken }),
       headers: { "Content-Type": "application/json" },
     })
       .then((res) => res.json())

--- a/api/docs/src/components/SignupForm.jsx
+++ b/api/docs/src/components/SignupForm.jsx
@@ -41,7 +41,7 @@ const SignupForm = () => {
   const [email, setEmail] = useState();
   const [apiKey, setApiKey] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
-  const {siteConfig} = useDocusaurusContext();
+  const { siteConfig } = useDocusaurusContext();
 
   const onSubmit = async (e) => {
     e.preventDefault();
@@ -50,11 +50,16 @@ const SignupForm = () => {
       setErrorMessage("Must supply a valid email address");
       return;
     }
+
     const hubspotToken = getCookie(HUBSPOT_COOKIE_NAME);
 
     fetch(siteConfig.customFields.registerUrl, {
       method: "POST",
-      body: JSON.stringify({ email, hubspot_token: hubspotToken }),
+      body: JSON.stringify({
+        email,
+        hubspot_token: hubspotToken,
+        page_uri: window.location.href,
+      }),
       headers: { "Content-Type": "application/json" },
     })
       .then((res) => res.json())


### PR DESCRIPTION
This lets us capture the hubspot token cookie and pass to form submission.  

Also adds in a bit of refactoring - when the more complicated reg form is added there will be a separate endpoint for retrieving an existing token.  This breaks up the `_get_api_key` and `_create_new_user` functions and adds a small class to parse/handle errors for input