### PR TITLE
Convert label_api_snapshot.yml to workflow_dispatch.

### DIFF
--- a/.github/workflows/label_api_snapshot.yml
+++ b/.github/workflows/label_api_snapshot.yml
@@ -7,10 +7,11 @@
 name: Label API Snapshot.
 
 on:
-  # Hook to trigger a manual run.
-  # See: https://goobar.io/2019/12/07/manually-trigger-a-github-actions-workflow/
-  repository_dispatch:
-    types: label-api-snapshot
+  workflow_dispatch:
+    inputs:
+      snapshot_id:
+        description: 'The snapshot ID (e.g. 1234) to be labeled as "latest" and used by the API.'
+        required: true
 
 jobs:
   label-api-snapshot:
@@ -18,18 +19,15 @@ jobs:
 
     env:
       AWS_S3_BUCKET: 'data.covidactnow.org'
-      LABEL: '${{ github.event.client_payload.label }}'
-      SNAPSHOT_ID: '${{ github.event.client_payload.snapshot_id }}'
+      LABEL: 'latest'
+      SNAPSHOT_ID: '${{ github.event.inputs.snapshot_id }}'
 
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2
-    - name: Verify Label provided
-      if: ${{ !env.LABEL }}
-      run: 'echo "Missing client_payload parameter: label" ; exit 1'
     - name: Verify Snapshot ID provided
       if: ${{ !env.SNAPSHOT_ID }}
-      run: 'echo "Missing client_payload parameter: snapshot_id" ; exit 1'
+      run: 'echo "Missing input parameter: snapshot_id" ; exit 1'
 
     # TODO: We want to replace this with a "symlink" of some kind, perhaps implemented at
     # the CloudFront layer.

--- a/tools/label-api.sh
+++ b/tools/label-api.sh
@@ -13,7 +13,6 @@ prepare () {
     exit_with_usage
   else
     SNAPSHOT_ID=$1
-    LABEL="latest"
   fi
 
   if ! [[ $SNAPSHOT_ID =~ ^[0-9]+$ ]] ; then
@@ -40,8 +39,8 @@ exit_with_usage () {
 execute () {
   curl -H "Authorization: token $GITHUB_TOKEN" \
       --request POST \
-      --data "{\"event_type\": \"label-api-snapshot\", \"client_payload\": { \"label\": \"${LABEL}\", \"snapshot_id\": \"${SNAPSHOT_ID}\" } }" \
-      https://api.github.com/repos/covid-projections/covid-data-model/dispatches
+      --data "{\"inputs\": { \"snapshot_id\": \"${SNAPSHOT_ID}\" } }" \
+      https://api.github.com/repos/covid-projections/covid-data-model/actions/workflows/label_api_snapshot.yml/dispatches
 
   echo "Label requested. Go to https://github.com/covid-projections/covid-data-model/actions to monitor progress."
 }


### PR DESCRIPTION
This way if we ever need to revert an API snapshot, we can do it via the github UI...

Also hardcoded the label to "latest" since we don't need that flexibility.