### PR TITLE
add disclaimer/public_note to 6 MO counties

### DIFF
--- a/data/region-overrides.json
+++ b/data/region-overrides.json
@@ -138,7 +138,7 @@
       "blocked": false,
       "region": "29037, 29047, 29095, 29165",
       "context": "https://trello.com/c/6roEMYkZ/1020-switch-to-usa-facts-for-6-mo-counties-nyt-is-under-reporting-kc-joplin-data",
-      "disclaimer": "Four counties (Cass, Clay, Jackson and Platte) overlap the municipality of Kansas City, MO. Our data source has all cases and deaths for the municipality in Jackson County."
+      "disclaimer": "Four counties (Cass, Clay, Jackson and Platte) overlap the municipality of Kansas City, MO. Our data source attributes all cases and deaths for Kansas City to Jackson County."
     },
     {
       "include": "region",
@@ -146,7 +146,7 @@
       "blocked": false,
       "region": "29097, 29145",
       "context": "https://trello.com/c/6roEMYkZ/1020-switch-to-usa-facts-for-6-mo-counties-nyt-is-under-reporting-kc-joplin-data",
-      "disclaimer": "Two counties (Jasper and Newton) overlap the municipality of Joplin, MO. Our data source has all cases and deaths for the municipality in Jasper County."
+      "disclaimer": "Two counties (Jasper and Newton) overlap the municipality of Joplin, MO. Our data source attributes all cases and deaths for Joplin to Jasper County."
     },
     {
       "include": "region-and-subregions",

--- a/data/region-overrides.json
+++ b/data/region-overrides.json
@@ -133,6 +133,22 @@
       "context": "https://trello.com/c/WCCU7ey1/1417-blocked-data-after-5-27-cases-in-collin-county-tx-stalled"
     },
     {
+      "include": "region",
+      "metric": "metrics.caseDensity",
+      "blocked": false,
+      "region": "29037, 29047, 29095, 29165",
+      "context": "https://trello.com/c/6roEMYkZ/1020-switch-to-usa-facts-for-6-mo-counties-nyt-is-under-reporting-kc-joplin-data",
+      "disclaimer": "Four counties (Cass, Clay, Jackson and Platte) overlap the municipality of Kansas City, MO. Our data source has all cases and deaths for the municipality in Jackson County."
+    },
+    {
+      "include": "region",
+      "metric": "metrics.caseDensity",
+      "blocked": false,
+      "region": "29097, 29145",
+      "context": "https://trello.com/c/6roEMYkZ/1020-switch-to-usa-facts-for-6-mo-counties-nyt-is-under-reporting-kc-joplin-data",
+      "disclaimer": "Two counties (Jasper and Newton) overlap the municipality of Joplin, MO. Our data source has all cases and deaths for the municipality in Jasper County."
+    },
+    {
       "include": "region-and-subregions",
       "metric": "metrics.caseDensity",
       "blocked": false,


### PR DESCRIPTION
This PR adds a disclaimer/public_note to 6 MO counties following up on https://trello.com/c/6roEMYkZ/1020-switch-to-usa-facts-for-6-mo-counties-nyt-is-under-reporting-kc-joplin-data

The note is added to `cases`. It is not added to `new_cases` because `new_cases_and_deaths` runs after `manual_filter` and doesn't copy tags. It isn't added to `deaths` or `new_deaths` because they aren't in `_METRIC_TO_FIELDS`.

## Tested

`./run.py data update` and `git difftool --no-prompt -t vimdiff main -- data/multiregion-wide-dates.csv` shows only changes described above.