### PR TITLE
fix for FutureWarning: Index.is_all_dates is deprecated

### DIFF
--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -483,7 +483,7 @@ def check_timeseries_wide_dates_structure(timeseries_wide_dates: pd.DataFrame, *
     assert timeseries_wide_dates.columns.is_unique
     # The following fails unexpectedly. See TODO in __post_init__.
     # assert timeseries_wide_dates.columns.is_monotonic_increasing
-    assert timeseries_wide_dates.columns.is_all_dates
+    assert isinstance(timeseries_wide_dates.columns, pd.DatetimeIndex)
 
 
 def _tag_add_all_bucket(tag: pd.Series) -> pd.Series:
@@ -707,7 +707,7 @@ class MultiRegionDataset:
                 [CommonFields.LOCATION_ID, PdFields.VARIABLE, PdFields.DEMOGRAPHIC_BUCKET]
             )
         )
-        if not timeseries_wide.columns.is_all_dates:
+        if not isinstance(timeseries_wide.columns, pd.DatetimeIndex):
             raise ValueError(f"Problem with {start_date} to {end_date}... {str(self.timeseries)}")
         return timeseries_wide
 


### PR DESCRIPTION
This PR is part of https://trello.com/c/e0PtnB7y/489-tech-debt-upgrade-to-python-39

I'm replacing is_all_dates with explicit check for DatetimeIndex because that's what we want in the DataFrame so it seems cleaner than checking the string index.inferred_type.

Changes in vaccine_backfills.py are to preserve the DatetimeIndex that was removed when adding a column temporarily.