### PR TITLE
Disable crashing test.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,8 @@ setup-dev: requirements.txt requirements_test.txt
 	pip install --upgrade -r requirements.txt -r requirements_test.txt
 	pre-commit install
 
-# As a work-around for a test failure in tests/libs/datasets/data_source_test.py::test_state_providers_smoke_test
-# run tests on a single process. The failure seems to happen on the server (which runs unittest) but not locally.
 unittest:
-	pytest -n 1 tests/
+	pytest -n 2 tests/
 
 unittest-not-slow:
 	pytest -k 'not slow' -n 2 --durations=5 tests/

--- a/tests/libs/datasets/data_source_test.py
+++ b/tests/libs/datasets/data_source_test.py
@@ -25,7 +25,9 @@ from tests.test_helpers import TimeseriesLiteral
 
 
 @pytest.mark.slow
-@pytest.mark.skip("This is crashing in CI for an unknown reason.")
+@pytest.mark.skip(
+    "https://trello.com/c/FFAUKu3k/ - This is crashing in CI (probably running out of memory)."
+)
 def test_state_providers_smoke_test():
     """Make sure *something* is returned without any raised exceptions."""
     assert can_scraper_local_dashboard_providers.CANScraperStateProviders.make_dataset()

--- a/tests/libs/datasets/data_source_test.py
+++ b/tests/libs/datasets/data_source_test.py
@@ -25,6 +25,7 @@ from tests.test_helpers import TimeseriesLiteral
 
 
 @pytest.mark.slow
+@pytest.mark.skip("This is crashing in CI for an unknown reason.")
 def test_state_providers_smoke_test():
     """Make sure *something* is returned without any raised exceptions."""
     assert can_scraper_local_dashboard_providers.CANScraperStateProviders.make_dataset()


### PR DESCRIPTION
`test_state_providers_smoke_test` started crashing even without parallelization.  I suspect it's running out of memory.  Disabling it.