### PR TITLE
add drop_observations after today UTC

### DIFF
--- a/cli/data.py
+++ b/cli/data.py
@@ -1,4 +1,5 @@
 import dataclasses
+import datetime
 from typing import List
 from typing import Mapping
 from typing import Optional
@@ -111,6 +112,7 @@ def update(
         timeseries_field_datasets, static_field_datasets
     )
     _logger.info("Finished combining datasets")
+    multiregion_dataset.print_stats("combined")
 
     # Apply manual overrides (currently only removing timeseries) before aggregation so we don't
     # need to remove CBSAs because they don't exist yet.
@@ -127,8 +129,12 @@ def update(
         dataset_utils.MANUAL_FILTER_REMOVED_WIDE_DATES_CSV_PATH,
         dataset_utils.MANUAL_FILTER_REMOVED_STATIC_CSV_PATH,
     )
+    multiregion_dataset.print_stats("manual filter")
 
-    multiregion_dataset.print_stats("combined")
+    multiregion_dataset = timeseries.drop_observations(
+        multiregion_dataset, after=datetime.datetime.utcnow().date()
+    )
+
     multiregion_dataset = outlier_detection.drop_tail_positivity_outliers(multiregion_dataset)
     multiregion_dataset.print_stats("drop_tail")
     # Filter for stalled cumulative values before deriving NEW_CASES from CASES.

--- a/libs/datasets/taglib.py
+++ b/libs/datasets/taglib.py
@@ -59,6 +59,7 @@ class TagType(GetByValueMixin, ValueAsStrMixin, str, enum.Enum):
     KNOWN_ISSUE = "known_issue"
     KNOWN_ISSUE_NO_DATE = "known_issue_no_date"
     DERIVED = "derived"
+    DROP_FUTURE_OBSERVATION = "drop_future_observation"
 
     PROVENANCE = PdFields.PROVENANCE
     SOURCE_URL = "source_url"
@@ -328,6 +329,22 @@ class Derived(TagInTimeseries):
         return json.dumps(d, separators=(",", ":"))
 
 
+@dataclass(frozen=True)
+class DropFutureObservation(TagInTimeseries):
+    TAG_TYPE = TagType.DROP_FUTURE_OBSERVATION
+    after: datetime.date
+
+    @classmethod
+    def make_instance(cls, *, content: str) -> "TagInTimeseries":
+        content_parsed = json.loads(content)
+        return cls(after=datetime.date.fromisoformat(content_parsed["after"]),)
+
+    @property
+    def content(self) -> str:
+        d = {"after": self.after.isoformat()}
+        return json.dumps(d, separators=(",", ":"))
+
+
 TAG_TYPE_TO_CLASS = {
     TagType.CUMULATIVE_TAIL_TRUNCATED: CumulativeTailTruncated,
     TagType.CUMULATIVE_LONG_TAIL_TRUNCATED: CumulativeLongTailTruncated,
@@ -338,6 +355,7 @@ TAG_TYPE_TO_CLASS = {
     TagType.KNOWN_ISSUE: KnownIssue,
     TagType.KNOWN_ISSUE_NO_DATE: KnownIssueNoDate,
     TagType.DERIVED: Derived,
+    TagType.DROP_FUTURE_OBSERVATION: DropFutureObservation,
 }
 
 

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -1388,6 +1388,20 @@ def drop_regions_without_population(
     return dataset.get_locations_subset(location_id_with_population)
 
 
+def drop_observations(
+    dataset_in: MultiRegionDataset, *, after: datetime.date
+) -> MultiRegionDataset:
+    wide_dates_df = dataset_in.timeseries_bucketed_wide_dates
+    after_columns_mask = wide_dates_df.columns > pd.to_datetime(after)
+    after_notna_index_mask = wide_dates_df.loc[:, after_columns_mask].notna().any(axis="columns")
+    after_notna_index = wide_dates_df.loc[after_notna_index_mask, :].index
+    wide_dates_not_after_df = wide_dates_df.loc[:, ~after_columns_mask]
+    tag = taglib.DropFutureObservation(after=after)
+    return dataset_in.replace_timeseries_wide_dates([wide_dates_not_after_df]).add_tag_to_subset(
+        tag, after_notna_index
+    )
+
+
 class DatasetName(str):
     """Human readable name for a dataset. In the future this may be an enum, for now it
     provides some type safety."""

--- a/tests/libs/datasets/timeseries_test.py
+++ b/tests/libs/datasets/timeseries_test.py
@@ -2018,3 +2018,33 @@ def test_delta_timeseries_removed():
     ds_expected = test_helpers.build_dataset({region_la: {CommonFields.CASES: {age_40s: [1, 2]}}})
 
     test_helpers.assert_dataset_like(ds_out, ds_expected)
+
+
+def test_drop_observations_after():
+    age_40s = DemographicBucket("age:40-49")
+    ds_in = test_helpers.build_default_region_dataset(
+        {
+            CommonFields.CASES: {DemographicBucket.ALL: [5, 10], age_40s: [1, 2, 3]},
+            # Check that observation is dropped even when not a True value (ie 0).
+            CommonFields.DEATHS: [0, 0, 0],
+            # Check what happens when there are no real valued observations after dropping,
+            # though the behaviour probably doesn't matter.
+            CommonFields.ICU_BEDS: [None, None, 10],
+        }
+    )
+
+    ds_out = timeseries.drop_observations(ds_in, after=datetime.date(2020, 4, 2))
+
+    tag = test_helpers.make_tag(taglib.TagType.DROP_FUTURE_OBSERVATION, after="2020-04-02")
+    ds_expected = test_helpers.build_default_region_dataset(
+        {
+            CommonFields.CASES: {
+                DemographicBucket.ALL: [5, 10],
+                age_40s: TimeseriesLiteral([1, 2], annotation=[tag]),
+            },
+            CommonFields.DEATHS: TimeseriesLiteral([0, 0], annotation=[tag]),
+            CommonFields.ICU_BEDS: TimeseriesLiteral([], annotation=[tag]),
+        }
+    )
+
+    test_helpers.assert_dataset_like(ds_out, ds_expected)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -104,6 +104,9 @@ def make_tag(
         kwargs["date"] = pd.to_datetime(kwargs.get("date", "2020-04-02"))
     elif tag_type is taglib.TagType.KNOWN_ISSUE:
         kwargs["date"] = pd.to_datetime(kwargs.get("date", "2020-04-02")).date()
+    elif tag_type is taglib.TagType.DROP_FUTURE_OBSERVATION:
+        # make_tag does not have a default `after`; force tests to provide it explicitly.
+        kwargs["after"] = pd.to_datetime(kwargs["after"]).date()
 
     return taglib.TAG_TYPE_TO_CLASS[tag_type](**kwargs)
 


### PR DESCRIPTION
This PR addresses https://trello.com/c/UKqdcj0z/1345-pipeline-block-data-for-future-dates

* Adds function `timeseries.drop_observations(..., after=)` and tag `drop_future_observation` to record where it did something
* Use this function to drop data that is more recent than today, UTC
* Clean up print_stats calls so "combined" is right after the combined data is produced and adding "manual filter" stats

### Tested

Running `./run.py data update` with covid-data-public manually tweaked to have a date in the future.
