### PR TITLE
Allow MultiRegionDataset.tag without timeseries

### DIFF
--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -8,7 +8,6 @@ from typing import (
     Union,
     TextIO,
     Mapping,
-    Set,
     Sequence,
     Tuple,
 )
@@ -549,13 +548,6 @@ class MultiRegionDataset:
     @cached_property
     def static_and_geo_data(self) -> pd.DataFrame:
         return self.static.join(self.geo_data)
-
-    @property
-    def timeseries_regions(self) -> Set[Region]:
-        """Returns a set of all regions in the timeseries dataset."""
-
-        location_ids = self.timeseries.index.get_level_values(CommonFields.LOCATION_ID)
-        return set(Region.from_location_id(location_id) for location_id in location_ids)
 
     @cached_property
     def provenance(self) -> pd.DataFrame:

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -784,7 +784,7 @@ class MultiRegionDataset:
         """Returns a new object containing data in self and given provenance information."""
         if not self.tag.empty:
             raise NotImplementedError(
-                "add_provenance_series is deprecated and only called with " "an empty tag Series."
+                "add_provenance_series is deprecated and only called with an empty tag Series."
             )
         assert provenance.index.names == [CommonFields.LOCATION_ID, PdFields.VARIABLE]
         assert isinstance(provenance, pd.Series)

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -911,12 +911,6 @@ class MultiRegionDataset:
         #  https://github.com/pandas-dev/pandas/issues/35992 which is fixed in pandas 1.2.0
         # assert self.tag.index.is_monotonic_increasing
         assert self.tag.name == TagField.CONTENT
-        # Check that all tag location_id are in timeseries location_id
-        assert (
-            self.tag.index.unique(TagField.LOCATION_ID)
-            .difference(self.timeseries_bucketed.index.unique(CommonFields.LOCATION_ID))
-            .empty
-        )
 
         extra_location_ids = self.location_ids.difference(dataset_utils.get_geo_data().index)
         if not extra_location_ids.empty:

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -532,8 +532,10 @@ class MultiRegionDataset:
 
     @cached_property
     def location_ids(self) -> pd.Index:
-        return self.static.index.unique(CommonFields.LOCATION_ID).union(
-            self.timeseries_bucketed.index.unique(CommonFields.LOCATION_ID)
+        return (
+            self.static.index.unique(CommonFields.LOCATION_ID)
+            .union(self.timeseries_bucketed.index.unique(CommonFields.LOCATION_ID))
+            .union(self.tag.index.unique(CommonFields.LOCATION_ID))
         )
 
     @cached_property
@@ -780,8 +782,10 @@ class MultiRegionDataset:
 
     def add_provenance_series(self, provenance: pd.Series) -> "MultiRegionDataset":
         """Returns a new object containing data in self and given provenance information."""
-        if not self.provenance.empty:
-            raise NotImplementedError("TODO(tom): add support for merging provenance data")
+        if not self.tag.empty:
+            raise NotImplementedError(
+                "add_provenance_series is deprecated and only called with " "an empty tag Series."
+            )
         assert provenance.index.names == [CommonFields.LOCATION_ID, PdFields.VARIABLE]
         assert isinstance(provenance, pd.Series)
 

--- a/tests/libs/datasets/custom_aggregations_test.py
+++ b/tests/libs/datasets/custom_aggregations_test.py
@@ -48,7 +48,7 @@ def test_replace_dc_county(nyc_region):
     output = custom_aggregations.replace_dc_county_with_state_data(dataset)
 
     # Verify that the regions are the same input and output
-    assert dataset.timeseries_regions == output.timeseries_regions
+    assert set(dataset.location_ids) == set(output.location_ids)
 
     # Verify that the state cases from before replacement are now the
     # same as the county cases

--- a/tests/libs/datasets/timeseries_test.py
+++ b/tests/libs/datasets/timeseries_test.py
@@ -1493,15 +1493,6 @@ def test_multi_region_dataset_get_subset_with_buckets():
     test_helpers.assert_dataset_like(ds.remove_regions([region_tx]), ds_expected)
 
 
-def test_dataset_regions_property(nyc_region):
-    az_region = Region.from_state("AZ")
-    dataset = test_helpers.build_dataset(
-        {nyc_region: {CommonFields.CASES: [100]}, az_region: {CommonFields.CASES: [100]}}
-    )
-
-    assert dataset.timeseries_regions == set([az_region, nyc_region])
-
-
 def test_write_read_dataset_pointer_with_source_url(tmpdir):
     pointer = _make_dataset_pointer(tmpdir)
     url_str1 = UrlStr("http://foo.com/1")

--- a/tests/libs/datasets/timeseries_test.py
+++ b/tests/libs/datasets/timeseries_test.py
@@ -1,7 +1,6 @@
 import datetime
 import io
 import pathlib
-import dataclasses
 import pickle
 
 import pytest


### PR DESCRIPTION
This PR is part of https://trello.com/c/f27O08ea/1266-make-it-possible-to-block-in-the-backend-using-the-cms and helps https://github.com/covid-projections/covid-data-model/pull/1080

* Adds support for MultiRegionDataset.tag without timeseries values
* (unrelated) Removes unused MultiRegionDataset.timeseries_regions
* (unrelated) Removes one use of deprecated MultiRegionDataset.provenance