### PR TITLE
change Make unittest to -n 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,10 @@ setup-dev: requirements.txt requirements_test.txt
 	pip install --upgrade -r requirements.txt -r requirements_test.txt
 	pre-commit install
 
+# As a work-around for a test failure in tests/libs/datasets/data_source_test.py::test_state_providers_smoke_test
+# run tests on a single process. The failure seems to happen on the server (which runs unittest) but not locally.
 unittest:
-	pytest -n 2 tests/
+	pytest -n 1 tests/
 
 unittest-not-slow:
 	pytest -k 'not slow' -n 2 --durations=5 tests/


### PR DESCRIPTION
This PR addresses https://trello.com/c/z2ZSJIoP/1363-fix-covid-data-model-tests-failing-on-server-only with a quick hack fix. https://trello.com/c/hCeBoMlZ/1369-get-tests-running-in-parallel-on-the-big-server is a card to debug and revert this.
