### PR TITLE
move non-numeric column out of PerTimeseries.stats

### DIFF
--- a/dash_app/dashboard.py
+++ b/dash_app/dashboard.py
@@ -47,7 +47,7 @@ class TimeSeriesPivotTablePreset(enum.Enum):
         "Per source count",
         {
             "rows": [CommonFields.AGGREGATE_LEVEL, timeseries_stats.FIELD_GROUP],
-            "cols": [timeseries_stats.StatName.SOURCE_TYPE_SET],
+            "cols": [timeseries_stats.SOURCE_TYPE_SET],
         },
     )
     SOURCE_BY_STATE = (
@@ -56,7 +56,7 @@ class TimeSeriesPivotTablePreset(enum.Enum):
             "rows": [CommonFields.AGGREGATE_LEVEL, CommonFields.STATE],
             "cols": [timeseries_stats.FIELD_GROUP],
             "aggregatorName": "List Unique Values",
-            "vals": [timeseries_stats.StatName.SOURCE_TYPE_SET],
+            "vals": [timeseries_stats.SOURCE_TYPE_SET],
         },
     )
     COUNTY_DEMO = (
@@ -163,7 +163,9 @@ def init(server):
         .rename("count")
     )
 
-    county_stats = per_timeseries_stats.subset_locations(aggregation_level=AggregationLevel.COUNTY)
+    county_stats = per_timeseries_stats.subset_locations(
+        aggregation_level=AggregationLevel.COUNTY
+    ).aggregate(CommonFields.LOCATION_ID, PdFields.VARIABLE)
     county_variable_population_ratio = pd.DataFrame(
         {
             "has_url": population_ratio_by_variable(ds, county_stats.has_url),
@@ -279,6 +281,7 @@ def population_ratio_by_variable(
 ) -> pd.DataFrame:
     """Finds the ratio of the population where df is True, broken down by column/variable."""
     assert df.index.names == [CommonFields.LOCATION_ID]
+    print(df.columns.names)
     assert df.columns.names == [PdFields.VARIABLE]
     population_indexed = dataset.static[CommonFields.POPULATION].reindex(df.index)
     population_total = population_indexed.sum()
@@ -325,9 +328,6 @@ def _init_callbacks(
         selected_row = more_itertools.one(selected_rows)
         return [region_id_series.iat[selected_row]]
 
-    df = per_timeseries_stats.stats.reset_index()
-    pivottable_data = [df.columns.tolist()] + df.values.tolist()
-
     @dash_app.callback(
         Output("pivot_table_parent", "children"),
         [Input(preset.btn_id, "n_clicks") for preset in TimeSeriesPivotTablePreset],
@@ -352,7 +352,9 @@ def _init_callbacks(
         # Each PivotTable needs a unique id as a work around for
         # https://github.com/plotly/dash-pivottable/issues/10
         return dash_pivottable.PivotTable(
-            id=preset.tbl_id, data=pivottable_data, **preset.pivot_table_parameters,
+            id=preset.tbl_id,
+            data=per_timeseries_stats.pivottable_data,
+            **preset.pivot_table_parameters,
         )
 
     # Input not in a list raises dash.exceptions.IncorrectTypeException: The input argument

--- a/dash_app/dashboard.py
+++ b/dash_app/dashboard.py
@@ -281,7 +281,6 @@ def population_ratio_by_variable(
 ) -> pd.DataFrame:
     """Finds the ratio of the population where df is True, broken down by column/variable."""
     assert df.index.names == [CommonFields.LOCATION_ID]
-    print(df.columns.names)
     assert df.columns.names == [PdFields.VARIABLE]
     population_indexed = dataset.static[CommonFields.POPULATION].reindex(df.index)
     population_total = population_indexed.sum()

--- a/libs/qa/timeseries_stats.py
+++ b/libs/qa/timeseries_stats.py
@@ -53,12 +53,7 @@ class Aggregated:
     def __post_init__(self):
         # index level 0 is a location_id or some kind of aggregated region kind of thing
         assert self.stats.index.names[0] in [CommonFields.LOCATION_ID, CommonFields.AGGREGATE_LEVEL]
-        assert self.stats.columns.to_list() == [
-            StatName.HAS_TIMESERIES,
-            StatName.HAS_URL,
-            StatName.ANNOTATION_COUNT,
-            StatName.BUCKET_ALL_COUNT,
-        ]
+        assert self.stats.columns.to_list() == list(StatName)
         assert is_numeric_dtype(more_itertools.one(set(self.stats.dtypes)))
         assert self.source_type.index.equals(self.stats.index)
         assert self.source_type.columns.to_list() in ([SOURCE_TYPE_SET], [])

--- a/tests/libs/qa/timeseries_stats_test.py
+++ b/tests/libs/qa/timeseries_stats_test.py
@@ -85,6 +85,7 @@ def test_make_from_dataset():
     )
 
     per_timeseries.stats_for_locations(dataset.location_ids)
+    assert per_timeseries.pivottable_data
 
     county_stats = per_timeseries.subset_locations(
         aggregation_level=AggregationLevel.COUNTY


### PR DESCRIPTION
* Moves the non-numeric column source_type_set out of Aggregate.stats so that `stats.groupby(...).sum()` does what I'd expect
* Moves creation of the list of data for the pivottable into Aggregate to keep logic around stats and source_type in one class.
* Fixes `PerTimeseries.__post_init__` to call super class, I thought this was already happening
* Factor out PerTimeseries._subset
* Change PerTimeseries.aggregate to accept any number of fields so it can be used by stats_for_locations, factoring out a call to stats.groupby