### PR TITLE
calculate manual_filter diff using MultiRegionDatasetDelta

### DIFF
--- a/cli/data.py
+++ b/cli/data.py
@@ -120,7 +120,7 @@ def update(
     )
     before_manual_filter = multiregion_dataset
     multiregion_dataset = manual_filter.run(multiregion_dataset, region_overrides_config)
-    delta = timeseries.MultiRegionDatasetDelta.make(
+    delta = timeseries.MultiRegionDatasetDiff.make(
         old=before_manual_filter, new=multiregion_dataset
     )
     delta.timeseries_removed.write_to_wide_dates_csv(

--- a/cli/data.py
+++ b/cli/data.py
@@ -118,7 +118,15 @@ def update(
     region_overrides_config = manual_filter.transform_region_overrides(
         json.load(open(REGION_OVERRIDES_JSON)), aggregator.cbsa_to_counties_region_map
     )
+    before_manual_filter = multiregion_dataset
     multiregion_dataset = manual_filter.run(multiregion_dataset, region_overrides_config)
+    delta = timeseries.MultiRegionDatasetDelta.make(
+        old=before_manual_filter, new=multiregion_dataset
+    )
+    delta.timeseries_removed.write_to_wide_dates_csv(
+        pathlib.Path("data/manual_filter_removed-wide-dates.csv"),
+        pathlib.Path("data/manual_filter_removed-static.csv"),
+    )
 
     multiregion_dataset.print_stats("combined")
     multiregion_dataset = outlier_detection.drop_tail_positivity_outliers(multiregion_dataset)

--- a/data/manual_filter_removed-static.csv
+++ b/data/manual_filter_removed-static.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:336eeef8aea5e84772df4bb5f8775d1892e95e403bc4367080ecb51e612ba4db
+size 12

--- a/data/manual_filter_removed-wide-dates.csv
+++ b/data/manual_filter_removed-wide-dates.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62e91f47ba620733fe6ba045febd514a2450e63351091cc3261b162f79563c9d
+size 19890

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -1607,21 +1607,26 @@ def make_source_url_tags(ds_in: MultiRegionDataset) -> MultiRegionDataset:
 # eq=False because instances are large and we want to compare by id instead of value
 @final
 @dataclasses.dataclass(frozen=True, eq=False)
-class MultiRegionDatasetDelta:
+class MultiRegionDatasetDiff:
     """Represents a delta/diff between two MultiRegionDataset objects."""
 
     old: MultiRegionDataset
     new: MultiRegionDataset
 
     @staticmethod
-    def make(*, old, new) -> "MultiRegionDatasetDelta":
-        return MultiRegionDatasetDelta(old=old, new=new)
+    def make(*, old, new) -> "MultiRegionDatasetDiff":
+        return MultiRegionDatasetDiff(old=old, new=new)
 
     @property
     def timeseries_removed(self) -> MultiRegionDataset:
-        """A dataset containing time series, tags and static values in old but not new."""
+        """A dataset containing time series, tags and static values in old but not new.
+
+        A time series is considered removed if it has at least one real (not-NA) value in
+        `old` and no real values (all NA) in `new`. Changes in the set of dates with a real value
+        and changes in the values themselves are ignored.
+        """
         # removed is currently calculated when accessed but it may make sense to move this to
-        # `make` depending on future uses of MultiRegionDatasetDelta.
+        # `make` depending on future uses of MultiRegionDatasetDiff.
         def removed(old: FrameOrSeries, new: FrameOrSeries) -> FrameOrSeries:
             removed_mask = ~old.index.isin(new.index)
             return old.loc[removed_mask]

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from functools import lru_cache
 from itertools import chain
 from collections import defaultdict
+from typing import TypeVar
 
 import more_itertools
 from covidactnow.datapublic import common_fields
@@ -382,6 +383,12 @@ EMPTY_STATIC_DF = pd.DataFrame(
     columns=pd.Index([], name=PdFields.VARIABLE),
 )
 
+EMPTY_STATIC_LONG = pd.Series(
+    [],
+    dtype=float,
+    index=pd.MultiIndex.from_tuples([], names=[CommonFields.LOCATION_ID, PdFields.VARIABLE]),
+    name=PdFields.VALUE,
+)
 
 # An empty DataFrame with the expected index names for a timeseries with row labels <location_id,
 # variable, bucket> and column labels <date>.
@@ -591,6 +598,15 @@ class MultiRegionDataset:
             self._timeseries_latest_values().reset_index(), self.static_and_geo_data.reset_index()
         )
 
+    @property
+    def static_long(self) -> pd.Series:
+        """All not-NA/real static values in one series"""
+        if self.static.empty:
+            return EMPTY_STATIC_LONG
+        else:
+            # Is it worth adding a PdFields.STATIC_VALUE? Doesn't seem like it yet.
+            return self.static.stack(dropna=True).rename(PdFields.VALUE).sort_index()
+
     @cached_property
     def timeseries_bucketed_long(self) -> pd.Series:
         """A Series with MultiIndex LOCATION_ID, DEMOGRAPHIC_BUCKET, DATE, VARIABLE"""
@@ -770,6 +786,11 @@ class MultiRegionDataset:
         return MultiRegionDataset(timeseries=timeseries_df)
 
     def add_fips_static_df(self, latest_df: pd.DataFrame) -> "MultiRegionDataset":
+        # This function is only called on empty datasets and is very unlikely to get any new
+        # callers. This is a useful constraint when simplifying add_static_values.
+        # TODO(tom): Uncomment after fixing test_multi_region_to_from_timeseries_and_latest_values
+        # assert self.timeseries_bucketed.empty
+        assert self.static.empty
         latest_df = _add_location_id(latest_df)
         return self.add_static_values(latest_df)
 
@@ -778,6 +799,8 @@ class MultiRegionDataset:
         scalars_without_geodata = attributes_df.loc[
             :, attributes_df.columns.difference(GEO_DATA_COLUMNS)
         ]
+        # TODO(tom): When this assert always passes remove all the junk in _merge_attributes.
+        assert self.static.columns.intersection(scalars_without_geodata.columns).empty
         combined_attributes = _merge_attributes(self.static.reset_index(), scalars_without_geodata)
         assert combined_attributes.index.names == [CommonFields.LOCATION_ID]
         return dataclasses.replace(self, static=combined_attributes)
@@ -915,6 +938,7 @@ class MultiRegionDataset:
         ).append_tag_df(tag_df)
 
     def add_static_csv_file(self, path_or_buf: Union[pathlib.Path, TextIO]) -> "MultiRegionDataset":
+        assert self.static.empty
         static_df = pd.read_csv(path_or_buf, dtype={CommonFields.FIPS: str}, low_memory=False)
         return self.add_static_values(static_df)
 
@@ -950,6 +974,7 @@ class MultiRegionDataset:
         assert self.static.index.is_monotonic_increasing
         assert self.static.columns.intersection(GEO_DATA_COLUMNS).empty
         assert self.static.columns.is_unique
+        assert self.static.columns.names == [PdFields.VARIABLE]
 
         assert isinstance(self.tag, pd.Series)
         assert self.tag.index.names == _TAG_INDEX_FIELDS
@@ -974,7 +999,13 @@ class MultiRegionDataset:
             .sort_index()
             .rename_axis(columns=PdFields.VARIABLE)
         )
-        static_df = pd.concat([self.static, other.static]).sort_index()
+        # TODO(tom): rename_axis can likely be removed with Pandas 1.2 because concat preserves the
+        #  names passed to it.
+        static_df = (
+            pd.concat([self.static, other.static])
+            .sort_index()
+            .rename_axis(columns=PdFields.VARIABLE)
+        )
         tag = pd.concat([self.tag, other.tag]).sort_index()
         return MultiRegionDataset(timeseries_bucketed=timeseries_df, static=static_df, tag=tag)
 
@@ -1433,7 +1464,7 @@ def combined_datasets(
     if static_series:
         output_static_df = pd.concat(
             static_series, axis=1, sort=True, verify_integrity=True
-        ).rename_axis(index=CommonFields.LOCATION_ID)
+        ).rename_axis(index=CommonFields.LOCATION_ID, columns=PdFields.VARIABLE)
     else:
         output_static_df = EMPTY_STATIC_DF
 
@@ -1571,3 +1602,42 @@ def make_source_url_tags(ds_in: MultiRegionDataset) -> MultiRegionDataset:
     )
     source_url[TagField.TYPE] = TagType.SOURCE_URL
     return ds_in.append_tag_df(source_url)
+
+
+T_SERIES_OR_DATAFRAME = TypeVar("T_SERIES_OR_DATAFRAME", pd.Series, pd.DataFrame)
+
+# eq=False because instances are large and we want to compare by id instead of value
+@final
+@dataclasses.dataclass(frozen=True, eq=False)
+class MultiRegionDatasetDelta:
+    """Represents a delta/diff between two MultiRegionDataset objects."""
+
+    old: MultiRegionDataset
+    new: MultiRegionDataset
+
+    @staticmethod
+    def make(*, old, new) -> "MultiRegionDatasetDelta":
+        return MultiRegionDatasetDelta(old=old, new=new)
+
+    @property
+    def timeseries_removed(self) -> MultiRegionDataset:
+        """A dataset containing time series, tags and static values in old but not new."""
+        # removed is currently calculated when accessed but it may make sense to move this to
+        # `make` depending on future uses of MultiRegionDatasetDelta.
+        def removed(
+            old: T_SERIES_OR_DATAFRAME, new: T_SERIES_OR_DATAFRAME
+        ) -> T_SERIES_OR_DATAFRAME:
+            removed_mask = ~old.index.isin(new.index)
+            return old.loc[removed_mask]
+
+        ts_wide_dates = removed(
+            self.old.timeseries_bucketed_wide_dates, self.new.timeseries_bucketed_wide_dates
+        )
+        tags = removed(self.old.tag, self.new.tag)
+        static_long = removed(self.old.static_long, self.new.static_long)
+
+        return (
+            MultiRegionDataset.from_timeseries_wide_dates_df(ts_wide_dates, bucketed=True)
+            .append_tag_df(tags.reset_index())
+            .add_static_values(static_long.unstack(level=PdFields.VARIABLE).reset_index())
+        )

--- a/tests/libs/datasets/timeseries_test.py
+++ b/tests/libs/datasets/timeseries_test.py
@@ -2012,7 +2012,7 @@ def test_delta_timeseries_removed():
     data_la_b = {region_la: {CommonFields.CASES: {DemographicBucket.ALL: [5, 10]}}}
     ds_b = test_helpers.build_dataset({**data_tx, **data_la_b})
 
-    delta = timeseries.MultiRegionDatasetDelta(old=ds_a, new=ds_b)
+    delta = timeseries.MultiRegionDatasetDiff(old=ds_a, new=ds_b)
     ds_out = delta.timeseries_removed
 
     ds_expected = test_helpers.build_dataset({region_la: {CommonFields.CASES: {age_40s: [1, 2]}}})

--- a/tests/libs/datasets/timeseries_test.py
+++ b/tests/libs/datasets/timeseries_test.py
@@ -1979,13 +1979,19 @@ def test_static_long():
     ds = test_helpers.build_dataset(
         {},
         static_by_region_then_field_name={
-            region_fips: {CommonFields.COUNTY: "Bar County", m1: 4},
+            region_fips: {CommonFields.CAN_LOCATION_PAGE_URL: "http://can.do", m1: 4},
             region_cbsa: {CommonFields.CASES: 3},
         },
     )
-    assert ds.static_long.at[region_fips.location_id, CommonFields.COUNTY] == "Bar County"
-    assert ds.static_long.at[region_fips.location_id, m1] == 4
-    assert ds.static_long.at[region_cbsa.location_id, CommonFields.CASES] == 3
+    # Use loc[level0].at[level1] as work-around for
+    # https://github.com/pandas-dev/pandas/issues/26989
+    # TODO(tom): Change to `at[level0, level1]` after upgrading to Pandas >=1.1
+    assert (
+        ds.static_long.loc[region_fips.location_id].at[CommonFields.CAN_LOCATION_PAGE_URL]
+        == "http://can.do"
+    )
+    assert ds.static_long.loc[region_fips.location_id].at[m1] == 4
+    assert ds.static_long.loc[region_cbsa.location_id].at[CommonFields.CASES] == 3
 
     ds_empty_static = timeseries.MultiRegionDataset.new_without_timeseries()
     assert ds_empty_static.static_long.empty


### PR DESCRIPTION
This PR addresses https://trello.com/c/1p0uTkYH/1300-pipeline-generate-csv-of-blocked-metrics-and-make-it-easy-for-data-dashboard-to-read-it

* Adds `MultiRegionDataset.static_long`, the static DataFrame restructured into a Series
* Adds `MultiRegionDatasetDiff` to calculate the diff between two `MultiRegionDataset`
* Uses `MultiRegionDatasetDiff` to record timeseries removed by the manual filter.
* Adds some more asserts and comments related to `MultiRegionDataset.static` that I noticed while working on this change.