### PR TITLE
remove block for UT TriCounty

### DIFF
--- a/libs/datasets/manual_filter.py
+++ b/libs/datasets/manual_filter.py
@@ -18,20 +18,6 @@ _logger = structlog.getLogger()
 CONFIG = {
     "filters": [
         {
-            "regions_included": [
-                Region.from_fips("49009"),
-                Region.from_fips("49013"),
-                Region.from_fips("49047"),
-            ],
-            "observations_to_drop": {
-                "start_date": "2021-02-12",
-                "fields": [CommonFields.CASES, CommonFields.DEATHS],
-                "internal_note": "https://trello.com/c/aj7ep7S7/1130",
-                "public_note": "The TriCounty Health Department is focusing on vaccinations "
-                "and we have not found a new source of case counts.",
-            },
-        },
-        {
             "regions_included": [RegionMask(AggregationLevel.COUNTY, states=["OK"])],
             "regions_excluded": [Region.from_fips("40109"), Region.from_fips("40143")],
             "observations_to_drop": {


### PR DESCRIPTION
Unblock CASES and DEATHS that were blocked for https://trello.com/c/aj7ep7S7/1130-3-utah-counties-tricounty now that https://github.com/nytimes/covid-19-data/issues/560 is addressed.


## Tested
`./run.py data update` and `git difftool --no-prompt -t vimdiff main -- data/multiregion-wide-dates.csv` confirms that only cases and deaths for these 3 counties change and they are different now.