### PR TITLE
Fix for ValueError: zero-size array

### DIFF
--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -55,6 +55,7 @@ from libs.datasets.taglib import UrlStr
 from libs.datasets.demographics import DistributionBucket
 from libs.pipeline import Region
 import pandas.core.groupby.generic
+from backports.cached_property import cached_property
 
 from libs.pipeline import RegionMaskOrRegion
 

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -1,5 +1,4 @@
 import textwrap
-from functools import cached_property
 from typing import (
     Any,
     Collection,
@@ -55,7 +54,11 @@ from libs.datasets.taglib import UrlStr
 from libs.datasets.demographics import DistributionBucket
 from libs.pipeline import Region
 import pandas.core.groupby.generic
-from backports.cached_property import cached_property
+
+try:  # To work with python 3.7 and 3.9 without changes.
+    from functools import cached_property
+except ImportError:
+    from backports.cached_property import cached_property
 
 from libs.pipeline import RegionMaskOrRegion
 
@@ -1422,7 +1425,10 @@ class MultiRegionDataset:
         ):
             latest_dict = self._location_id_latest_dict(location_id)
             region = Region.from_location_id(location_id)
-            tag = self.tag.loc[[region.location_id]].reset_index(TagField.LOCATION_ID, drop=True)
+            try:
+                tag = self.tag.xs(region.location_id, level=TagField.LOCATION_ID, drop_level=True)
+            except KeyError:
+                tag = _EMPTY_ONE_REGION_TAG_SERIES
             bucketed_latest = self._bucketed_latest_for_location_id(location_id)
 
             yield region, OneRegionTimeseriesDataset(

--- a/libs/datasets/timeseries.py
+++ b/libs/datasets/timeseries.py
@@ -1,4 +1,5 @@
 import textwrap
+from functools import cached_property
 from typing import (
     Any,
     Collection,
@@ -54,7 +55,6 @@ from libs.datasets.taglib import UrlStr
 from libs.datasets.demographics import DistributionBucket
 from libs.pipeline import Region
 import pandas.core.groupby.generic
-from backports.cached_property import cached_property
 
 from libs.pipeline import RegionMaskOrRegion
 
@@ -203,6 +203,7 @@ class OneRegionTimeseriesDataset:
         if CommonFields.DATE not in self.data.columns:
             raise ValueError("A timeseries must have a date column")
 
+        assert isinstance(self.tag, pd.Series)
         assert self.tag.index.names == [
             TagField.VARIABLE,
             TagField.DEMOGRAPHIC_BUCKET,
@@ -1097,7 +1098,10 @@ class MultiRegionDataset:
         if ts_df.empty and not latest_dict:
             raise RegionLatestNotFound(region)
 
-        tag = self.tag.loc[[region.location_id]].reset_index(TagField.LOCATION_ID, drop=True)
+        try:
+            tag = self.tag.xs(region.location_id, level=CommonFields.LOCATION_ID, drop_level=True)
+        except KeyError:
+            tag = _EMPTY_ONE_REGION_TAG_SERIES
 
         return OneRegionTimeseriesDataset(
             region=region, data=ts_df, latest=latest_dict, tag=tag, bucketed_latest=bucketed_latest

--- a/tests/dataset_utils_test.py
+++ b/tests/dataset_utils_test.py
@@ -65,10 +65,7 @@ def read_csv_and_index_fips(csv_str: str) -> pd.DataFrame:
 def read_csv_and_index_fips_date(csv_str: str) -> pd.DataFrame:
     """Read a CSV in a str to a DataFrame and set the FIPS and DATE columns as MultiIndex."""
     return pd.read_csv(
-        StringIO(csv_str),
-        parse_dates=[CommonFields.DATE],
-        dtype={CommonFields.FIPS: str},
-        low_memory=False,
+        StringIO(csv_str), parse_dates=[CommonFields.DATE], dtype={CommonFields.FIPS: str},
     ).set_index(COMMON_FIELDS_TIMESERIES_KEYS)
 
 

--- a/tests/dataset_utils_test.py
+++ b/tests/dataset_utils_test.py
@@ -65,7 +65,10 @@ def read_csv_and_index_fips(csv_str: str) -> pd.DataFrame:
 def read_csv_and_index_fips_date(csv_str: str) -> pd.DataFrame:
     """Read a CSV in a str to a DataFrame and set the FIPS and DATE columns as MultiIndex."""
     return pd.read_csv(
-        StringIO(csv_str), parse_dates=[CommonFields.DATE], dtype={CommonFields.FIPS: str},
+        StringIO(csv_str),
+        parse_dates=[CommonFields.DATE],
+        dtype={CommonFields.FIPS: str},
+        low_memory=False,
     ).set_index(COMMON_FIELDS_TIMESERIES_KEYS)
 
 


### PR DESCRIPTION
This PR is part of https://trello.com/c/e0PtnB7y/489-tech-debt-upgrade-to-python-39

* fix for 'ValueError: zero-size array to reduction operation maximum which has no identity' when .loc[[key]] isn't found. This didn't raise in pandas 1.0, does in 1.2
* fix cached_property to work with 3.7 or 3.9.