### PR TITLE
move vaccine_backfills.derive_vaccine_pct from api to combined data

### DIFF
--- a/cli/data.py
+++ b/cli/data.py
@@ -164,6 +164,8 @@ def update(aggregate_to_country: bool, state: Optional[str], fips: Optional[str]
         multiregion_dataset = multiregion_dataset.append_regions(country_dataset)
         multiregion_dataset.print_stats("aggregate_to_country")
 
+    multiregion_dataset = vaccine_backfills.derive_vaccine_pct(multiregion_dataset)
+
     multiregion_dataset = manual_filter.run(multiregion_dataset)
 
     combined_dataset_utils.persist_dataset(multiregion_dataset, path_prefix)

--- a/libs/pipelines/api_v2_pipeline.py
+++ b/libs/pipelines/api_v2_pipeline.py
@@ -310,8 +310,6 @@ def generate_from_loaded_data(
     log.info("Running test positivity.")
     regions_data = test_positivity.run_and_maybe_join_columns(selected_dataset, log)
 
-    regions_data = vaccine_backfills.derive_vaccine_pct(regions_data)
-
     log.info(f"Joining inputs by region.")
     icu_data_map = dict(model_output.icu.iter_one_regions())
     rt_data_map = dict(model_output.infection_rate.iter_one_regions())


### PR DESCRIPTION
This PR addresses issue #<insert number>

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/main/api/schemas) updated?
- [ ] Are tests passing?
