### PR TITLE
fix TODO disclaimer -> public_note in taglib

### DIFF
--- a/libs/datasets/manual_filter.py
+++ b/libs/datasets/manual_filter.py
@@ -43,7 +43,7 @@ class Filter(pydantic.BaseModel):
     @property
     def tag(self) -> taglib.TagInTimeseries:
         if self.start_date:
-            return taglib.KnownIssue(date=self.start_date, disclaimer=self.public_note)
+            return taglib.KnownIssue(date=self.start_date, public_note=self.public_note)
         else:
             return taglib.KnownIssueNoDate(public_note=self.public_note)
 

--- a/libs/datasets/taglib.py
+++ b/libs/datasets/taglib.py
@@ -278,7 +278,7 @@ class ZScoreOutlier(AnnotationWithDate):
 
 @dataclass(frozen=True)
 class KnownIssue(TagInTimeseries):
-    disclaimer: str  # TODO(tom): Rename to public_note, to be consistent with KnownIssueNoDate
+    public_note: str
     date: datetime.date
 
     TAG_TYPE = TagType.KNOWN_ISSUE
@@ -286,14 +286,15 @@ class KnownIssue(TagInTimeseries):
     @classmethod
     def make_instance(cls, *, content: str) -> "TagInTimeseries":
         content_parsed = json.loads(content)
+        # Support loading old "disclaimer" and new "public_note".
+        public_note = content_parsed.get("disclaimer", content_parsed.get("public_note", ""))
         return cls(
-            disclaimer=content_parsed["disclaimer"],
-            date=datetime.date.fromisoformat(content_parsed["date"]),
+            public_note=public_note, date=datetime.date.fromisoformat(content_parsed["date"]),
         )
 
     @property
     def content(self) -> str:
-        d = {"disclaimer": self.disclaimer, "date": self.date.isoformat()}
+        d = {"public_note": self.public_note, "date": self.date.isoformat()}
         return json.dumps(d, separators=(",", ":"))
 
 

--- a/tests/libs/datasets/manual_filter_test.py
+++ b/tests/libs/datasets/manual_filter_test.py
@@ -84,7 +84,7 @@ def test_manual_filter():
     tag_expected = test_helpers.make_tag(
         taglib.TagType.KNOWN_ISSUE,
         date="2021-02-12",
-        disclaimer=TEST_CONFIG.filters[0].public_note,
+        public_note=TEST_CONFIG.filters[0].public_note,
     )
     ds_expected = test_helpers.build_dataset(
         {
@@ -110,7 +110,7 @@ def test_manual_filter_region_excluded():
     tag_expected = test_helpers.make_tag(
         taglib.TagType.KNOWN_ISSUE,
         date="2021-03-15",
-        disclaimer=TEST_CONFIG.filters[1].public_note,
+        public_note=TEST_CONFIG.filters[1].public_note,
     )
     ds_expected = test_helpers.build_dataset(
         {
@@ -139,7 +139,7 @@ def test_manual_filter_field_groups():
     tag_expected = test_helpers.make_tag(
         taglib.TagType.KNOWN_ISSUE,
         date="2021-03-15",
-        disclaimer=TEST_CONFIG.filters[1].public_note,
+        public_note=TEST_CONFIG.filters[1].public_note,
     )
     ds_expected = test_helpers.build_default_region_dataset(
         {CommonFields.DEATHS: TimeseriesLiteral([1], annotation=[tag_expected]), **other_data},
@@ -178,7 +178,7 @@ def test_manual_filter_per_bucket_tag():
     tag_expected = test_helpers.make_tag(
         taglib.TagType.KNOWN_ISSUE,
         date="2021-03-15",
-        disclaimer=TEST_CONFIG.filters[1].public_note,
+        public_note=TEST_CONFIG.filters[1].public_note,
     )
     ds_expected = test_helpers.build_default_region_dataset(
         {
@@ -361,10 +361,10 @@ def test_touched_subset():
     # Add 2 known issue tags for the same time series and check that touched_subset still produces
     # the expected output.
     known_issue_1 = test_helpers.make_tag(
-        taglib.TagType.KNOWN_ISSUE, disclaimer="foo", date="2021-04-01"
+        taglib.TagType.KNOWN_ISSUE, public_note="foo", date="2021-04-01"
     )
     known_issue_2 = test_helpers.make_tag(
-        taglib.TagType.KNOWN_ISSUE, disclaimer="foo", date="2021-04-02"
+        taglib.TagType.KNOWN_ISSUE, public_note="foo", date="2021-04-02"
     )
     ds_out = test_helpers.build_default_region_dataset(
         {
@@ -398,7 +398,7 @@ def test_touched_subset_only_observation_drops():
         }
     )
     known_issue = test_helpers.make_tag(
-        taglib.TagType.KNOWN_ISSUE, disclaimer="foo", date="2021-04-01"
+        taglib.TagType.KNOWN_ISSUE, public_note="foo", date="2021-04-01"
     )
     # ds_out is a mock of what is returned by `manual_filter.run`.
     ds_out = test_helpers.build_default_region_dataset(

--- a/tests/libs/datasets/taglib_test.py
+++ b/tests/libs/datasets/taglib_test.py
@@ -29,3 +29,19 @@ def test_tag_type_to_class():
 def test_enum_names_match_values():
     test_helpers.assert_enum_names_match_values(taglib.TagType)
     test_helpers.assert_enum_names_match_values(taglib.TagField, exceptions={taglib.TagField.TYPE})
+
+
+def test_load_known_issue_json():
+    parsed_old = taglib.KnownIssue.make_instance(content='{"disclaimer":"a","date":"2021-05-14"}')
+    expected = test_helpers.make_tag(taglib.TagType.KNOWN_ISSUE, public_note="a", date="2021-05-14")
+    assert parsed_old == expected
+    parsed_new = taglib.KnownIssue.make_instance(content='{"public_note":"a","date":"2021-05-14"}')
+    assert parsed_new == expected
+
+
+def test_load_known_issue_json_empty_disclaimer():
+    parsed_old = taglib.KnownIssue.make_instance(content='{"disclaimer":"","date":"2021-05-14"}')
+    expected = test_helpers.make_tag(taglib.TagType.KNOWN_ISSUE, public_note="", date="2021-05-14")
+    assert parsed_old == expected
+    parsed_new = taglib.KnownIssue.make_instance(content='{"public_note":"","date":"2021-05-14"}')
+    assert parsed_new == expected


### PR DESCRIPTION
This PR addresses a TODO I notice while working on https://trello.com/c/weIWXUgV/1353-add-enddate-to-backend-metric-blocking