### PR TITLE
remove exclude IA counties from NYT data

### DIFF
--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -15,7 +15,6 @@ from covidactnow.datapublic.common_fields import CommonFields
 from covidactnow.datapublic.common_fields import FieldName
 from typing_extensions import final
 
-from libs.datasets import AggregationLevel
 from libs.datasets import dataset_utils
 from libs.datasets import data_source
 from libs.datasets import dataset_pointer
@@ -41,7 +40,6 @@ from libs.datasets.sources.hhs_testing_dataset import HHSTestingDataset
 from libs.datasets.sources.can_location_page_urls import CANLocationPageURLS
 from libs.datasets.sources.cdc_vaccine_dataset import CDCVaccinesDataset
 from libs.pipeline import Region
-from libs.pipeline import RegionMask
 from libs.pipeline import RegionMaskOrRegion
 from covidactnow.datapublic.common_fields import COMMON_FIELDS_TIMESERIES_KEYS
 

--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -140,12 +140,7 @@ FeatureDataSourceMap = NewType(
 
 # NY Times has cases and deaths for all boroughs aggregated into 36061 / New York County.
 # Remove all the NYC data so that USAFacts (which reports each borough separately) is used.
-# Also, on 2/20, NYTimes stopped updating IA counties as well, removing from NYTimes dataset
-# to rely on USA Facts.
-NYTimesDatasetWithoutNYCOrIACounties = datasource_regions(
-    NYTimesDataset,
-    exclude=[RegionMask(level=AggregationLevel.COUNTY, states=["IA"]), *ALL_NYC_REGIONS],
-)
+NYTimesDatasetWithoutNYC = datasource_regions(NYTimesDataset, exclude=[*ALL_NYC_REGIONS],)
 
 
 # Below are two instances of feature definitions. These define
@@ -164,7 +159,7 @@ ALL_TIMESERIES_FEATURE_DEFINITION: FeatureDataSourceMap = {
     CommonFields.CASES: [
         CANScraperStateProviders,
         CANScraperUSAFactsProvider,
-        NYTimesDatasetWithoutNYCOrIACounties,
+        NYTimesDatasetWithoutNYC,
     ],
     CommonFields.CONTACT_TRACERS_COUNT: [TestAndTraceData],
     CommonFields.CUMULATIVE_HOSPITALIZED: [CovidTrackingDataSource],
@@ -188,7 +183,7 @@ ALL_TIMESERIES_FEATURE_DEFINITION: FeatureDataSourceMap = {
     CommonFields.DEATHS: [
         CANScraperStateProviders,
         CANScraperUSAFactsProvider,
-        NYTimesDatasetWithoutNYCOrIACounties,
+        NYTimesDatasetWithoutNYC,
     ],
     CommonFields.HOSPITAL_BEDS_IN_USE_ANY: [HHSHospitalCountyDataset, HHSHospitalStateDataset],
     CommonFields.ICU_BEDS: [


### PR DESCRIPTION
This PR addresses https://trello.com/c/Qrgw8AR9/1228-switch-iowa-cases-back-to-nyt-instead-of-usa-facts-igor-says-its-fixed by undoing some of https://github.com/covid-projections/covid-data-model/pull/982