### PR TITLE
tag vaccine backfill as derived

### DIFF
--- a/libs/datasets/taglib.py
+++ b/libs/datasets/taglib.py
@@ -56,6 +56,7 @@ class TagType(GetByValueMixin, ValueAsStrMixin, str, enum.Enum):
     CUMULATIVE_LONG_TAIL_TRUNCATED = "cumulative_long_tail_truncated"
     ZSCORE_OUTLIER = "zscore_outlier"
     KNOWN_ISSUE = "known_issue"
+    DERIVED = "derived"
 
     PROVENANCE = PdFields.PROVENANCE
     SOURCE_URL = "source_url"
@@ -290,6 +291,20 @@ class KnownIssue(TagInTimeseries):
         return json.dumps(d, separators=(",", ":"))
 
 
+@dataclass(frozen=True)
+class Derived(TagInTimeseries):
+    TAG_TYPE = TagType.DERIVED
+
+    @classmethod
+    def make_instance(cls, *, content: str) -> "TagInTimeseries":
+        assert content == "{}"
+        return cls()
+
+    @property
+    def content(self) -> str:
+        return "{}"
+
+
 TAG_TYPE_TO_CLASS = {
     TagType.CUMULATIVE_TAIL_TRUNCATED: CumulativeTailTruncated,
     TagType.CUMULATIVE_LONG_TAIL_TRUNCATED: CumulativeLongTailTruncated,
@@ -298,6 +313,7 @@ TAG_TYPE_TO_CLASS = {
     TagType.SOURCE_URL: SourceUrl,
     TagType.SOURCE: Source,
     TagType.KNOWN_ISSUE: KnownIssue,
+    TagType.DERIVED: Derived,
 }
 
 

--- a/libs/datasets/vaccine_backfills.py
+++ b/libs/datasets/vaccine_backfills.py
@@ -4,6 +4,7 @@ import pandas as pd
 from covidactnow.datapublic.common_fields import CommonFields
 from covidactnow.datapublic.common_fields import PdFields
 
+from libs.datasets import taglib
 from libs.datasets import timeseries
 
 
@@ -79,6 +80,11 @@ def backfill_vaccination_initiated(dataset: MultiRegionDataset) -> MultiRegionDa
 
     # Compute and keep only time series with at least one real value
     computed_initiated = administered - completed
+    computed_initiated = computed_initiated.dropna(axis=1, how="all")
+    # Keep the computed initiated only where there is not already an existing time series.
+    computed_initiated = computed_initiated.loc[
+        ~computed_initiated.index.isin(existing_initiated.index)
+    ]
 
     # Use concat to prepend the VARIABLE index level, then reorder the levels to match the dataset.
     computed_initiated = pd.concat(
@@ -86,21 +92,10 @@ def backfill_vaccination_initiated(dataset: MultiRegionDataset) -> MultiRegionDa
         names=[PdFields.VARIABLE] + list(computed_initiated.index.names),
     ).reorder_levels(timeseries_wide.index.names)
 
-    timeseries_wide_combined = pd.concat([timeseries_wide, computed_initiated])
+    timeseries_wide_dates_combined = pd.concat([timeseries_wide, computed_initiated])
 
-    # https://stackoverflow.com/a/34297689
-    timeseries_wide_deduped = timeseries_wide_combined.loc[
-        ~timeseries_wide_combined.index.duplicated(keep="first")
-    ]
+    timeseries_wide_vars = timeseries_wide_dates_combined.stack().unstack(PdFields.VARIABLE)
 
-    computed_initiated = computed_initiated.dropna(axis=1, how="all")
-    computed_initiated = computed_initiated.loc[
-        ~computed_initiated.droplevel(PdFields.VARIABLE).index.isin(existing_initiated.index)
-    ]
-    timeseries_wide_deduped_2 = pd.concat([timeseries_wide, computed_initiated])
-
-    assert timeseries_wide_deduped_2.equals(timeseries_wide_deduped)
-
-    timeseries_wide_vars = timeseries_wide_deduped.stack().unstack(PdFields.VARIABLE)
-
-    return dataclasses.replace(dataset, timeseries_bucketed=timeseries_wide_vars)
+    return dataclasses.replace(dataset, timeseries_bucketed=timeseries_wide_vars).add_tag_to_subset(
+        taglib.Derived(), computed_initiated.index
+    )

--- a/tests/libs/datasets/timeseries_test.py
+++ b/tests/libs/datasets/timeseries_test.py
@@ -1805,3 +1805,26 @@ def test_static_and_geo_data():
     )
     assert ds.static_and_geo_data.loc[region_chi.location_id, CommonFields.COUNTY] == "Cook County"
     assert ds.static_and_geo_data.loc[region_chi.location_id, CommonFields.POPULATION] == 5
+
+
+def test_add_tag_all_bucket():
+    region_tx = Region.from_state("TX")
+    region_la = Region.from_fips("06037")
+    age_40s = DemographicBucket("age:40-49")
+    data_tx = {region_tx: {CommonFields.CASES: [10, 20]}}
+    data_la = {region_la: {CommonFields.CASES: {DemographicBucket.ALL: [5, 10], age_40s: [1, 2]}}}
+
+    tag = test_helpers.make_tag(date="2020-04-01")
+    ds = test_helpers.build_dataset({**data_tx, **data_la}).add_tag_all_bucket(tag)
+
+    expected_tx = {region_tx: {CommonFields.CASES: TimeseriesLiteral([10, 20], annotation=[tag])}}
+    expected_la = {
+        region_la: {
+            CommonFields.CASES: {
+                DemographicBucket.ALL: TimeseriesLiteral([5, 10], annotation=[tag]),
+                age_40s: [1, 2],
+            }
+        }
+    }
+    ds_expected = test_helpers.build_dataset({**expected_tx, **expected_la})
+    test_helpers.assert_dataset_like(ds, ds_expected)

--- a/tests/libs/datasets/vaccine_backfill_test.py
+++ b/tests/libs/datasets/vaccine_backfill_test.py
@@ -3,6 +3,7 @@ import pytest
 from covidactnow.datapublic.common_fields import CommonFields
 from covidactnow.datapublic.common_fields import DemographicBucket
 
+from libs.datasets import taglib
 from libs.pipeline import Region
 from tests import test_helpers
 from tests.test_helpers import TimeseriesLiteral
@@ -10,9 +11,10 @@ from libs.datasets import vaccine_backfills
 
 
 @pytest.mark.parametrize(
-    "initiated_values,initiated_expected", [([50, None], [50, None]), ([None, None], [50, 150])]
+    "initiated_values,initiated_expected,annotation",
+    [([50, None], [50, None], False), ([None, None], [50, 150], True)],
 )
-def test_backfill_vaccine_initiated(initiated_values, initiated_expected):
+def test_backfill_vaccine_initiated(initiated_values, initiated_expected, annotation):
     ny_region = Region.from_state("NY")
     az_region = Region.from_state("AZ")
 
@@ -32,6 +34,8 @@ def test_backfill_vaccine_initiated(initiated_values, initiated_expected):
     metrics = {ny_region: ny_metrics, az_region: az_metrics}
     dataset = test_helpers.build_dataset(metrics)
     result = vaccine_backfills.backfill_vaccination_initiated(dataset)
+    if annotation:
+        initiated_expected = TimeseriesLiteral(initiated_expected, annotation=[taglib.Derived()])
     expected_ny = {
         CommonFields.VACCINES_ADMINISTERED: [100, 200],
         CommonFields.VACCINATIONS_COMPLETED: [50, 50],

--- a/tests/libs/datasets/vaccine_backfill_test.py
+++ b/tests/libs/datasets/vaccine_backfill_test.py
@@ -63,7 +63,10 @@ def test_backfill_vaccine_initiated_by_bucket():
     ds_expected = test_helpers.build_default_region_dataset(
         {
             CommonFields.VACCINES_ADMINISTERED: {bucket_all: [100, 200], bucket_40s: [40, 60]},
-            CommonFields.VACCINATIONS_INITIATED: {bucket_all: [50, 150], bucket_40s: [30, 40]},
+            CommonFields.VACCINATIONS_INITIATED: {
+                bucket_all: TimeseriesLiteral([50, 150], annotation=[taglib.Derived()]),
+                bucket_40s: TimeseriesLiteral([30, 40], annotation=[taglib.Derived()]),
+            },
             CommonFields.VACCINATIONS_COMPLETED: {bucket_all: [50, 50], bucket_40s: [10, 20]},
         }
     )


### PR DESCRIPTION
This PR is part of https://trello.com/c/jeoMFnbb/1243-revisit-backfillvaccinationinitiated

* Adds taglib.Derived that for now has no attributes so is encoded as an empty JSON `"{}"`
* Adds `MultiRegionDataset.add_tag_to_subset` making it easy to add a tag to a subset of time series
* Changes how backfill_vaccination_initiated merges calculated and existing time series without changing behavior

## Tested

Ran `./run.py data update` and checked `git difftool -t vimdiff --no-prompt main -- data/multiregion-annotations.csv` only adds a column.

05eecac asserted that the old and new way of merging the backfill produced the same output. This worked with the current combined data.