### PR TITLE
Rm OK county cases, last manual filter

### DIFF
--- a/cli/data.py
+++ b/cli/data.py
@@ -164,8 +164,6 @@ def update(aggregate_to_country: bool, state: Optional[str], fips: Optional[str]
         multiregion_dataset = multiregion_dataset.append_regions(country_dataset)
         multiregion_dataset.print_stats("aggregate_to_country")
 
-    multiregion_dataset = manual_filter.run(multiregion_dataset)
-
     combined_dataset_utils.persist_dataset(multiregion_dataset, path_prefix)
     multiregion_dataset.print_stats("persist")
 

--- a/cli/data.py
+++ b/cli/data.py
@@ -17,7 +17,6 @@ from libs import google_sheet_helpers
 from libs import pipeline
 from libs.datasets import combined_dataset_utils
 from libs.datasets import custom_aggregations
-from libs.datasets import manual_filter
 from libs.datasets import statistical_areas
 from libs.datasets.combined_datasets import (
     ALL_TIMESERIES_FEATURE_DEFINITION,

--- a/libs/datasets/manual_filter.py
+++ b/libs/datasets/manual_filter.py
@@ -6,10 +6,8 @@ from covidactnow.datapublic.common_fields import CommonFields
 from covidactnow.datapublic.common_fields import PdFields
 import pandas as pd
 
-from libs.datasets import AggregationLevel
 from libs.datasets import taglib
 from libs.datasets import timeseries
-from libs.pipeline import Region, RegionMask
 
 
 _logger = structlog.getLogger()

--- a/libs/datasets/manual_filter.py
+++ b/libs/datasets/manual_filter.py
@@ -16,20 +16,7 @@ _logger = structlog.getLogger()
 
 
 # TODO(tom): Make some kind of hierarchy of class to form a schema that can be populated by a JSON.
-CONFIG = {
-    "filters": [
-        {
-            "regions_included": [RegionMask(AggregationLevel.COUNTY, states=["OK"])],
-            "regions_excluded": [Region.from_fips("40109"), Region.from_fips("40143")],
-            "observations_to_drop": {
-                "start_date": "2021-03-15",
-                "fields": [CommonFields.CASES, CommonFields.DEATHS],
-                "internal_note": "https://trello.com/c/HdAKfp49/1139",
-                "public_note": "Something broke with the OK county data.",
-            },
-        },
-    ]
-}
+CONFIG = {"filters": []}
 
 
 def drop_observations(


### PR DESCRIPTION
This PR is for https://trello.com/c/HdAKfp49/1139-disabled-all-ok-counties-except-2-no-longer-reporting-cases

* Removes OK county manual_filter
* Stop calling manual_filter run during data update because https://github.com/covid-projections/covid-data-model/pull/1080 will bring it back

# Tested

Ran `./run.py data update` and looked at `git difftool --no-prompt -t vimdiff main -- data/multiregion-wide-dates.csv`. There I saw
* known_issues annotation column removed
* us-ok counties cases and deaths rows have new cumulative values, but only updated ~weekly
* us-ok counties new_cases and new_deaths have lots of zeros, for example `iso1:us#iso2:us-ok#fips:40019,new_cases` newest dates first `19,0,0,0,0,0,0,43,0,0,0,0,0,0,69,0,0,0,0,0,0`. This is unchanged from main because the manual filter (that dropped observations) was applied to cases after new_cases was calculated :-/