### PR TITLE
More uses of manual_filter. Ignore tests when checking subclasses.

### DIFF
--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -12,7 +12,6 @@ import pandas as pd
 import structlog
 
 from covidactnow.datapublic.common_fields import CommonFields
-from covidactnow.datapublic.common_fields import FieldGroup
 from covidactnow.datapublic.common_fields import FieldName
 from typing_extensions import final
 
@@ -149,26 +148,6 @@ NYTimesDatasetWithoutNYCOrIACounties = datasource_regions(
 )
 
 
-HHSHospitalCountyDatasetFixed = datasource_regions(
-    HHSHospitalCountyDataset,
-    # This data source contains only county data so this include effectively includes them all.
-    include=RegionMask(AggregationLevel.COUNTY),
-    manual_filter={
-        "filters": [
-            {
-                "regions_included": [RegionMask(AggregationLevel.COUNTY)],
-                "observations_to_drop": {
-                    "start_date": "2021-04-06",
-                    "field_group": FieldGroup.HEALTHCARE_CAPACITY,
-                    "internal_note": "https://trello.com/c/Dls22XAk/1226-hhs-facility-hospital",
-                    "public_note": "Truncated data in the future",
-                },
-            },
-        ]
-    },
-)
-
-
 # Below are two instances of feature definitions. These define
 # how to assemble values for a specific field.  Right now, we only
 # support overlaying values. i.e. a row of
@@ -194,27 +173,27 @@ ALL_TIMESERIES_FEATURE_DEFINITION: FeatureDataSourceMap = {
         CANScraperStateProviders,
         CovidTrackingDataSource,
         TexasHospitalizations,
-        HHSHospitalCountyDatasetFixed,
+        HHSHospitalCountyDataset,
         HHSHospitalStateDataset,
     ],
     CommonFields.CURRENT_ICU: [
         CANScraperStateProviders,
         CovidTrackingDataSource,
         TexasHospitalizations,
-        HHSHospitalCountyDatasetFixed,
+        HHSHospitalCountyDataset,
         HHSHospitalStateDataset,
     ],
-    CommonFields.CURRENT_ICU_TOTAL: [HHSHospitalCountyDatasetFixed, HHSHospitalStateDataset],
+    CommonFields.CURRENT_ICU_TOTAL: [HHSHospitalCountyDataset, HHSHospitalStateDataset],
     CommonFields.CURRENT_VENTILATED: [CovidTrackingDataSource],
     CommonFields.DEATHS: [
         CANScraperStateProviders,
         CANScraperUSAFactsProvider,
         NYTimesDatasetWithoutNYCOrIACounties,
     ],
-    CommonFields.HOSPITAL_BEDS_IN_USE_ANY: [HHSHospitalCountyDatasetFixed, HHSHospitalStateDataset],
+    CommonFields.HOSPITAL_BEDS_IN_USE_ANY: [HHSHospitalCountyDataset, HHSHospitalStateDataset],
     CommonFields.ICU_BEDS: [
         CANScraperStateProviders,
-        HHSHospitalCountyDatasetFixed,
+        HHSHospitalCountyDataset,
         HHSHospitalStateDataset,
     ],
     CommonFields.NEGATIVE_TESTS: [CovidTrackingDataSource, HHSTestingDataset],
@@ -241,11 +220,7 @@ ALL_FIELDS_FEATURE_DEFINITION: FeatureDataSourceMap = {
     CommonFields.POPULATION: [FIPSPopulation],
     # TODO(michael): We don't really trust the CCM bed numbers and would ideally remove them entirely.
     CommonFields.ALL_BED_TYPICAL_OCCUPANCY_RATE: [CovidCareMapBeds],
-    CommonFields.ICU_BEDS: [
-        CovidCareMapBeds,
-        HHSHospitalCountyDatasetFixed,
-        HHSHospitalStateDataset,
-    ],
+    CommonFields.ICU_BEDS: [CovidCareMapBeds, HHSHospitalCountyDataset, HHSHospitalStateDataset],
     CommonFields.ICU_TYPICAL_OCCUPANCY_RATE: [CovidCareMapBeds],
     CommonFields.LICENSED_BEDS: [CovidCareMapBeds],
     CommonFields.MAX_BED_COUNT: [CovidCareMapBeds],

--- a/libs/datasets/manual_filter.py
+++ b/libs/datasets/manual_filter.py
@@ -1,6 +1,7 @@
 import dataclasses
 
 import structlog
+from covidactnow.datapublic import common_fields
 from covidactnow.datapublic.common_fields import CommonFields
 from covidactnow.datapublic.common_fields import PdFields
 import pandas as pd
@@ -39,7 +40,11 @@ def drop_observations(
 
     ts_in = dataset.timeseries_bucketed_wide_dates
 
-    mask_selected_fields = ts_in.index.get_level_values(PdFields.VARIABLE).isin(config["fields"])
+    if "field_group" in config:
+        fields = common_fields.FIELD_GROUP_TO_LIST_FIELDS[config["field_group"]]
+    else:
+        fields = config["fields"]
+    mask_selected_fields = ts_in.index.get_level_values(PdFields.VARIABLE).isin(fields)
     ts_selected_fields = ts_in.loc[mask_selected_fields]
     ts_not_selected_fields = ts_in.loc[~mask_selected_fields]
 

--- a/tests/libs/datasets/combined_dataset_utils_test.py
+++ b/tests/libs/datasets/combined_dataset_utils_test.py
@@ -76,6 +76,7 @@ def test_include_exclude_regions():
             Region.from_fips("36061"),
             RegionMask(level=AggregationLevel.COUNTY, states=["DC"]),
         ],
+        manual_filter_config=None,
     )
 
     location_ids = set(mask.make_dataset().location_ids)

--- a/tests/libs/datasets/data_source_test.py
+++ b/tests/libs/datasets/data_source_test.py
@@ -152,14 +152,14 @@ def test_data_source_truncates_dates_can_scraper():
 
 def test_can_scraper_class_single_provider():
     cls: data_source.CanScraperBase
-    for cls in test_helpers.get_concrete_subclasses(data_source.CanScraperBase):
+    for cls in test_helpers.get_concrete_subclasses_not_in_tests(data_source.CanScraperBase):
         providers = set(v.provider for v in cls.VARIABLES)
         assert len(providers) == 1
 
 
 def test_can_scraper_class_unique_variable_names():
     cls: data_source.CanScraperBase
-    for cls in test_helpers.get_concrete_subclasses(data_source.CanScraperBase):
+    for cls in test_helpers.get_concrete_subclasses_not_in_tests(data_source.CanScraperBase):
         variables_not_none = [v for v in cls.VARIABLES if v.common_field is not None]
         # Source `variable_name` may be duplicated with different measurement or unit.
         assert len(variables_not_none) == len(
@@ -171,7 +171,7 @@ def test_can_scraper_class_unique_variable_names():
 
 def test_can_scraper_class_variable_set():
     cls: data_source.CanScraperBase
-    for cls in test_helpers.get_concrete_subclasses(data_source.CanScraperBase):
+    for cls in test_helpers.get_concrete_subclasses_not_in_tests(data_source.CanScraperBase):
         assert cls.VARIABLES
 
 
@@ -181,7 +181,7 @@ def test_can_scraper_class_expected_fields_set():
     with pytest.raises(AttributeError):
         data_source.DataSource.EXPECTED_FIELDS
     cls: data_source.DataSource
-    for cls in test_helpers.get_concrete_subclasses(data_source.DataSource):
+    for cls in test_helpers.get_concrete_subclasses_not_in_tests(data_source.DataSource):
         assert isinstance(cls.EXPECTED_FIELDS, list)
         assert cls.SOURCE_TYPE
         assert isinstance(cls.SOURCE_TYPE, str)

--- a/tests/libs/datasets/taglib_test.py
+++ b/tests/libs/datasets/taglib_test.py
@@ -5,7 +5,7 @@ from tests import test_helpers
 
 def _get_subclass_tag_types(cls):
     """Returns a list of all TAG_TYPE subclasses of concrete subclasses of cls."""
-    return [k.TAG_TYPE for k in test_helpers.get_concrete_subclasses(cls)]
+    return [k.TAG_TYPE for k in test_helpers.get_concrete_subclasses_not_in_tests(cls)]
 
 
 def test_all_tag_subclasses_accounted_for():

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -318,11 +318,15 @@ def get_subclasses(cls) -> Iterable[Type]:
         yield subclass
 
 
-def get_concrete_subclasses(cls) -> Iterable[Type]:
-    """Yields all subclasses of `cls` that have no abstract methods and do not directly subclass
-    abc.ABC."""
+def get_concrete_subclasses_not_in_tests(cls) -> Iterable[Type]:
+    """Yields all subclasses of `cls` that have no abstract methods, do not directly subclass
+    abc.ABC and are not in a `tests` module."""
     for subcls in get_subclasses(cls):
-        if not inspect.isabstract(subcls) and abc.ABC not in subcls.__bases__:
+        if (
+            not inspect.isabstract(subcls)
+            and abc.ABC not in subcls.__bases__
+            and not subcls.__module__.startswith("tests.")
+        ):
             yield subcls
 
 


### PR DESCRIPTION
This PR was originally motivated by  https://github.com/covid-projections/covid-data-model/pull/1065 but wasn't used to resolve it.

* adds manual_filter support for field_group
* adds datasource_regions manual_filter
* Unrelated fix for tests/libs/datasets/data_source_test.py::test_can_scraper_class_expected_fields_set by changing get_concrete_subclasses to get_concrete_subclasses_not_in_tests, exempting test subclasses from checks