### PR TITLE
Improve Small N Infection Rate Performance

### DIFF
--- a/pyseir/rt/infer_rt.py
+++ b/pyseir/rt/infer_rt.py
@@ -412,7 +412,7 @@ class RtInferenceEngine:
         process_matrix /= process_matrix.sum(axis=0)
 
         # (4) Calculate the initial prior. Gamma mean of "a" with mode of "a-1".
-        prior0 = sps.gamma(a=2.5).pdf(self.r_list)
+        prior0 = sps.gamma(a=2).pdf(self.r_list)
         prior0 /= prior0.sum()
 
         reinit_prior = sps.gamma(a=2).pdf(self.r_list)
@@ -467,6 +467,10 @@ class RtInferenceEngine:
                 # deaths that dip down to zero, but then start to increase
                 # again.
 
+                posteriors[current_day] = reinit_prior
+            elif timeseries[current_day] == 0:
+                # If the smoothed values for Daily New Cases is 0, then reset the prior to the initial
+                # In this branch reinit_prior is equal to the initial prior
                 posteriors[current_day] = reinit_prior
             else:
                 posteriors[current_day] = numerator / denominator

--- a/pyseir/rt/infer_rt.py
+++ b/pyseir/rt/infer_rt.py
@@ -468,9 +468,12 @@ class RtInferenceEngine:
                 # again.
 
                 posteriors[current_day] = reinit_prior
-            elif timeseries[current_day] == 0:
-                # If the smoothed values for Daily New Cases is 0, then reset the prior to the initial
+            elif timeseries[current_day] <= 0.4:
+                # If the smoothed values for Daily New Cases is less than or equal to 0.4, then reset the prior to the initial
                 # In this branch reinit_prior is equal to the initial prior
+                # This magic number was decided in consultation between Brett and Chris on 26 May 2021
+                # We looked at the impulse response function for the current input smoothing window
+                # 6 cases separated by 2 days each has a peak value of 0.41.
                 posteriors[current_day] = reinit_prior
             else:
                 posteriors[current_day] = numerator / denominator


### PR DESCRIPTION
This PR addresses issue https://trello.com/c/JzkA9Q51/1366-can-auto-pilot-what-to-do-with-infection-rate.

The current implementation of our Infection Rate is sensitive to places with consistent low case numbers. In some cases, this will cause a systematic error that makes the metric appear to be very high and growing. Right now this error is only seen in locations that are small enough to have on the order of 1s of cases over the last couple weeks.

We our updating our model to be more clear about our uncertainty at very low cases numbers.

We decided to choose a threshold number of smoothed daily cases. Below that threshold, we say "this is too low to confidently have informed priors about the future infection rate" with the consequence that we will use the default priors to restart the model going forward. That default is standardized to a gamma with a=2 which has a mode/prediction of 1. So for as long as the smoothed daily cases remains below that threshold, we will maintain the default "the infection rate can be loosely defined as being unity in this edge case while we wait for more data". Right now we will continue to show that series of 1s, but in the future we might just mask them.

Chris and Brett hand-tuned the threshold cutoff to be 0.4 units in the Infection Rate smoothing reference frame. Due to historical+product reasons, the smoothing window for the case input data is more aggressive than the Daily New Cases smoothing window. In that reference frame, 6 new cases spread evenly over 10 days results in a peak value of 0.41. Looking at that scenario and others, we decided that 0.4 was good enough. This threshold should be revisited if the smoothing kernel for the input data changes.

Our internal discussions and investigations were tracked [in this document](https://www.dropbox.com/scl/fi/aarxa3lie1c4rsb1wdcc6/CAN-Sunset-Infection-Rate.paper?dl=0&rlkey=pr9fxt1sei89flqsp97k19m7i).

