### PR TITLE
drop_regions_without_population fix for country data

### DIFF
--- a/cli/data.py
+++ b/cli/data.py
@@ -147,9 +147,11 @@ def update(
 
     multiregion_dataset = new_cases_and_deaths.add_new_cases(multiregion_dataset)
     multiregion_dataset = new_cases_and_deaths.add_new_deaths(multiregion_dataset)
+    multiregion_dataset.print_stats("new_cases_and_deaths")
 
     multiregion_dataset = outlier_detection.drop_new_case_outliers(multiregion_dataset)
     multiregion_dataset = outlier_detection.drop_new_deaths_outliers(multiregion_dataset)
+    multiregion_dataset.print_stats("outlier_detection")
 
     multiregion_dataset = timeseries.drop_regions_without_population(
         multiregion_dataset, KNOWN_LOCATION_ID_WITHOUT_POPULATION, structlog.get_logger()

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -650,7 +650,6 @@ class MultiRegionDataset:
             self.timeseries_bucketed_long.index.get_level_values(CommonFields.LOCATION_ID)
             .map(dataset_utils.get_geo_data()[CommonFields.AGGREGATE_LEVEL])
             .value_counts()
-            .rename(None)
         )
         stats_in_text = "\n".join(
             [

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -1,3 +1,4 @@
+import textwrap
 from typing import (
     Any,
     Collection,
@@ -645,7 +646,21 @@ class MultiRegionDataset:
             .groupby(common_fields.COMMON_FIELD_TO_GROUP, sort=False)
             .sum()
         )
-        print(f"Dataset {name}:\n{count}")
+        by_level = (
+            self.timeseries_bucketed_long.index.get_level_values(CommonFields.LOCATION_ID)
+            .map(dataset_utils.get_geo_data()[CommonFields.AGGREGATE_LEVEL])
+            .value_counts()
+            .rename(None)
+        )
+        stats_in_text = "\n".join(
+            [
+                "By bucket:",
+                textwrap.indent(count.to_string(), "  "),
+                "By level:",
+                textwrap.indent(by_level.to_string(), "  "),
+            ]
+        )
+        print(f"Observations in dataset {name}:\n" + textwrap.indent(stats_in_text, "  "))
 
     @cached_property
     def _timeseries_not_bucketed_wide_dates(self) -> pd.DataFrame:
@@ -1307,20 +1322,19 @@ def _remove_padded_nans(df, columns):
 
 
 def drop_regions_without_population(
-    mrts: MultiRegionDataset,
+    dataset: MultiRegionDataset,
     known_location_id_to_drop: Sequence[str],
     log: Union[structlog.BoundLoggerBase, structlog._config.BoundLoggerLazyProxy],
 ) -> MultiRegionDataset:
-    assert mrts.static.index.names == [CommonFields.LOCATION_ID]
-    latest_population = mrts.static[CommonFields.POPULATION]
-    locations_with_population = mrts.static.loc[latest_population.notna()].index
-    locations_without_population = mrts.static.loc[latest_population.isna()].index
-    unexpected_drops = set(locations_without_population) - set(known_location_id_to_drop)
+    location_id_with_population = dataset.static[CommonFields.POPULATION].dropna().index
+    assert location_id_with_population.names == [CommonFields.LOCATION_ID]
+    location_id_without_population = dataset.location_ids.difference(location_id_with_population)
+    unexpected_drops = set(location_id_without_population) - set(known_location_id_to_drop)
     if unexpected_drops:
         log.warning(
             "Dropping unexpected regions without populaton", location_ids=sorted(unexpected_drops)
         )
-    return mrts.get_locations_subset(locations_with_population)
+    return dataset.get_locations_subset(location_id_with_population)
 
 
 class DatasetName(str):


### PR DESCRIPTION
This PR is part of https://trello.com/c/sJDKzKIU/1302-make-usa-aggregation-use-incoming-usa-data-if-it-exists-rather-than-aggregate-the-states

* re-write drop_regions_without_population to not depend on MultiRegionDataset.static. Country data was silently dropped because the country did not appear in 'static'.
* Extend print_stats to breakdown by level so I can see where the country data is being dropped
* print_stats at a few more stages of data update

## Tested

`./run.py data update` reproduced identical output to main.