### PR TITLE
unknown top level risk when cases is unknown

### DIFF
--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -172,6 +172,13 @@ CDCVaccinesStatesAndNationDataset = datasource_regions(
 )
 
 
+# Excludes FL counties for vaccine fields. See
+# https://trello.com/c/0nVivEMt/1435-fix-florida-data-scraper
+CANScraperStateProvidersWithoutFLCounties = datasource_regions(
+    CANScraperStateProviders, exclude=RegionMask(level=AggregationLevel.COUNTY, states=["FL"])
+)
+
+
 # Below are two instances of feature definitions. These define
 # how to assemble values for a specific field.  Right now, we only
 # support overlaying values. i.e. a row of
@@ -234,30 +241,36 @@ ALL_TIMESERIES_FEATURE_DEFINITION: FeatureDataSourceMap = {
     CommonFields.TEST_POSITIVITY_7D: [CDCTestingDataset],
     CommonFields.VACCINES_DISTRIBUTED: [
         CDCVaccinesCountiesDataset,
-        CANScraperStateProviders,
+        CANScraperStateProvidersWithoutFLCounties,
         CANScraperCountyProviders,
         CDCVaccinesStatesAndNationDataset,
     ],
     CommonFields.VACCINES_ADMINISTERED: [
         CDCVaccinesCountiesDataset,
-        CANScraperStateProviders,
+        CANScraperStateProvidersWithoutFLCounties,
         CANScraperCountyProviders,
         CDCVaccinesStatesAndNationDataset,
     ],
     CommonFields.VACCINATIONS_INITIATED: [
         CDCVaccinesCountiesDataset,
-        CANScraperStateProviders,
+        CANScraperStateProvidersWithoutFLCounties,
         CANScraperCountyProviders,
         CDCVaccinesStatesAndNationDataset,
     ],
     CommonFields.VACCINATIONS_COMPLETED: [
         CDCVaccinesCountiesDataset,
-        CANScraperStateProviders,
+        CANScraperStateProvidersWithoutFLCounties,
         CANScraperCountyProviders,
         CDCVaccinesStatesAndNationDataset,
     ],
-    CommonFields.VACCINATIONS_INITIATED_PCT: [CANScraperStateProviders, CANScraperCountyProviders],
-    CommonFields.VACCINATIONS_COMPLETED_PCT: [CANScraperStateProviders, CANScraperCountyProviders],
+    CommonFields.VACCINATIONS_INITIATED_PCT: [
+        CANScraperStateProvidersWithoutFLCounties,
+        CANScraperCountyProviders,
+    ],
+    CommonFields.VACCINATIONS_COMPLETED_PCT: [
+        CANScraperStateProvidersWithoutFLCounties,
+        CANScraperCountyProviders,
+    ],
 }
 
 ALL_FIELDS_FEATURE_DEFINITION: FeatureDataSourceMap = {

--- a/libs/metrics/top_level_metric_risk_levels.py
+++ b/libs/metrics/top_level_metric_risk_levels.py
@@ -95,8 +95,8 @@ def top_level_risk_level(
     infection_rate_level: RiskLevel,
 ) -> RiskLevel:
     """Calculate the overall risk for a region based on metric risk levels."""
-    if case_density_level is RiskLevel.LOW:
-        return RiskLevel.LOW
+    if case_density_level in (RiskLevel.LOW, RiskLevel.UNKNOWN):
+        return case_density_level
 
     level_list = [
         infection_rate_level,

--- a/tests/libs/metrics/top_level_metric_risk_levels_test.py
+++ b/tests/libs/metrics/top_level_metric_risk_levels_test.py
@@ -38,6 +38,7 @@ def test_contact_tracing_levels(value, expected_level):
 @pytest.mark.parametrize(
     "case_density_level,expected",
     [
+        (RiskLevel.UNKNOWN, RiskLevel.UNKNOWN),
         (RiskLevel.LOW, RiskLevel.LOW),
         (RiskLevel.MEDIUM, RiskLevel.CRITICAL),
         (RiskLevel.EXTREME, RiskLevel.EXTREME),


### PR DESCRIPTION
This PR addresses https://trello.com/c/trOrDzSb/1439-api-overall-risk-level-doesnt-match-website-when-cases-are-unknown
