### PR TITLE
MultiRegionDataset.join_columns to support joining static data.

### DIFF
--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -1273,18 +1273,15 @@ class MultiRegionDataset:
         Args:
             other: The dataset to join with `self`.
         """
-        common_static_colmuns = set(self.static.columns.intersection(other.static.columns))
+        common_static_colmuns = set(self.static.columns) & set(other.static.columns)
         if common_static_colmuns:
-            raise NotImplementedError(
-                f"join with common static columns {common_static_colmuns} not supported"
-            )
+            raise ValueError(f"join_columns static columns not disjoint: {common_static_colmuns}")
         combined_static = pd.concat([self.static, other.static], axis=1)
-        common_ts_columns = set(
-            other.timeseries_bucketed.columns.intersection(self.timeseries_bucketed.columns)
+        common_ts_columns = set(other.timeseries_bucketed.columns) & set(
+            self.timeseries_bucketed.columns
         )
         if common_ts_columns:
-            # columns to be joined need to be disjoint
-            raise ValueError(f"Columns are in both dataset: {common_ts_columns}")
+            raise ValueError(f"join_columns time series columns not disjoint: {common_ts_columns}")
         combined_df = pd.concat([self.timeseries_bucketed, other.timeseries_bucketed], axis=1)
         combined_tag = pd.concat([self.tag, other.tag]).sort_index()
         return MultiRegionDataset(

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -943,6 +943,7 @@ class MultiRegionDataset:
         assert self.static.index.is_unique
         assert self.static.index.is_monotonic_increasing
         assert self.static.columns.intersection(GEO_DATA_COLUMNS).empty
+        assert self.static.columns.is_unique
 
         assert isinstance(self.tag, pd.Series)
         assert self.tag.index.names == _TAG_INDEX_FIELDS
@@ -1276,13 +1277,15 @@ class MultiRegionDataset:
         common_static_colmuns = set(self.static.columns) & set(other.static.columns)
         if common_static_colmuns:
             raise ValueError(f"join_columns static columns not disjoint: {common_static_colmuns}")
-        combined_static = pd.concat([self.static, other.static], axis=1)
+        combined_static = pd.concat([self.static, other.static], axis="columns")
         common_ts_columns = set(other.timeseries_bucketed.columns) & set(
             self.timeseries_bucketed.columns
         )
         if common_ts_columns:
             raise ValueError(f"join_columns time series columns not disjoint: {common_ts_columns}")
-        combined_df = pd.concat([self.timeseries_bucketed, other.timeseries_bucketed], axis=1)
+        combined_df = pd.concat(
+            [self.timeseries_bucketed, other.timeseries_bucketed], axis="columns"
+        )
         combined_tag = pd.concat([self.tag, other.tag]).sort_index()
         return MultiRegionDataset(
             timeseries_bucketed=combined_df, static=combined_static, tag=combined_tag

--- a/tests/libs/datasets/timeseries_test.py
+++ b/tests/libs/datasets/timeseries_test.py
@@ -983,8 +983,8 @@ def test_join_columns():
     ts_joined = ts_1.join_columns(ts_2)
     test_helpers.assert_dataset_like(ts_joined, ts_expected, drop_na_latest=True)
 
-    with pytest.raises(NotImplementedError):
-        ts_2.join_columns(ts_1)
+    ts_joined = ts_2.join_columns(ts_1)
+    test_helpers.assert_dataset_like(ts_joined, ts_expected, drop_na_latest=True)
 
     with pytest.raises(ValueError):
         # Raises because the same column is in both datasets
@@ -1050,6 +1050,25 @@ def test_join_columns_with_buckets():
     ds_expected = test_helpers.build_default_region_dataset({**m1_data, **m2_data})
 
     ds_joined = ds_1.join_columns(ds_2)
+    test_helpers.assert_dataset_like(ds_joined, ds_expected)
+
+
+def test_join_columns_with_static():
+    m1 = FieldName("m1")
+    m2 = FieldName("m2")
+
+    ds_1 = test_helpers.build_default_region_dataset({}, static={m1: 1})
+    ds_2 = test_helpers.build_default_region_dataset({}, static={m2: 2})
+
+    with pytest.raises(NotImplementedError):
+        ds_1.join_columns(ds_1)
+
+    ds_expected = test_helpers.build_default_region_dataset({}, static={m1: 1, m2: 2})
+
+    ds_joined = ds_1.join_columns(ds_2)
+    test_helpers.assert_dataset_like(ds_joined, ds_expected)
+
+    ds_joined = ds_2.join_columns(ds_1)
     test_helpers.assert_dataset_like(ds_joined, ds_expected)
 
 

--- a/tests/libs/datasets/timeseries_test.py
+++ b/tests/libs/datasets/timeseries_test.py
@@ -990,16 +990,8 @@ def test_join_columns():
         # Raises because the same column is in both datasets
         ts_2.join_columns(ts_2)
 
-    # Checking geo attributes is currently disabled.
-    # ts_2_variation_df = ts_2.combined_df.copy()
-    # ts_2_variation_df.loc[
-    #     ts_2_variation_df[CommonFields.COUNTY] == "Bar County", CommonFields.COUNTY
-    # ] = "Bart County"
-    # ts_2_variation = timeseries.MultiRegionDataset.from_combined_dataframe(
-    #     ts_2_variation_df
-    # )
-    # with pytest.raises(ValueError):
-    #     ts_1.join_columns(ts_2_variation)
+    # geo attributes, such as aggregation level and county name, generally appear in geo-data.csv
+    # instead of MultiRegionDataset so they don't need special handling in join_columns.
 
 
 def test_join_columns_missing_regions():
@@ -1060,7 +1052,7 @@ def test_join_columns_with_static():
     ds_1 = test_helpers.build_default_region_dataset({}, static={m1: 1})
     ds_2 = test_helpers.build_default_region_dataset({}, static={m2: 2})
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(ValueError):
         ds_1.join_columns(ds_1)
 
     ds_expected = test_helpers.build_default_region_dataset({}, static={m1: 1, m2: 2})


### PR DESCRIPTION
This PR is part of https://trello.com/c/sJDKzKIU/1302-make-usa-aggregation-use-incoming-usa-data

- test_helpers.build_dataset support for empty timeseries.
- change MultiRegionDataset.join_columns to support joining static data.
- add __post_init__ check for static.columns.is_unique to verify that the structure is as expected