### PR TITLE
add update_test_combined_data command line options

### DIFF
--- a/cli/data.py
+++ b/cli/data.py
@@ -280,7 +280,11 @@ def update_case_based_icu_utilization_weights():
         json.dump(output, f, indent=2, sort_keys=True)
 
 
-@main.command()
+@main.command(
+    help="Regenerate the test combined data. The options can be used to produce data for "
+    "testing or experimenting with particular subsets of the entire dataset. Use "
+    "the default options when producing test data to merge into the main branch."
+)
 @click.option(
     "--truncate-dates/--no-truncate-dates",
     is_flag=True,

--- a/cli/data.py
+++ b/cli/data.py
@@ -281,12 +281,26 @@ def update_case_based_icu_utilization_weights():
 
 
 @main.command()
-def update_test_combined_data():
+@click.option(
+    "--truncate-dates/--no-truncate-dates",
+    is_flag=True,
+    help="Keep a subset of all dates to reduce the test data size",
+    default=True,
+    show_default=True,
+)
+@click.option(
+    "--state",
+    multiple=True,
+    help="State to include in test data. Repeat for multiple states: --state TX --state WI.",
+    default=["NY", "CA", "IL"],
+    show_default=True,
+)
+def update_test_combined_data(truncate_dates: bool, state: List[str]):
     us_dataset = combined_datasets.load_us_timeseries_dataset()
     # Keep only a small subset of the regions so we have enough to exercise our code in tests.
     test_subset = us_dataset.get_regions_subset(
         [
-            RegionMask(states=["NY", "CA", "IL"]),
+            RegionMask(states=[s.strip() for s in state]),
             Region.from_fips("48201"),
             Region.from_fips("48301"),
             Region.from_fips("20161"),
@@ -294,11 +308,12 @@ def update_test_combined_data():
             Region.from_state("KS"),
         ]
     )
-    dates = test_subset.timeseries_bucketed.index.get_level_values(CommonFields.DATE)
-    date_range_mask = (dates >= "2021-01-01") & (dates < "2021-04-01")
-    test_subset = dataclasses.replace(
-        test_subset, timeseries_bucketed=test_subset.timeseries_bucketed.loc[date_range_mask]
-    )
+    if truncate_dates:
+        dates = test_subset.timeseries_bucketed.index.get_level_values(CommonFields.DATE)
+        date_range_mask = (dates >= "2021-01-01") & (dates < "2021-04-01")
+        test_subset = dataclasses.replace(
+            test_subset, timeseries_bucketed=test_subset.timeseries_bucketed.loc[date_range_mask]
+        )
     test_subset.write_to_wide_dates_csv(
         dataset_utils.TEST_COMBINED_WIDE_DATES_CSV_PATH, dataset_utils.TEST_COMBINED_STATIC_CSV_PATH
     )


### PR DESCRIPTION
I've been using a subset of data created with 

```
./run.py data update-test-combined-data --no-truncate-dates --state SD
cp tests/data/test-combined-wide-dates.csv data/multiregion-wide-dates.csv
cp tests/data/test-combined-static.csv data/multiregion-static.csv
```

to browse SD data while working on https://trello.com/c/KdcwKHwK/1241-several-south-dakota-counties-have-fully