### PR TITLE
Round metric values.

### DIFF
--- a/libs/metrics/top_level_metrics.py
+++ b/libs/metrics/top_level_metrics.py
@@ -48,6 +48,25 @@ class MetricsFields(common_fields.ValueAsStrMixin, str, enum.Enum):
     VACCINATIONS_COMPLETED_RATIO = "vaccinationsCompletedRatio"
 
 
+# These precisions should be inline with
+# https://github.com/covid-projections/covid-projections/blob/c076f39f54dcf6ca3f20fbb67839c37bb8b0f5bf/src/common/metric.tsx#L90
+# but note that percentages (ICU_*, TEST_POSITIVITY, VACCINATIONS_*) need an
+# additional 2 digits of precisions since they will be converted from ratio
+# (0.xyz) to percentage (XY.Z%).
+
+METRIC_ROUNDING_PRECISION = {
+    MetricsFields.CASE_DENSITY_RATIO: 1,
+    MetricsFields.TEST_POSITIVITY: 3,
+    MetricsFields.CONTACT_TRACER_CAPACITY_RATIO: 2,
+    MetricsFields.INFECTION_RATE: 2,
+    MetricsFields.INFECTION_RATE_CI90: 2,
+    MetricsFields.ICU_HEADROOM_RATIO: 2,
+    MetricsFields.ICU_CAPACITY_RATIO: 2,
+    MetricsFields.VACCINATIONS_INITIATED_RATIO: 3,
+    MetricsFields.VACCINATIONS_COMPLETED_RATIO: 3,
+}
+
+
 def has_data_in_past_10_days(series: pd.Series) -> bool:
     return series_utils.has_recent_data(series, days_back=10, required_non_null_datapoints=1)
 
@@ -123,6 +142,7 @@ def calculate_metrics_for_timeseries(
         MetricsFields.VACCINATIONS_COMPLETED_RATIO: vaccines_completed_ratio,
     }
     metrics = pd.DataFrame(top_level_metrics_data)
+    metrics = metrics.round(METRIC_ROUNDING_PRECISION)
     metrics.index.name = CommonFields.DATE
     metrics = metrics.reset_index()
 


### PR DESCRIPTION
This fixes the Arkansas issue we looked at this morning (as well as a number of other cases where states/counties were on a metric threshold).

I verified that the generated summary file on the frontend (where we already were doing this kind of rounding) was unaffected except:
1. As desired, risk levels were fixed when a rounded metric value ended up on a metric threshold.
2. JavaScript and Python round slightly differently when the value ends in a `5` (e.g. `0.115` rounds to `0.12` in JavaScript but `0.11` in Python).

Also worth noting that the resulting .timeseries.json API endpoints are ~35% smaller.