### PR TITLE
drop instead of raise bad fips

### DIFF
--- a/tests/libs/datasets/timeseries_test.py
+++ b/tests/libs/datasets/timeseries_test.py
@@ -276,11 +276,14 @@ def test_add_aggregate_level():
 
 
 def test_fips_not_in_geo_data_csv_raises():
-    with pytest.raises(KeyError):
-        ts_df = read_csv_and_index_fips_date(
-            "fips,date,m1,m2\n" "98789,2020-04-02,2,\n"
-        ).reset_index()
-        timeseries.MultiRegionDataset.from_fips_timeseries_df(ts_df)
+    df = test_helpers.read_csv_str(
+        "       location_id,       date,       cases\n"
+        "iso1:us#fips:06010, 2020-04-01,         100\n",
+        skip_spaces=True,
+    )
+
+    with pytest.raises(AssertionError):
+        timeseries.MultiRegionDataset.from_timeseries_df(df)
 
 
 def test_append_regions():


### PR DESCRIPTION
This PR addresses https://trello.com/c/2hfcOmg2/1358-fix-cms-testing-import-and-prevent-future-bad-fips-breaking-data-update

### Tested

With covid-data-public checked out without Michael's fix (for example at 41f54e8) and without this change `./run.py data update` crashes.

```
2021-05-17T22:23:45.414578Z Exception reached __main__     [root] exc_info=(<class 'ValueError'>, ValueError("Problem with <class 'libs.datasets.sources.cms_testing_dataset.CMSTestingDataset'>"), <traceback object at 0x7f73015e3c30>)
Traceback (most recent call last):
  File "/home/thecap/projects/covid-data-model/cli/data.py", line 355, in _load_dataset
    dataset = data_source_cls.make_dataset()
  File "/home/thecap/projects/covid-data-model/libs/datasets/data_source.py", line 119, in make_dataset
    return MultiRegionDataset.from_fips_timeseries_df(data).add_tag_all_bucket(cls.source_tag())
  File "/home/thecap/projects/covid-data-model/libs/datasets/timeseries.py", line 955, in from_fips_timeseries_df
    ts_df = _add_location_id(ts_df)
  File "/home/thecap/projects/covid-data-model/libs/datasets/timeseries.py", line 248, in _add_location_id
    f"No location_id found for "
KeyError: 'No location_id found for 60030    1\n60050    1\n72888    1\n60010    1\n60040    1\n60020    1\nName: fips, dtype: int64'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./run.py", line 36, in <module>
    entry_point()  # pylint: disable=no-value-for-parameter
  File "/home/thecap/.pyenv/versions/covid-data-model/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
...
```

With this change the same setup does not crash. It logs:

```
2021-05-17T22:26:43.474848Z [warning  ] No location_id found for FIPS  fips=60050    1
60040    1
60020    1
60010    1
72888    1
60030    1
Name: fips, dtype: int64 sentry=skipped
```