### PR TITLE
Exclude FL counties from vaccine fields when reading from CAN scraper state providers

### DIFF
--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -172,6 +172,13 @@ CDCVaccinesStatesAndNationDataset = datasource_regions(
 )
 
 
+# Excludes FL counties for vaccine fields. See
+# https://trello.com/c/0nVivEMt/1435-fix-florida-data-scraper
+CANScraperStateProvidersWithoutFLCounties = datasource_regions(
+    CANScraperStateProviders, exclude=RegionMask(level=AggregationLevel.COUNTY, states=["FL"])
+)
+
+
 # Below are two instances of feature definitions. These define
 # how to assemble values for a specific field.  Right now, we only
 # support overlaying values. i.e. a row of
@@ -234,30 +241,36 @@ ALL_TIMESERIES_FEATURE_DEFINITION: FeatureDataSourceMap = {
     CommonFields.TEST_POSITIVITY_7D: [CDCTestingDataset],
     CommonFields.VACCINES_DISTRIBUTED: [
         CDCVaccinesCountiesDataset,
-        CANScraperStateProviders,
+        CANScraperStateProvidersWithoutFLCounties,
         CANScraperCountyProviders,
         CDCVaccinesStatesAndNationDataset,
     ],
     CommonFields.VACCINES_ADMINISTERED: [
         CDCVaccinesCountiesDataset,
-        CANScraperStateProviders,
+        CANScraperStateProvidersWithoutFLCounties,
         CANScraperCountyProviders,
         CDCVaccinesStatesAndNationDataset,
     ],
     CommonFields.VACCINATIONS_INITIATED: [
         CDCVaccinesCountiesDataset,
-        CANScraperStateProviders,
+        CANScraperStateProvidersWithoutFLCounties,
         CANScraperCountyProviders,
         CDCVaccinesStatesAndNationDataset,
     ],
     CommonFields.VACCINATIONS_COMPLETED: [
         CDCVaccinesCountiesDataset,
-        CANScraperStateProviders,
+        CANScraperStateProvidersWithoutFLCounties,
         CANScraperCountyProviders,
         CDCVaccinesStatesAndNationDataset,
     ],
-    CommonFields.VACCINATIONS_INITIATED_PCT: [CANScraperStateProviders, CANScraperCountyProviders],
-    CommonFields.VACCINATIONS_COMPLETED_PCT: [CANScraperStateProviders, CANScraperCountyProviders],
+    CommonFields.VACCINATIONS_INITIATED_PCT: [
+        CANScraperStateProvidersWithoutFLCounties,
+        CANScraperCountyProviders,
+    ],
+    CommonFields.VACCINATIONS_COMPLETED_PCT: [
+        CANScraperStateProvidersWithoutFLCounties,
+        CANScraperCountyProviders,
+    ],
 }
 
 ALL_FIELDS_FEATURE_DEFINITION: FeatureDataSourceMap = {


### PR DESCRIPTION
This PR addresses https://trello.com/c/0nVivEMt/1435-fix-florida-data-scraper

## Tested

```
./run.py data update
git difftool -t vimdiff main -- data/multiregion-wide-dates.csv
```

shows some CBSA dropping vaccines_administered and gaining vaccinations_completed, vaccinations_initiated for many days in most recent ~2 weeks.  FL counties lost vaccines_administered and vaccinations_initiated demographic breakdowns and has only vaccinations_completed age 18+, 65+, all buckets but gained a much more complete timeseries. 