### PR TITLE
Fewer dashboard tables, pivot table help and defaults

### DIFF
--- a/dash_app/dashboard.py
+++ b/dash_app/dashboard.py
@@ -105,9 +105,9 @@ def init(server):
         children=[
             html.H1(children="CAN Data Pipeline Dashboard"),
             html.P(commit_str),
-            html.H2("Time-series pivot table"),
+            html.H2("Time series pivot table"),
             dcc.Markdown(
-                "Drag attributes to explore information about time-series in "
+                "Drag attributes to explore information about time series in "
                 "this dataset. See an animated demo in the [Dash Pivottable docs]("
                 "https://github.com/plotly/dash-pivottable#readme)."
             ),
@@ -123,9 +123,10 @@ def init(server):
                     dash_table_from_data_frame(
                         source_url_value_counts, id="source_url_counts", page_size=8
                     ),
-                    html.Br(),  # Give table above some space for page action controls
-                    html.Br(),  # Give table above some space for page action controls
-                    html.Br(),  # Give table above some space for page action controls
+                    # Add some BR as a hack to give table above some space for page action controls
+                    html.Br(),
+                    html.Br(),
+                    html.Br(),
                     dash_table_from_data_frame(agg_level_and_field_group.has_url, id="agg_has_url"),
                     html.P("Ratio of population in county data with a URL, by variable"),
                     dash_table_from_data_frame(

--- a/dash_app/dashboard.py
+++ b/dash_app/dashboard.py
@@ -79,9 +79,6 @@ def init(server):
     agg_level_and_field_group = per_timeseries_stats.aggregate(
         CommonFields.AGGREGATE_LEVEL, timeseries_stats.FIELD_GROUP
     )
-    agg_level_and_distribution = per_timeseries_stats.aggregate(
-        CommonFields.AGGREGATE_LEVEL, timeseries_stats.DISTRIBUTION
-    )
 
     source_url_value_counts = (
         ds.tag_all_bucket.loc[:, :, TagType.SOURCE_URL]
@@ -108,17 +105,18 @@ def init(server):
         children=[
             html.H1(children="CAN Data Pipeline Dashboard"),
             html.P(commit_str),
-            html.H2("Time-series count"),
-            html.H3("By variable group"),
-            dash_table_from_data_frame(
-                agg_level_and_field_group.has_timeseries, id="agg_has_timeseries"
+            html.H2("Time-series pivot table"),
+            dcc.Markdown(
+                "Drag attributes to explore information about time-series in "
+                "this dataset. See an animated demo in the [Dash Pivottable docs]("
+                "https://github.com/plotly/dash-pivottable#readme)."
             ),
-            html.H3("By demographic distribution"),
-            dash_table_from_data_frame(
-                agg_level_and_distribution.has_timeseries, id="distribution_timeseries_count",
+            dash_pivottable.PivotTable(
+                id="pivot_table",
+                data=pivottable_data,
+                rows=[CommonFields.AGGREGATE_LEVEL],
+                cols=[timeseries_stats.FIELD_GROUP, timeseries_stats.DISTRIBUTION],
             ),
-            html.H2("Interactive pivot table"),
-            dash_pivottable.PivotTable(id="pivot_table", data=pivottable_data),
             html.H2("Source URLs"),
             dash_table_from_data_frame(
                 source_url_value_counts, id="source_url_counts", page_size=8

--- a/dash_app/dashboard.py
+++ b/dash_app/dashboard.py
@@ -118,16 +118,20 @@ def init(server):
                 cols=[timeseries_stats.FIELD_GROUP, timeseries_stats.DISTRIBUTION],
             ),
             html.H2("Source URLs"),
-            dash_table_from_data_frame(
-                source_url_value_counts, id="source_url_counts", page_size=8
-            ),
-            html.Br(),  # Give table above some space for page action controls
-            html.Br(),  # Give table above some space for page action controls
-            html.Br(),  # Give table above some space for page action controls
-            dash_table_from_data_frame(agg_level_and_field_group.has_url, id="agg_has_url"),
-            html.P("Ratio of population in county data with a URL, by variable"),
-            dash_table_from_data_frame(
-                county_variable_population_ratio, id="county_variable_population_ratio"
+            html.Details(
+                [
+                    dash_table_from_data_frame(
+                        source_url_value_counts, id="source_url_counts", page_size=8
+                    ),
+                    html.Br(),  # Give table above some space for page action controls
+                    html.Br(),  # Give table above some space for page action controls
+                    html.Br(),  # Give table above some space for page action controls
+                    dash_table_from_data_frame(agg_level_and_field_group.has_url, id="agg_has_url"),
+                    html.P("Ratio of population in county data with a URL, by variable"),
+                    dash_table_from_data_frame(
+                        county_variable_population_ratio, id="county_variable_population_ratio",
+                    ),
+                ]
             ),
             html.H2("Regions"),
             html.Div(


### PR DESCRIPTION
## Tested

Manually tested. To get faster dashboard reloads I used a subset of our data with

```
cp tests/data/test-combined-wide-dates.csv data/multiregion-wide-dates.csv
cp tests/data/test-combined-static.csv data/multiregion-static.csv
```