### PR TITLE
Refactor drop_observations

### DIFF
--- a/libs/datasets/ca_vaccination_backfill.py
+++ b/libs/datasets/ca_vaccination_backfill.py
@@ -1,5 +1,3 @@
-import dataclasses
-import pandas as pd
 from covidactnow.datapublic.common_fields import DemographicBucket
 
 from libs.datasets.timeseries import MultiRegionDataset

--- a/libs/datasets/ca_vaccination_backfill.py
+++ b/libs/datasets/ca_vaccination_backfill.py
@@ -81,11 +81,6 @@ def derive_ca_county_vaccine_pct(ds_in: MultiRegionDataset) -> MultiRegionDatase
     all_wide = ds_in.timeseries_bucketed_wide_dates
     # Because we assert that existing dataset does not have CA county VACCINATIONS_COMPLETED_PCT
     # or VACCINATIONS_INITIATED_PCT we can safely combine the existing rows with new derived rows
-    combined = pd.concat([vaccines_completed_pct, vaccines_initiated_pct, all_wide])
-
-    return dataclasses.replace(
-        ds_in,
-        timeseries_bucketed=MultiRegionDataset.from_timeseries_wide_dates_df(
-            combined, bucketed=True
-        ).timeseries_bucketed,
+    return ds_in.replace_timeseries_wide_dates(
+        [vaccines_completed_pct, vaccines_initiated_pct, all_wide]
     )

--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -90,10 +90,7 @@ class DataSourceAndRegionMasks:
         """
         dataset = self.data_source_cls.make_dataset()
 
-        if self.include:
-            dataset = dataset.get_regions_subset(self.include)
-        if self.exclude:
-            dataset = dataset.remove_regions(self.exclude)
+        dataset, _ = dataset.partition_by_region(include=self.include, exclude=self.exclude)
         if self.manual_filter_config:
             dataset = manual_filter.run(dataset, self.manual_filter_config)
         return dataset

--- a/libs/datasets/custom_aggregations.py
+++ b/libs/datasets/custom_aggregations.py
@@ -63,13 +63,13 @@ def replace_dc_county_with_state_data(
 
     # aggregate_regions only copies number columns. Extract them and re-add to the aggregated
     # dataset.
-    static_excluding_numbers = dataset_in.get_regions_subset(
+    dataset_with_dc_county, dataset_without_dc_county = dataset_in.partition_by_region(
         [dc_county_region]
-    ).static.select_dtypes(exclude="number")
+    )
+    static_excluding_numbers = dataset_with_dc_county.static.select_dtypes(exclude="number")
     dc_county_dataset = region_aggregation.aggregate_regions(dataset_in, dc_map).add_static_values(
         static_excluding_numbers.reset_index()
     )
-    dataset_without_dc_county = dataset_in.remove_regions([dc_county_region])
 
     return dataset_without_dc_county.append_regions(dc_county_dataset)
 

--- a/libs/datasets/manual_filter.py
+++ b/libs/datasets/manual_filter.py
@@ -120,14 +120,13 @@ def run(
     dataset: timeseries.MultiRegionDataset, config: Config = CONFIG
 ) -> timeseries.MultiRegionDataset:
     for filter_ in config.filters:
-        filtered_dataset = dataset.get_regions_subset(filter_.regions_included)
-        if filter_.regions_excluded:
-            filtered_dataset = filtered_dataset.remove_regions(filter_.regions_excluded)
+        filtered_dataset, passed_dataset = dataset.partition_by_region(
+            filter_.regions_included, exclude=filter_.regions_excluded
+        )
         if filtered_dataset.location_ids.empty:
             # TODO(tom): Find a cleaner way to refer to a filter in logs.
             _logger.info("No locations matched", regions=str(filter_.regions_included))
             continue
-        passed_dataset = dataset.remove_locations(filtered_dataset.location_ids)
         filtered_dataset = drop_observations(filtered_dataset, filter_.observations_to_drop)
 
         dataset = filtered_dataset.append_regions(passed_dataset)

--- a/libs/datasets/manual_filter.py
+++ b/libs/datasets/manual_filter.py
@@ -111,7 +111,7 @@ def drop_observations(
     new_tags = taglib.TagCollection()
     new_tags.add_by_index(tag, index=ts_filtered.index)
 
-    return dataset.replace_timeseries_bucketed(
+    return dataset.replace_timeseries_wide_dates(
         [ts_not_selected_fields, ts_no_real_values_to_drop, ts_filtered]
     ).append_tag_df(new_tags.as_dataframe())
 

--- a/libs/datasets/manual_filter.py
+++ b/libs/datasets/manual_filter.py
@@ -1,5 +1,9 @@
-import dataclasses
+import datetime
+from typing import List
+from typing import Optional
+from typing import Tuple
 
+import pydantic
 import structlog
 from covidactnow.datapublic import common_fields
 from covidactnow.datapublic.common_fields import CommonFields
@@ -10,7 +14,7 @@ from libs.datasets import AggregationLevel
 from libs.datasets import taglib
 from libs.datasets import timeseries
 from libs.pipeline import Region, RegionMask
-
+from libs.pipeline import RegionMaskOrRegion
 
 _logger = structlog.getLogger()
 
@@ -23,7 +27,7 @@ CONFIG = {
             "regions_excluded": [Region.from_fips("40109"), Region.from_fips("40143")],
             "observations_to_drop": {
                 "start_date": "2021-03-15",
-                "fields": [CommonFields.CASES, CommonFields.DEATHS],
+                "drop_fields": [CommonFields.CASES, CommonFields.DEATHS],
                 "internal_note": "https://trello.com/c/HdAKfp49/1139",
                 "public_note": "Something broke with the OK county data.",
             },
@@ -32,66 +36,88 @@ CONFIG = {
 }
 
 
-def drop_observations(
-    dataset: timeseries.MultiRegionDataset, config
-) -> timeseries.MultiRegionDataset:
-    """Drops observations according to `config` from every region in dataset."""
-    drop_start_date = pd.to_datetime(config["start_date"])
+class ObservationsToDrop(pydantic.BaseModel):
+    start_date: datetime.date
+    drop_fields: Optional[List[CommonFields]] = None
+    drop_field_group: Optional[common_fields.FieldGroup] = None
+    internal_note: str
+    public_note: str
 
+    @property
+    def drop_field_list(self) -> List[CommonFields]:
+        if self.drop_fields is not None:
+            assert self.drop_field_group is None
+            return self.drop_fields
+        else:
+            # self.drop_fields is None
+            assert self.drop_field_group is not None
+            return common_fields.FIELD_GROUP_TO_LIST_FIELDS[self.drop_field_group]
+
+
+class Filter(pydantic.BaseModel):
+    regions_included: List[RegionMaskOrRegion]
+    regions_excluded: Optional[List[RegionMaskOrRegion]] = None
+    observations_to_drop: ObservationsToDrop
+
+
+class Config(pydantic.BaseModel):
+    filters: List[Filter]
+
+
+def _partition_by_fields(
+    dataset: timeseries.MultiRegionDataset, fields: List[CommonFields]
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Returns a tuple of the timeseries in fields and all others, in wide dates DataFrames."""
     ts_in = dataset.timeseries_bucketed_wide_dates
-
-    if "field_group" in config:
-        fields = common_fields.FIELD_GROUP_TO_LIST_FIELDS[config["field_group"]]
-    else:
-        fields = config["fields"]
     mask_selected_fields = ts_in.index.get_level_values(PdFields.VARIABLE).isin(fields)
     ts_selected_fields = ts_in.loc[mask_selected_fields]
     ts_not_selected_fields = ts_in.loc[~mask_selected_fields]
+    return ts_selected_fields, ts_not_selected_fields
 
-    obsv_selected = ts_selected_fields.loc[:, ts_selected_fields.columns >= drop_start_date]
+
+def drop_observations(
+    dataset: timeseries.MultiRegionDataset,
+    fields: List[CommonFields],
+    drop_start_date: datetime.date,
+    public_note: str,
+) -> timeseries.MultiRegionDataset:
+    """Drops observations according to `config` from every region in dataset."""
+    ts_selected_fields, ts_not_selected_fields = _partition_by_fields(dataset, fields)
+
+    start_date = pd.to_datetime(drop_start_date)
+    obsv_selected = ts_selected_fields.loc[:, ts_selected_fields.columns >= start_date]
     mask_has_real_value_to_drop = obsv_selected.notna().any(1)
     ts_to_filter = ts_selected_fields.loc[mask_has_real_value_to_drop]
     ts_no_real_values_to_drop = ts_selected_fields.loc[~mask_has_real_value_to_drop]
+    ts_filtered = ts_to_filter.loc[:, ts_to_filter.columns < start_date]
 
-    ts_filtered = ts_to_filter.loc[:, ts_to_filter.columns < drop_start_date]
+    tag = taglib.KnownIssue(date=drop_start_date, disclaimer=public_note)
 
     new_tags = taglib.TagCollection()
-    assert ts_to_filter.index.names == [
-        CommonFields.LOCATION_ID,
-        PdFields.VARIABLE,
-        PdFields.DEMOGRAPHIC_BUCKET,
-    ]
-    for location_id, variable, bucket in ts_to_filter.index:
-        new_tags.add(
-            taglib.KnownIssue(date=drop_start_date, disclaimer=config["public_note"]),
-            location_id=location_id,
-            variable=variable,
-            bucket=bucket,
-        )
+    new_tags.add_by_index(tag, index=ts_to_filter.index)
 
-    ts_new = (
-        pd.concat([ts_not_selected_fields, ts_no_real_values_to_drop, ts_filtered])
-        .stack()
-        .unstack(PdFields.VARIABLE)
-        .sort_index()
-    )
-    return dataclasses.replace(dataset, timeseries_bucketed=ts_new).append_tag_df(
-        new_tags.as_dataframe()
-    )
+    return dataset.replace_timeseries_bucketed(
+        [ts_not_selected_fields, ts_no_real_values_to_drop, ts_filtered]
+    ).append_tag_df(new_tags.as_dataframe())
 
 
 def run(dataset: timeseries.MultiRegionDataset, config=CONFIG) -> timeseries.MultiRegionDataset:
-    for filter_ in config["filters"]:
-        filtered_dataset = dataset.get_regions_subset(filter_["regions_included"])
-        if filter_.get("regions_excluded"):
-            filtered_dataset = filtered_dataset.remove_regions(filter_["regions_excluded"])
+    config = Config.parse_obj(config)
+    for filter_ in config.filters:
+        filtered_dataset = dataset.get_regions_subset(filter_.regions_included)
+        if filter_.regions_excluded:
+            filtered_dataset = filtered_dataset.remove_regions(filter_.regions_excluded)
         if filtered_dataset.location_ids.empty:
             # TODO(tom): Find a cleaner way to refer to a filter in logs.
-            _logger.info("No locations matched", regions=str(filter_["regions_included"]))
+            _logger.info("No locations matched", regions=str(filter_.regions_included))
             continue
         passed_dataset = dataset.remove_locations(filtered_dataset.location_ids)
-        observations_to_drop = filter_.get("observations_to_drop")
-        filtered_dataset = drop_observations(filtered_dataset, observations_to_drop)
+        filtered_dataset = drop_observations(
+            filtered_dataset,
+            filter_.observations_to_drop.drop_field_list,
+            filter_.observations_to_drop.start_date,
+            filter_.observations_to_drop.public_note,
+        )
 
         dataset = filtered_dataset.append_regions(passed_dataset)
 

--- a/libs/datasets/manual_filter.py
+++ b/libs/datasets/manual_filter.py
@@ -108,10 +108,9 @@ def drop_observations(
     ts_results.append(ts_no_real_values_to_drop)
     index_to_tag = ts_filtered.index
 
-    new_tags = taglib.TagCollection()
-    new_tags.add_by_index(filter_.tag, index=index_to_tag)
-
-    return dataset.replace_timeseries_wide_dates(ts_results).append_tag_df(new_tags.as_dataframe())
+    return dataset.replace_timeseries_wide_dates(ts_results).add_tag_to_subset(
+        filter_.tag, index_to_tag
+    )
 
 
 def run(

--- a/libs/datasets/taglib.py
+++ b/libs/datasets/taglib.py
@@ -348,16 +348,6 @@ class TagCollection:
         """Returns all tags in this collection in a DataFrame."""
         return pd.DataFrame.from_records(self._as_records())
 
-    def add_by_index(self, tag: TagInTimeseries, *, index: pd.MultiIndex):
-        """Adds `tag` to each time series in `index`."""
-        assert index.names == [
-            CommonFields.LOCATION_ID,
-            PdFields.VARIABLE,
-            PdFields.DEMOGRAPHIC_BUCKET,
-        ]
-        for location_id, variable, bucket in index:
-            self.add(tag, location_id=location_id, variable=variable, bucket=bucket)
-
 
 def series_string_to_object(tag: pd.Series) -> pd.Series:
     """Converts a Series of content strings (generally JSONs) into a Series of TagInTimeseries

--- a/libs/datasets/taglib.py
+++ b/libs/datasets/taglib.py
@@ -1,5 +1,6 @@
 import collections
 import dataclasses
+import datetime
 import enum
 import json
 from abc import ABC
@@ -274,7 +275,7 @@ class ZScoreOutlier(AnnotationWithDate):
 @dataclass(frozen=True)
 class KnownIssue(TagInTimeseries):
     disclaimer: str
-    date: pd.Timestamp
+    date: datetime.date
 
     TAG_TYPE = TagType.KNOWN_ISSUE
 
@@ -282,12 +283,13 @@ class KnownIssue(TagInTimeseries):
     def make_instance(cls, *, content: str) -> "TagInTimeseries":
         content_parsed = json.loads(content)
         return cls(
-            disclaimer=content_parsed["disclaimer"], date=pd.to_datetime(content_parsed["date"]),
+            disclaimer=content_parsed["disclaimer"],
+            date=datetime.date.fromisoformat(content_parsed["date"]),
         )
 
     @property
     def content(self) -> str:
-        d = {"disclaimer": self.disclaimer, "date": self.date.date().isoformat()}
+        d = {"disclaimer": self.disclaimer, "date": self.date.isoformat()}
         return json.dumps(d, separators=(",", ":"))
 
 
@@ -345,6 +347,16 @@ class TagCollection:
     def as_dataframe(self) -> pd.DataFrame:
         """Returns all tags in this collection in a DataFrame."""
         return pd.DataFrame.from_records(self._as_records())
+
+    def add_by_index(self, tag: TagInTimeseries, *, index: pd.MultiIndex):
+        """Adds `tag` to each time series in `index`."""
+        assert index.names == [
+            CommonFields.LOCATION_ID,
+            PdFields.VARIABLE,
+            PdFields.DEMOGRAPHIC_BUCKET,
+        ]
+        for location_id, variable, bucket in index:
+            self.add(tag, location_id=location_id, variable=variable, bucket=bucket)
 
 
 def series_string_to_object(tag: pd.Series) -> pd.Series:

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -442,6 +442,21 @@ def _check_timeseries_wide_vars_structure(wide_vars_df: pd.DataFrame, *, buckete
     assert numeric_columns.all()
 
 
+def check_timeseries_wide_dates_structure(timeseries_wide_dates: pd.DataFrame, *, bucketed=True):
+    if bucketed:
+        assert timeseries_wide_dates.index.names == [
+            CommonFields.LOCATION_ID,
+            PdFields.VARIABLE,
+            PdFields.DEMOGRAPHIC_BUCKET,
+        ]
+    else:
+        assert timeseries_wide_dates.index.names == [
+            CommonFields.LOCATION_ID,
+            PdFields.VARIABLE,
+        ]
+    assert timeseries_wide_dates.columns.names == [CommonFields.DATE]
+
+
 def _tag_add_all_bucket(tag: pd.Series) -> pd.Series:
     tag_bucketed = pd.concat(
         {DemographicBucket.ALL: tag}, names=[PdFields.DEMOGRAPHIC_BUCKET]
@@ -690,18 +705,7 @@ class MultiRegionDataset:
         timeseries_wide_dates: pd.DataFrame, *, bucketed=False
     ) -> "MultiRegionDataset":
         """Make a new dataset from a DataFrame as returned by timeseries_wide_dates."""
-        if bucketed:
-            assert timeseries_wide_dates.index.names == [
-                CommonFields.LOCATION_ID,
-                PdFields.VARIABLE,
-                PdFields.DEMOGRAPHIC_BUCKET,
-            ]
-        else:
-            assert timeseries_wide_dates.index.names == [
-                CommonFields.LOCATION_ID,
-                PdFields.VARIABLE,
-            ]
-        assert timeseries_wide_dates.columns.names == [CommonFields.DATE]
+        check_timeseries_wide_dates_structure(timeseries_wide_dates, bucketed=bucketed)
         timeseries_wide_dates.columns: pd.DatetimeIndex = pd.to_datetime(
             timeseries_wide_dates.columns
         )

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -1145,6 +1145,16 @@ class MultiRegionDataset:
         tag = _slice_with_labels(self.tag, timeseries_wide_dates.index)
         return dataclasses.replace(self, timeseries_bucketed=timeseries_wide_variables, tag=tag,)
 
+    def replace_timeseries_bucketed(
+        self, timeseries_bucketed_to_concat: List[pd.DataFrame]
+    ) -> "MultiRegionDataset":
+        """Returns a new object with timeseries data copied from the given list of wide-date
+        DataFrames."""
+        ts_new = (
+            pd.concat(timeseries_bucketed_to_concat).stack().unstack(PdFields.VARIABLE).sort_index()
+        )
+        return dataclasses.replace(self, timeseries_bucketed=ts_new)
+
     def to_csv(self, path: pathlib.Path, include_latest=True):
         """Persists timeseries to CSV.
 

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -1149,11 +1149,13 @@ class MultiRegionDataset:
         tag = _slice_with_labels(self.tag, timeseries_wide_dates.index)
         return dataclasses.replace(self, timeseries_bucketed=timeseries_wide_variables, tag=tag,)
 
-    def replace_timeseries_bucketed(
+    def replace_timeseries_wide_dates(
         self, timeseries_bucketed_to_concat: List[pd.DataFrame]
     ) -> "MultiRegionDataset":
         """Returns a new object with timeseries data copied from the given list of wide-date
         DataFrames."""
+        for df in timeseries_bucketed_to_concat:
+            check_timeseries_wide_dates_structure(df, bucketed=True)
         ts_new = (
             pd.concat(timeseries_bucketed_to_concat).stack().unstack(PdFields.VARIABLE).sort_index()
         )

--- a/libs/pipeline.py
+++ b/libs/pipeline.py
@@ -183,7 +183,11 @@ class Region:
 @final
 @dataclass(frozen=True)
 class RegionMask:
+    """Represents attributes which may be used to select a subset of regions."""
+
+    # A level (county, state, ...) OR None to select regions ignoring their level.
     level: Optional[AggregationLevel] = None
+    # A list of states, each a two letter string OR None to select regions ignoring their state.
     states: Optional[List[str]] = None
 
 

--- a/tests/libs/datasets/combined_dataset_utils_test.py
+++ b/tests/libs/datasets/combined_dataset_utils_test.py
@@ -71,10 +71,7 @@ def test_include_exclude_regions():
     mask = combined_datasets.DataSourceAndRegionMasks(
         DataSourceForTest,
         include=[],
-        exclude=[
-            Region.from_fips("36061"),
-            RegionMask(level=AggregationLevel.COUNTY, states=["DC"]),
-        ],
+        exclude=[Region.from_fips("36061"), RegionMask(AggregationLevel.COUNTY, states=["DC"])],
         manual_filter_config=None,
     )
 

--- a/tests/libs/datasets/manual_filter_test.py
+++ b/tests/libs/datasets/manual_filter_test.py
@@ -1,3 +1,4 @@
+import pytest
 from covidactnow.datapublic import common_fields
 from covidactnow.datapublic.common_fields import CommonFields
 from covidactnow.datapublic.common_fields import DemographicBucket
@@ -26,7 +27,7 @@ TEST_CONFIG = manual_filter.Config.parse_obj(
                 "internal_note": "https://trello.com/c/aj7ep7S7/1130",
                 "public_note": "The TriCounty Health Department is focusing on vaccinations "
                 "and we have not found a new source of case counts.",
-                "action": manual_filter.Action.DROP_OBSERVATIONS,
+                "drop_observations": True,
             },
             {
                 "regions_included": [RegionMask(AggregationLevel.COUNTY, states=["OK"])],
@@ -37,11 +38,32 @@ TEST_CONFIG = manual_filter.Config.parse_obj(
                 ],
                 "internal_note": "https://trello.com/c/HdAKfp49/1139",
                 "public_note": "Something broke with the OK county data.",
-                "action": manual_filter.Action.DROP_OBSERVATIONS,
+                "drop_observations": True,
             },
         ]
     }
 )
+
+
+def test_filter_config_check():
+    with pytest.raises(Exception, match="doesn't drop observations or add a public_note"):
+        manual_filter.Filter(
+            regions_included=[],
+            fields_included=[],
+            internal_note="",
+            public_note="",
+            drop_observations=False,
+        )
+
+    with pytest.raises(Exception, match="start_date without dropping"):
+        manual_filter.Filter(
+            regions_included=[],
+            fields_included=[],
+            internal_note="",
+            public_note="We did something",
+            start_date="2020-04-01",
+            drop_observations=False,
+        )
 
 
 def test_manual_filter():

--- a/tests/libs/datasets/manual_filter_test.py
+++ b/tests/libs/datasets/manual_filter_test.py
@@ -1,3 +1,4 @@
+from covidactnow.datapublic import common_fields
 from covidactnow.datapublic.common_fields import CommonFields
 from covidactnow.datapublic.common_fields import DemographicBucket
 from covidactnow.datapublic.common_fields import FieldGroup
@@ -20,23 +21,23 @@ TEST_CONFIG = manual_filter.Config.parse_obj(
                     Region.from_fips("49013"),
                     Region.from_fips("49047"),
                 ],
-                "observations_to_drop": {
-                    "start_date": "2021-02-12",
-                    "drop_fields": [CommonFields.CASES, CommonFields.DEATHS],
-                    "internal_note": "https://trello.com/c/aj7ep7S7/1130",
-                    "public_note": "The TriCounty Health Department is focusing on vaccinations "
-                    "and we have not found a new source of case counts.",
-                },
+                "start_date": "2021-02-12",
+                "fields_included": [CommonFields.CASES, CommonFields.DEATHS],
+                "internal_note": "https://trello.com/c/aj7ep7S7/1130",
+                "public_note": "The TriCounty Health Department is focusing on vaccinations "
+                "and we have not found a new source of case counts.",
+                "action": manual_filter.Action.DROP_OBSERVATIONS,
             },
             {
                 "regions_included": [RegionMask(AggregationLevel.COUNTY, states=["OK"])],
                 "regions_excluded": [Region.from_fips("40109"), Region.from_fips("40143")],
-                "observations_to_drop": {
-                    "start_date": "2021-03-15",
-                    "drop_field_group": FieldGroup.CASES_DEATHS,
-                    "internal_note": "https://trello.com/c/HdAKfp49/1139",
-                    "public_note": "Something broke with the OK county data.",
-                },
+                "start_date": "2021-03-15",
+                "fields_included": common_fields.FIELD_GROUP_TO_LIST_FIELDS[
+                    FieldGroup.CASES_DEATHS
+                ],
+                "internal_note": "https://trello.com/c/HdAKfp49/1139",
+                "public_note": "Something broke with the OK county data.",
+                "action": manual_filter.Action.DROP_OBSERVATIONS,
             },
         ]
     }
@@ -55,7 +56,7 @@ def test_manual_filter():
     tag_expected = test_helpers.make_tag(
         taglib.TagType.KNOWN_ISSUE,
         date="2021-02-12",
-        disclaimer=TEST_CONFIG.filters[0].observations_to_drop.public_note,
+        disclaimer=TEST_CONFIG.filters[0].public_note,
     )
     ds_expected = test_helpers.build_dataset(
         {
@@ -81,7 +82,7 @@ def test_manual_filter_region_excluded():
     tag_expected = test_helpers.make_tag(
         taglib.TagType.KNOWN_ISSUE,
         date="2021-03-15",
-        disclaimer=TEST_CONFIG.filters[1].observations_to_drop.public_note,
+        disclaimer=TEST_CONFIG.filters[1].public_note,
     )
     ds_expected = test_helpers.build_dataset(
         {
@@ -110,7 +111,7 @@ def test_manual_filter_field_groups():
     tag_expected = test_helpers.make_tag(
         taglib.TagType.KNOWN_ISSUE,
         date="2021-03-15",
-        disclaimer=TEST_CONFIG.filters[1].observations_to_drop.public_note,
+        disclaimer=TEST_CONFIG.filters[1].public_note,
     )
     ds_expected = test_helpers.build_default_region_dataset(
         {CommonFields.DEATHS: TimeseriesLiteral([1], annotation=[tag_expected]), **other_data},
@@ -141,7 +142,7 @@ def test_manual_filter_per_bucket_tag():
     tag_expected = test_helpers.make_tag(
         taglib.TagType.KNOWN_ISSUE,
         date="2021-03-15",
-        disclaimer=TEST_CONFIG.filters[1].observations_to_drop.public_note,
+        disclaimer=TEST_CONFIG.filters[1].public_note,
     )
     ds_expected = test_helpers.build_default_region_dataset(
         {

--- a/tests/libs/datasets/manual_filter_test.py
+++ b/tests/libs/datasets/manual_filter_test.py
@@ -21,7 +21,7 @@ TEST_CONFIG = {
             ],
             "observations_to_drop": {
                 "start_date": "2021-02-12",
-                "fields": [CommonFields.CASES, CommonFields.DEATHS],
+                "drop_fields": [CommonFields.CASES, CommonFields.DEATHS],
                 "internal_note": "https://trello.com/c/aj7ep7S7/1130",
                 "public_note": "The TriCounty Health Department is focusing on vaccinations "
                 "and we have not found a new source of case counts.",
@@ -32,7 +32,7 @@ TEST_CONFIG = {
             "regions_excluded": [Region.from_fips("40109"), Region.from_fips("40143")],
             "observations_to_drop": {
                 "start_date": "2021-03-15",
-                "field_group": FieldGroup.CASES_DEATHS,
+                "drop_field_group": FieldGroup.CASES_DEATHS,
                 "internal_note": "https://trello.com/c/HdAKfp49/1139",
                 "public_note": "Something broke with the OK county data.",
             },

--- a/tests/libs/datasets/manual_filter_test.py
+++ b/tests/libs/datasets/manual_filter_test.py
@@ -11,34 +11,36 @@ from tests import test_helpers
 from tests.test_helpers import TimeseriesLiteral
 
 
-TEST_CONFIG = {
-    "filters": [
-        {
-            "regions_included": [
-                Region.from_fips("49009"),
-                Region.from_fips("49013"),
-                Region.from_fips("49047"),
-            ],
-            "observations_to_drop": {
-                "start_date": "2021-02-12",
-                "drop_fields": [CommonFields.CASES, CommonFields.DEATHS],
-                "internal_note": "https://trello.com/c/aj7ep7S7/1130",
-                "public_note": "The TriCounty Health Department is focusing on vaccinations "
-                "and we have not found a new source of case counts.",
+TEST_CONFIG = manual_filter.Config.parse_obj(
+    {
+        "filters": [
+            {
+                "regions_included": [
+                    Region.from_fips("49009"),
+                    Region.from_fips("49013"),
+                    Region.from_fips("49047"),
+                ],
+                "observations_to_drop": {
+                    "start_date": "2021-02-12",
+                    "drop_fields": [CommonFields.CASES, CommonFields.DEATHS],
+                    "internal_note": "https://trello.com/c/aj7ep7S7/1130",
+                    "public_note": "The TriCounty Health Department is focusing on vaccinations "
+                    "and we have not found a new source of case counts.",
+                },
             },
-        },
-        {
-            "regions_included": [RegionMask(AggregationLevel.COUNTY, states=["OK"])],
-            "regions_excluded": [Region.from_fips("40109"), Region.from_fips("40143")],
-            "observations_to_drop": {
-                "start_date": "2021-03-15",
-                "drop_field_group": FieldGroup.CASES_DEATHS,
-                "internal_note": "https://trello.com/c/HdAKfp49/1139",
-                "public_note": "Something broke with the OK county data.",
+            {
+                "regions_included": [RegionMask(AggregationLevel.COUNTY, states=["OK"])],
+                "regions_excluded": [Region.from_fips("40109"), Region.from_fips("40143")],
+                "observations_to_drop": {
+                    "start_date": "2021-03-15",
+                    "drop_field_group": FieldGroup.CASES_DEATHS,
+                    "internal_note": "https://trello.com/c/HdAKfp49/1139",
+                    "public_note": "Something broke with the OK county data.",
+                },
             },
-        },
-    ]
-}
+        ]
+    }
+)
 
 
 def test_manual_filter():
@@ -53,7 +55,7 @@ def test_manual_filter():
     tag_expected = test_helpers.make_tag(
         taglib.TagType.KNOWN_ISSUE,
         date="2021-02-12",
-        disclaimer=TEST_CONFIG["filters"][0]["observations_to_drop"]["public_note"],
+        disclaimer=TEST_CONFIG.filters[0].observations_to_drop.public_note,
     )
     ds_expected = test_helpers.build_dataset(
         {
@@ -79,7 +81,7 @@ def test_manual_filter_region_excluded():
     tag_expected = test_helpers.make_tag(
         taglib.TagType.KNOWN_ISSUE,
         date="2021-03-15",
-        disclaimer=TEST_CONFIG["filters"][1]["observations_to_drop"]["public_note"],
+        disclaimer=TEST_CONFIG.filters[1].observations_to_drop.public_note,
     )
     ds_expected = test_helpers.build_dataset(
         {
@@ -108,7 +110,7 @@ def test_manual_filter_field_groups():
     tag_expected = test_helpers.make_tag(
         taglib.TagType.KNOWN_ISSUE,
         date="2021-03-15",
-        disclaimer=TEST_CONFIG["filters"][1]["observations_to_drop"]["public_note"],
+        disclaimer=TEST_CONFIG.filters[1].observations_to_drop.public_note,
     )
     ds_expected = test_helpers.build_default_region_dataset(
         {CommonFields.DEATHS: TimeseriesLiteral([1], annotation=[tag_expected]), **other_data},
@@ -139,7 +141,7 @@ def test_manual_filter_per_bucket_tag():
     tag_expected = test_helpers.make_tag(
         taglib.TagType.KNOWN_ISSUE,
         date="2021-03-15",
-        disclaimer=TEST_CONFIG["filters"][1]["observations_to_drop"]["public_note"],
+        disclaimer=TEST_CONFIG.filters[1].observations_to_drop.public_note,
     )
     ds_expected = test_helpers.build_default_region_dataset(
         {

--- a/tests/libs/datasets/timeseries_test.py
+++ b/tests/libs/datasets/timeseries_test.py
@@ -1490,7 +1490,7 @@ def test_multi_region_dataset_get_subset_with_buckets():
 
     ds_expected = test_helpers.build_dataset({**data_us, **data_la})
     test_helpers.assert_dataset_like(ds.get_regions_subset([region_us, region_la]), ds_expected)
-    test_helpers.assert_dataset_like(ds.remove_regions([region_tx]), ds_expected)
+    test_helpers.assert_dataset_like(ds.partition_by_region(exclude=[region_tx])[0], ds_expected)
 
 
 def test_dataset_regions_property(nyc_region):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -101,7 +101,7 @@ def make_tag(
         kwargs["original_observation"] = float(kwargs.get("original_observation", 10))
         kwargs["date"] = pd.to_datetime(kwargs.get("date", "2020-04-02"))
     elif tag_type is taglib.TagType.KNOWN_ISSUE:
-        kwargs["date"] = pd.to_datetime(kwargs.get("date", "2020-04-02"))
+        kwargs["date"] = pd.to_datetime(kwargs.get("date", "2020-04-02")).date()
 
     return taglib.TAG_TYPE_TO_CLASS[tag_type](**kwargs)
 


### PR DESCRIPTION
This PR is part of https://trello.com/c/f27O08ea/1266-make-it-possible-to-block-in-the-backend-using-the-cms

Most of these changes are done to simplify drop_observations because https://github.com/covid-projections/covid-data-model/pull/1080 uses different subsets of the code.

* changes manual_filter config to use a pydantic model instead of unstructured JSON
* replaces MultiRegionDataset.remove_regions with MultiRegionDataset.partition_by_region
* adds MultiRegionDataset.replace_timeseries_wide_dates which is used in the new manual filter code and replaces some funky use of dataclasses.replace in ca_vaccination_backfill.py
* adds RegionMask comments
* changes KnownIssue.date to a datetime instead of panda timestamp, for better compatibility with pydantic

## Tested

`/run.py data update` reproduced identical combined data.