### PR TITLE
data update --aggregate-to-country by default

### DIFF
--- a/cli/data.py
+++ b/cli/data.py
@@ -82,7 +82,7 @@ def update_forecasts(filename):
     "--aggregate-to-country/--no-aggregate-to-country",
     is_flag=True,
     help="Aggregate states to one USA country region",
-    default=False,
+    default=True,
 )
 @click.option("--state", type=str, help="For testing, a two letter state abbr")
 @click.option("--fips", type=str, help="For testing, a 5 digit county fips")


### PR DESCRIPTION
This PR finishes https://trello.com/c/EyISOtVY/623-usa-data-aggregation-in-pipeline-doesnt-work

## Tested

`./run.py data update` and `git status`, `git difftool` showed that data/multiregion-wide-dates.csv and data/multiregion-status.csv had iso1:us data added and nothing else changed.

`python pyseir/cli.py build-all --generate-api-v2 --location-id-matches 'iso1:us$'` ran without error on my laptop but didn't output any API data. Getting it in the API is https://trello.com/c/dckJRBsA/574-add-usa-aggregation-to-api.