### PR TITLE
add CDC country vaccine numbers

### DIFF
--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -145,9 +145,10 @@ CDCVaccinesCountiesDataset = datasource_regions(
     CDCVaccinesDataset, RegionMask(AggregationLevel.COUNTY)
 )
 
-CDCVaccinesStatesDataset = datasource_regions(
-    CDCVaccinesDataset, RegionMask(AggregationLevel.STATE)
+CDCVaccinesStatesAndNationDataset = datasource_regions(
+    CDCVaccinesDataset, [RegionMask(AggregationLevel.STATE), RegionMask(AggregationLevel.COUNTRY)]
 )
+
 
 # Below are two instances of feature definitions. These define
 # how to assemble values for a specific field.  Right now, we only
@@ -213,25 +214,25 @@ ALL_TIMESERIES_FEATURE_DEFINITION: FeatureDataSourceMap = {
         CDCVaccinesCountiesDataset,
         CANScraperStateProviders,
         CANScraperCountyProviders,
-        CDCVaccinesStatesDataset,
+        CDCVaccinesStatesAndNationDataset,
     ],
     CommonFields.VACCINES_ADMINISTERED: [
         CDCVaccinesCountiesDataset,
         CANScraperStateProviders,
         CANScraperCountyProviders,
-        CDCVaccinesStatesDataset,
+        CDCVaccinesStatesAndNationDataset,
     ],
     CommonFields.VACCINATIONS_INITIATED: [
         CDCVaccinesCountiesDataset,
         CANScraperStateProviders,
         CANScraperCountyProviders,
-        CDCVaccinesStatesDataset,
+        CDCVaccinesStatesAndNationDataset,
     ],
     CommonFields.VACCINATIONS_COMPLETED: [
         CDCVaccinesCountiesDataset,
         CANScraperStateProviders,
         CANScraperCountyProviders,
-        CDCVaccinesStatesDataset,
+        CDCVaccinesStatesAndNationDataset,
     ],
     CommonFields.VACCINATIONS_INITIATED_PCT: [CANScraperStateProviders, CANScraperCountyProviders],
     CommonFields.VACCINATIONS_COMPLETED_PCT: [CANScraperStateProviders, CANScraperCountyProviders],


### PR DESCRIPTION
This PR addresses https://trello.com/c/JQh3iWkJ/1344-add-cdc-us-country-level-data-without-being-overwritten-by-aggregation
### Tested

`./run.py data update` and `git difftool --no-prompt -t vimdiff main -- data/multiregion-wide-dates.csv` shows 4 time series changed, all country level vaccine data gained the CDC source tag.