### PR TITLE
MultiRegionDataset.get_timeseries_bucketed_wide_dates and friends

### DIFF
--- a/libs/datasets/taglib.py
+++ b/libs/datasets/taglib.py
@@ -315,16 +315,16 @@ class KnownIssueNoDate(TagInTimeseries):
 class Derived(TagInTimeseries):
     TAG_TYPE = TagType.DERIVED
     # Name of the function which added this derived tag.
-    f: str
+    function_name: str
 
     @classmethod
     def make_instance(cls, *, content: str) -> "TagInTimeseries":
         content_parsed = json.loads(content)
-        return cls(f=content_parsed.get("f", ""))
+        return cls(function_name=content_parsed.get("f", ""))
 
     @property
     def content(self) -> str:
-        d = {"f": self.f}
+        d = {"f": self.function_name}
         return json.dumps(d, separators=(",", ":"))
 
 

--- a/libs/datasets/taglib.py
+++ b/libs/datasets/taglib.py
@@ -314,6 +314,7 @@ class KnownIssueNoDate(TagInTimeseries):
 @dataclass(frozen=True)
 class Derived(TagInTimeseries):
     TAG_TYPE = TagType.DERIVED
+    # Name of the function which added this derived tag.
     f: str
 
     @classmethod

--- a/libs/datasets/taglib.py
+++ b/libs/datasets/taglib.py
@@ -314,15 +314,17 @@ class KnownIssueNoDate(TagInTimeseries):
 @dataclass(frozen=True)
 class Derived(TagInTimeseries):
     TAG_TYPE = TagType.DERIVED
+    f: str
 
     @classmethod
     def make_instance(cls, *, content: str) -> "TagInTimeseries":
-        assert content == "{}"
-        return cls()
+        content_parsed = json.loads(content)
+        return cls(f=content_parsed.get("f", ""))
 
     @property
     def content(self) -> str:
-        return "{}"
+        d = {"f": self.f}
+        return json.dumps(d, separators=(",", ":"))
 
 
 TAG_TYPE_TO_CLASS = {

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -658,6 +658,17 @@ class MultiRegionDataset:
         except KeyError:
             return EMPTY_TIMESERIES_NOT_BUCKETED_WIDE_DATES_DF
 
+    def get_timeseries_wide_dates(self, field: FieldName, *, bucketed: bool) -> pd.DataFrame:
+        """Returns a DataFrame with LOCATION_ID index and DATE columns"""
+        if bucketed:
+            raise NotImplementedError()
+        try:
+            return self.timeseries_not_bucketed_wide_dates.xs(
+                field, level=PdFields.VARIABLE, axis=0
+            )
+        except KeyError:
+            return EMPTY_TIMESERIES_NOT_BUCKETED_WIDE_DATES_DF.droplevel(PdFields.VARIABLE)
+
     def _timeseries_latest_values(self) -> pd.DataFrame:
         """Returns the latest value for every region and metric, derived from timeseries."""
 

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -648,9 +648,8 @@ class MultiRegionDataset:
         print(f"Dataset {name}:\n{count}")
 
     @cached_property
-    def timeseries_not_bucketed_wide_dates(self) -> pd.DataFrame:
+    def _timeseries_not_bucketed_wide_dates(self) -> pd.DataFrame:
         """Returns the timeseries in a DataFrame with LOCATION_ID, VARIABLE index and DATE columns."""
-        # TODO(tom): Replace all calls to this function with calls to timeseries_bucketed_wide_dates
         try:
             return self.timeseries_bucketed_wide_dates.xs(
                 "all", level=PdFields.DEMOGRAPHIC_BUCKET, axis=0
@@ -658,16 +657,22 @@ class MultiRegionDataset:
         except KeyError:
             return EMPTY_TIMESERIES_NOT_BUCKETED_WIDE_DATES_DF
 
-    def get_timeseries_wide_dates(self, field: FieldName, *, bucketed: bool) -> pd.DataFrame:
-        """Returns a DataFrame with LOCATION_ID index and DATE columns"""
-        if bucketed:
-            raise NotImplementedError()
+    def get_timeseries_not_bucketed_wide_dates(self, field: FieldName) -> pd.DataFrame:
+        """Returns a field in a wide-dates DataFrame with LOCATION_ID index and DATE columns"""
         try:
-            return self.timeseries_not_bucketed_wide_dates.xs(
+            return self._timeseries_not_bucketed_wide_dates.xs(
                 field, level=PdFields.VARIABLE, axis=0
             )
         except KeyError:
             return EMPTY_TIMESERIES_NOT_BUCKETED_WIDE_DATES_DF.droplevel(PdFields.VARIABLE)
+
+    def get_timeseries_bucketed_wide_dates(self, field: FieldName) -> pd.DataFrame:
+        """Returns a field in a wide-dates DataFrame with LOCATION_ID, DEMOGRAPHIC_BUCKET index and
+        DATE columns"""
+        try:
+            return self.timeseries_bucketed_wide_dates.xs(field, level=PdFields.VARIABLE, axis=0)
+        except KeyError:
+            return EMPTY_TIMESERIES_BUCKETED_WIDE_DATES_DF.droplevel(PdFields.VARIABLE)
 
     def _timeseries_latest_values(self) -> pd.DataFrame:
         """Returns the latest value for every region and metric, derived from timeseries."""
@@ -769,7 +774,7 @@ class MultiRegionDataset:
         """Returns a new object with given provenance string for every timeseries."""
         return self.add_provenance_series(
             pd.Series([], dtype=str, name=PdFields.PROVENANCE).reindex(
-                self.timeseries_not_bucketed_wide_dates.index, fill_value=provenance
+                self._timeseries_not_bucketed_wide_dates.index, fill_value=provenance
             )
         )
 

--- a/libs/datasets/vaccine_backfills.py
+++ b/libs/datasets/vaccine_backfills.py
@@ -91,6 +91,4 @@ def backfill_vaccination_initiated(dataset: MultiRegionDataset) -> MultiRegionDa
 
     return dataset.replace_timeseries_wide_dates(
         [dataset.timeseries_bucketed_wide_dates, computed_initiated]
-    ).add_tag_to_subset(
-        taglib.Derived(f="backfill_vaccination_initiated"), computed_initiated.index
-    )
+    ).add_tag_to_subset(taglib.Derived("backfill_vaccination_initiated"), computed_initiated.index)

--- a/libs/datasets/vaccine_backfills.py
+++ b/libs/datasets/vaccine_backfills.py
@@ -1,10 +1,12 @@
 import pandas as pd
 from covidactnow.datapublic.common_fields import CommonFields
+from covidactnow.datapublic.common_fields import DemographicBucket
 from covidactnow.datapublic.common_fields import PdFields
 
+from libs.datasets import AggregationLevel
 from libs.datasets import taglib
 from libs.datasets import timeseries
-
+from libs.pipeline import Region
 
 MultiRegionDataset = timeseries.MultiRegionDataset
 
@@ -106,4 +108,6 @@ def backfill_vaccination_initiated(dataset: MultiRegionDataset) -> MultiRegionDa
 
     return dataset.replace_timeseries_wide_dates(
         [timeseries_wide, computed_initiated]
-    ).add_tag_to_subset(taglib.Derived(), computed_initiated.index)
+    ).add_tag_to_subset(
+        taglib.Derived(f="backfill_vaccination_initiated"), computed_initiated.index
+    )

--- a/libs/qa/timeseries_stats.py
+++ b/libs/qa/timeseries_stats.py
@@ -156,6 +156,8 @@ class PerTimeseries(Aggregated):
             == DemographicBucket.ALL
         ).astype(int)
         tag_count = (
+            # This groupby(...).count() could be replaced by `tag.index.value_counts(sort=False)`
+            # but value_count drops the index names.
             ds.tag.groupby(
                 [
                     CommonFields.LOCATION_ID,

--- a/tests/libs/datasets/vaccine_backfill_test.py
+++ b/tests/libs/datasets/vaccine_backfill_test.py
@@ -3,7 +3,7 @@ import pytest
 from covidactnow.datapublic.common_fields import CommonFields
 from covidactnow.datapublic.common_fields import DemographicBucket
 
-from libs.datasets import taglib
+from libs.datasets.taglib import TagType
 from libs.pipeline import Region
 from tests import test_helpers
 from tests.test_helpers import TimeseriesLiteral
@@ -34,8 +34,9 @@ def test_backfill_vaccine_initiated(initiated_values, initiated_expected, annota
     metrics = {ny_region: ny_metrics, az_region: az_metrics}
     dataset = test_helpers.build_dataset(metrics)
     result = vaccine_backfills.backfill_vaccination_initiated(dataset)
+    derived = test_helpers.make_tag(TagType.DERIVED, f="backfill_vaccination_initiated")
     if annotation:
-        initiated_expected = TimeseriesLiteral(initiated_expected, annotation=[taglib.Derived()])
+        initiated_expected = TimeseriesLiteral(initiated_expected, annotation=[derived])
     expected_ny = {
         CommonFields.VACCINES_ADMINISTERED: [100, 200],
         CommonFields.VACCINATIONS_COMPLETED: [50, 50],
@@ -50,6 +51,7 @@ def test_backfill_vaccine_initiated(initiated_values, initiated_expected, annota
 def test_backfill_vaccine_initiated_by_bucket():
     bucket_all = DemographicBucket.ALL
     bucket_40s = DemographicBucket("age:40-49")
+    derived = test_helpers.make_tag(TagType.DERIVED, f="backfill_vaccination_initiated")
 
     ds_in = test_helpers.build_default_region_dataset(
         {
@@ -64,8 +66,8 @@ def test_backfill_vaccine_initiated_by_bucket():
         {
             CommonFields.VACCINES_ADMINISTERED: {bucket_all: [100, 200], bucket_40s: [40, 60]},
             CommonFields.VACCINATIONS_INITIATED: {
-                bucket_all: TimeseriesLiteral([50, 150], annotation=[taglib.Derived()]),
-                bucket_40s: TimeseriesLiteral([30, 40], annotation=[taglib.Derived()]),
+                bucket_all: TimeseriesLiteral([50, 150], annotation=[derived]),
+                bucket_40s: TimeseriesLiteral([30, 40], annotation=[derived]),
             },
             CommonFields.VACCINATIONS_COMPLETED: {bucket_all: [50, 50], bucket_40s: [10, 20]},
         }

--- a/tests/libs/datasets/vaccine_backfill_test.py
+++ b/tests/libs/datasets/vaccine_backfill_test.py
@@ -34,7 +34,7 @@ def test_backfill_vaccine_initiated(initiated_values, initiated_expected, annota
     metrics = {ny_region: ny_metrics, az_region: az_metrics}
     dataset = test_helpers.build_dataset(metrics)
     result = vaccine_backfills.backfill_vaccination_initiated(dataset)
-    derived = test_helpers.make_tag(TagType.DERIVED, f="backfill_vaccination_initiated")
+    derived = test_helpers.make_tag(TagType.DERIVED, function_name="backfill_vaccination_initiated")
     if annotation:
         initiated_expected = TimeseriesLiteral(initiated_expected, annotation=[derived])
     expected_ny = {
@@ -51,7 +51,7 @@ def test_backfill_vaccine_initiated(initiated_values, initiated_expected, annota
 def test_backfill_vaccine_initiated_by_bucket():
     bucket_all = DemographicBucket.ALL
     bucket_40s = DemographicBucket("age:40-49")
-    derived = test_helpers.make_tag(TagType.DERIVED, f="backfill_vaccination_initiated")
+    derived = test_helpers.make_tag(TagType.DERIVED, function_name="backfill_vaccination_initiated")
 
     ds_in = test_helpers.build_default_region_dataset(
         {
@@ -92,7 +92,7 @@ def test_backfill_vaccine_without_completed():
 
     ds_result = vaccine_backfills.backfill_vaccination_initiated(ds_in)
 
-    derived = test_helpers.make_tag(TagType.DERIVED, f="backfill_vaccination_initiated")
+    derived = test_helpers.make_tag(TagType.DERIVED, function_name="backfill_vaccination_initiated")
     ds_expected = test_helpers.build_dataset(
         {
             region_tx: metrics_tx,


### PR DESCRIPTION
This is some more cleanup associated with https://github.com/covid-projections/covid-data-model/pull/1094

* Adds tag parameter `Derived.f` to save the function name, useful now that we're adding that tag to the same field from multiple places.
* Replaces some direct access to `MultiRegionDataset.timeseries_bucketed_wide_dates` with new function `get_timeseries_bucketed_wide_dates` that returns one field and similarly for `timeseries_not_bucketed_wide_dates`.
* Replaces some calls to Index.get_level_values with Index.unique where a copy of the value per index entry isn't needed. See https://stackoverflow.com/a/50364903

## Tested

```
./run.py data update
git difftool --no-prompt -t vimdiff main -- data/multiregion-wide-dates.csv
```
shows the same diff as https://github.com/covid-projections/covid-data-model/pull/1096 because main hasn't been update plus counties in IL have backfill_vaccination_initiated added to derived tag of vaccinations_initiated. As expected, don't see any other changes.
