### PR TITLE
remove check_less_precise, deprecated in pandas 1.1

### DIFF
--- a/tests/libs/metrics/test_positivity_test.py
+++ b/tests/libs/metrics/test_positivity_test.py
@@ -377,7 +377,7 @@ def test_recent_pos_neg_tests_has_positivity_ratio(pos_neg_tests_recent):
         # positive_tests and negative_tests are used
         expected_metrics = {
             CommonFields.TEST_POSITIVITY: TimeseriesLiteral(
-                [None, 0.0909, None, None, None, None], provenance="pos"
+                [None, 2 / (2 + 20), None, None, None, None], provenance="pos"
             )
         }
         expected = test_helpers.build_default_region_dataset(
@@ -401,4 +401,4 @@ def test_recent_pos_neg_tests_has_positivity_ratio(pos_neg_tests_recent):
         all_methods = AllMethods.run(dataset_in)
 
     # check_less_precise so only 3 digits need match for testPositivityRatio
-    test_helpers.assert_dataset_like(all_methods.test_positivity, expected, check_less_precise=True)
+    test_helpers.assert_dataset_like(all_methods.test_positivity, expected)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -308,7 +308,6 @@ def assert_dataset_like(
     drop_na_timeseries=False,
     drop_na_latest=False,
     drop_na_dates=False,
-    check_less_precise=False,
     compare_tags=True,
 ):
     """Asserts that two datasets contain similar date, ignoring order."""
@@ -318,21 +317,15 @@ def assert_dataset_like(
     ts2 = _timeseries_sorted_by_location_date(
         ds2, drop_na=drop_na_timeseries, drop_na_dates=drop_na_dates
     )
-    pd.testing.assert_frame_equal(
-        ts1, ts2, check_like=True, check_dtype=False, check_less_precise=check_less_precise
-    )
+    pd.testing.assert_frame_equal(ts1, ts2, check_like=True, check_dtype=False)
     latest1 = _latest_sorted_by_location_date(ds1, drop_na_latest)
     latest2 = _latest_sorted_by_location_date(ds2, drop_na_latest)
-    pd.testing.assert_frame_equal(
-        latest1, latest2, check_like=True, check_dtype=False, check_less_precise=check_less_precise
-    )
+    pd.testing.assert_frame_equal(latest1, latest2, check_like=True, check_dtype=False)
     # Somehow tests/libs/datasets/combined_dataset_utils_test.py::test_update_and_load has
     # two provenance Series that are empty but assert_series_equal fails with message
     # 'Attribute "inferred_type" are different'. Don't call it when both series are empty.
     if not (ds1.provenance.empty and ds2.provenance.empty):
-        pd.testing.assert_series_equal(
-            ds1.provenance, ds2.provenance, check_less_precise=check_less_precise
-        )
+        pd.testing.assert_series_equal(ds1.provenance, ds2.provenance)
 
     if compare_tags:
         tag1 = ds1.tag.astype("string")
@@ -391,7 +384,7 @@ def read_csv_str(
         else:
             dtype = {}
 
-    return pd.read_csv(io.StringIO(csv), parse_dates=parse_dates, dtype=dtype, low_memory=True)
+    return pd.read_csv(io.StringIO(csv), parse_dates=parse_dates, dtype=dtype)
 
 
 @functools.lru_cache(None)


### PR DESCRIPTION
I ran into deprecated check_less_precise when upgrading to pandas 1.2. This removes use of it, which works in our current pandas 1.0 and 1.2. Also removes one use of low_memory which also caused a problem in 1.2.