### PR TITLE
backfill_vaccination_initiated incorrectly added empty time series

### DIFF
--- a/libs/datasets/vaccine_backfills.py
+++ b/libs/datasets/vaccine_backfills.py
@@ -92,7 +92,7 @@ def backfill_vaccination_initiated(dataset: MultiRegionDataset) -> MultiRegionDa
 
     # Compute and keep only time series with at least one real value
     computed_initiated = administered - completed
-    computed_initiated = computed_initiated.dropna(axis=1, how="all")
+    computed_initiated = computed_initiated.dropna(axis=0, how="all")
     # Keep the computed initiated only where there is not already an existing time series.
     computed_initiated = computed_initiated.loc[
         ~computed_initiated.index.isin(existing_initiated.index)

--- a/tests/libs/datasets/vaccine_backfill_test.py
+++ b/tests/libs/datasets/vaccine_backfill_test.py
@@ -74,6 +74,17 @@ def test_backfill_vaccine_initiated_by_bucket():
     test_helpers.assert_dataset_like(ds_result, ds_expected)
 
 
+def test_backfill_vaccine_without_completed():
+    """Make sure nothing is changed when VACCINATIONS_COMPLETED is incomplete."""
+    ds_in = test_helpers.build_default_region_dataset(
+        {CommonFields.VACCINES_ADMINISTERED: [100, 200],}
+    )
+
+    ds_result = vaccine_backfills.backfill_vaccination_initiated(ds_in)
+
+    test_helpers.assert_dataset_like(ds_result, ds_in)
+
+
 def test_derive_vaccine_pct():
     region_tx = Region.from_state("TX")
     region_sf = Region.from_fips("06075")


### PR DESCRIPTION
This PR fixes a bug in `backfill_vaccination_initiated` that I noticed while working on https://github.com/covid-projections/covid-data-model/pull/1094

`computed_initiated` was being kept even when it was all NA for a location+bucket. This happens when one or both of administered and completed were all NA. The bug cause combined datasets to include a row with a derived tag but no real values. The fix is changing dropna axis param to `0, or ‘index’ : Drop rows which contain missing values.` (from DataFrame.dropna docs).

## Tested

```
./run.py data update
git difftool --no-prompt -t vimdiff main -- data/multiregion-wide-dates.csv
```
shows 2533 dropped empty `vaccinations_initiated` for various buckets that all have derived tag `{}`.