### PR TITLE
Wire up US to FIPS 0.

### DIFF
--- a/data/geo-data.csv
+++ b/data/geo-data.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ec0585c977de54c40240e33c5da0f8709c9bf04835cdc5608ce8e76c9b3ca448
-size 249450
+oid sha256:99b4c7aa361206cb1e19727db1e4ad17fe3dcb71b9d9fcbec1fb398b61064415
+size 249451

--- a/libs/datasets/sources/can_scraper_helpers.py
+++ b/libs/datasets/sources/can_scraper_helpers.py
@@ -80,7 +80,7 @@ def _fips_from_int(param: pd.Series):
 
     Copied from covid-data-public/scripts/helpers.py
     """
-    return param.apply(lambda v: f"{v:0>{2 if v < 100 else 5}}")
+    return param.apply(lambda v: f"{v:0>{1 if v == 0 else 2 if v < 100 else 5}}")
 
 
 DEMOGRAPHIC_FIELDS = [Fields.AGE, Fields.RACE, Fields.ETHNICITY, Fields.SEX]


### PR DESCRIPTION
This unblocks our data updates.

Tested via: `./run.py data update`

I think we're squashing the incoming US-level data so it didn't actually show up in the output, but at least the pipeline is unblocked.

FYI- This is the diff on geo-data.csv since github doesn't show it:
![image](https://user-images.githubusercontent.com/206364/115781858-cfec4f80-a36f-11eb-81fc-f8fc34f4b444.png)
