### PR TITLE
Get NE county cases from state provider. add --no-print-stats

### DIFF
--- a/cli/data.py
+++ b/cli/data.py
@@ -92,9 +92,17 @@ def update_forecasts(filename):
     help="Aggregate states to one USA country region",
     default=True,
 )
+@click.option(
+    "--print-stats/--no-print-stats",
+    is_flag=True,
+    help="Print summary stats at several places in the pipeline. Producing these takes extra time.",
+    default=True,
+)
 @click.option("--state", type=str, help="For testing, a two letter state abbr")
 @click.option("--fips", type=str, help="For testing, a 5 digit county fips")
-def update(aggregate_to_country: bool, state: Optional[str], fips: Optional[str]):
+def update(
+    aggregate_to_country: bool, print_stats: bool, state: Optional[str], fips: Optional[str]
+):
     """Updates latest and timeseries datasets to the current checked out covid data public commit"""
     path_prefix = dataset_utils.DATA_DIRECTORY.relative_to(dataset_utils.REPO_ROOT)
 
@@ -110,7 +118,8 @@ def update(aggregate_to_country: bool, state: Optional[str], fips: Optional[str]
     )
     _logger.info("Finished combining datasets")
     multiregion_dataset.to_compressed_pickle(dataset_utils.COMBINED_RAW_PICKLE_GZ_PATH)
-    multiregion_dataset.print_stats("combined")
+    if print_stats:
+        multiregion_dataset.print_stats("combined")
 
     # Apply manual overrides (currently only removing timeseries) before aggregation so we don't
     # need to remove CBSAs because they don't exist yet.
@@ -125,17 +134,20 @@ def update(aggregate_to_country: bool, state: Optional[str], fips: Optional[str]
         dataset_utils.MANUAL_FILTER_REMOVED_WIDE_DATES_CSV_PATH,
         dataset_utils.MANUAL_FILTER_REMOVED_STATIC_CSV_PATH,
     )
-    multiregion_dataset.print_stats("manual filter")
+    if print_stats:
+        multiregion_dataset.print_stats("manual filter")
 
     multiregion_dataset = timeseries.drop_observations(
         multiregion_dataset, after=datetime.datetime.utcnow().date()
     )
 
     multiregion_dataset = outlier_detection.drop_tail_positivity_outliers(multiregion_dataset)
-    multiregion_dataset.print_stats("drop_tail")
+    if print_stats:
+        multiregion_dataset.print_stats("drop_tail")
     # Filter for stalled cumulative values before deriving NEW_CASES from CASES.
     _, multiregion_dataset = TailFilter.run(multiregion_dataset, CUMULATIVE_FIELDS_TO_FILTER)
-    multiregion_dataset.print_stats("TailFilter")
+    if print_stats:
+        multiregion_dataset.print_stats("TailFilter")
     multiregion_dataset = zeros_filter.drop_all_zero_timeseries(
         multiregion_dataset,
         [
@@ -145,38 +157,47 @@ def update(aggregate_to_country: bool, state: Optional[str], fips: Optional[str]
             CommonFields.VACCINATIONS_INITIATED,
         ],
     )
-    multiregion_dataset.print_stats("zeros_filter")
+    if print_stats:
+        multiregion_dataset.print_stats("zeros_filter")
 
     multiregion_dataset = vaccine_backfills.estimate_initiated_from_state_ratio(multiregion_dataset)
-    multiregion_dataset.print_stats("estimate_initiated_from_state_ratio")
+    if print_stats:
+        multiregion_dataset.print_stats("estimate_initiated_from_state_ratio")
 
     multiregion_dataset = new_cases_and_deaths.add_new_cases(multiregion_dataset)
     multiregion_dataset = new_cases_and_deaths.add_new_deaths(multiregion_dataset)
-    multiregion_dataset.print_stats("new_cases_and_deaths")
+    if print_stats:
+        multiregion_dataset.print_stats("new_cases_and_deaths")
 
     multiregion_dataset = outlier_detection.drop_new_case_outliers(multiregion_dataset)
     multiregion_dataset = outlier_detection.drop_new_deaths_outliers(multiregion_dataset)
-    multiregion_dataset.print_stats("outlier_detection")
+    if print_stats:
+        multiregion_dataset.print_stats("outlier_detection")
 
     multiregion_dataset = timeseries.drop_regions_without_population(
         multiregion_dataset, KNOWN_LOCATION_ID_WITHOUT_POPULATION, structlog.get_logger()
     )
-    multiregion_dataset.print_stats("drop_regions_without_population")
+    if print_stats:
+        multiregion_dataset.print_stats("drop_regions_without_population")
 
     multiregion_dataset = custom_aggregations.aggregate_puerto_rico_from_counties(
         multiregion_dataset
     )
-    multiregion_dataset.print_stats("aggregate_puerto_rico_from_counties")
+    if print_stats:
+        multiregion_dataset.print_stats("aggregate_puerto_rico_from_counties")
     multiregion_dataset = custom_aggregations.aggregate_to_new_york_city(multiregion_dataset)
-    multiregion_dataset.print_stats("aggregate_to_new_york_city")
+    if print_stats:
+        multiregion_dataset.print_stats("aggregate_to_new_york_city")
     multiregion_dataset = custom_aggregations.replace_dc_county_with_state_data(multiregion_dataset)
-    multiregion_dataset.print_stats("replace_dc_county_with_state_data")
+    if print_stats:
+        multiregion_dataset.print_stats("replace_dc_county_with_state_data")
 
     cbsa_dataset = aggregator.aggregate(
         multiregion_dataset, reporting_ratio_required_to_aggregate=DEFAULT_REPORTING_RATIO
     )
     multiregion_dataset = multiregion_dataset.append_regions(cbsa_dataset)
-    multiregion_dataset.print_stats("CountyToCBSAAggregator")
+    if print_stats:
+        multiregion_dataset.print_stats("CountyToCBSAAggregator")
 
     # TODO(tom): Add a clean way to store intermediate values instead of commenting out code like
     #  this:
@@ -187,10 +208,12 @@ def update(aggregate_to_country: bool, state: Optional[str], fips: Optional[str]
         multiregion_dataset = custom_aggregations.aggregate_to_country(
             multiregion_dataset, reporting_ratio_required_to_aggregate=DEFAULT_REPORTING_RATIO
         )
-        multiregion_dataset.print_stats("aggregate_to_country")
+        if print_stats:
+            multiregion_dataset.print_stats("aggregate_to_country")
 
     combined_dataset_utils.persist_dataset(multiregion_dataset, path_prefix)
-    multiregion_dataset.print_stats("persist")
+    if print_stats:
+        multiregion_dataset.print_stats("persist")
 
 
 @main.command()

--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -153,15 +153,22 @@ JOPLIN_COUNTIES = [
     Region.from_fips("29145"),
 ]
 
+NE_COUNTIES = RegionMask(AggregationLevel.COUNTY, states=["NE"])
+
 # NY Times has cases and deaths for all boroughs aggregated into 36061 / New York County.
 # Remove all the NYC data so that USAFacts (which reports each borough separately) is used.
 # Remove counties in MO that overlap with Kansas City and Joplin because we don't handle the
 # reporting done by city, as documented at
 # https://github.com/nytimes/covid-19-data/blob/master/README.md#geographic-exceptions
 NYTimesDatasetWithoutExceptions = datasource_regions(
-    NYTimesDataset, exclude=[*ALL_NYC_REGIONS, *KANSAS_CITY_COUNTIES, *JOPLIN_COUNTIES],
+    NYTimesDataset,
+    exclude=[*ALL_NYC_REGIONS, *KANSAS_CITY_COUNTIES, *JOPLIN_COUNTIES, NE_COUNTIES],
 )
 
+
+CANScraperUSAFactsProviderWithoutNe = datasource_regions(
+    CANScraperUSAFactsProvider, exclude=[NE_COUNTIES]
+)
 
 CDCVaccinesCountiesDataset = datasource_regions(
     CDCVaccinesDataset, RegionMask(AggregationLevel.COUNTY)
@@ -194,7 +201,7 @@ CANScraperStateProvidersWithoutFLCounties = datasource_regions(
 ALL_TIMESERIES_FEATURE_DEFINITION: FeatureDataSourceMap = {
     CommonFields.CASES: [
         CANScraperStateProviders,
-        CANScraperUSAFactsProvider,
+        CANScraperUSAFactsProviderWithoutNe,
         NYTimesDatasetWithoutExceptions,
     ],
     CommonFields.CONTACT_TRACERS_COUNT: [TestAndTraceData],
@@ -218,7 +225,7 @@ ALL_TIMESERIES_FEATURE_DEFINITION: FeatureDataSourceMap = {
     CommonFields.CURRENT_VENTILATED: [CovidTrackingDataSource],
     CommonFields.DEATHS: [
         CANScraperStateProviders,
-        CANScraperUSAFactsProvider,
+        CANScraperUSAFactsProviderWithoutNe,
         NYTimesDatasetWithoutExceptions,
     ],
     CommonFields.HOSPITAL_BEDS_IN_USE_ANY: [HHSHospitalCountyDataset, HHSHospitalStateDataset],


### PR DESCRIPTION
This PR adds data collected by https://github.com/covid-projections/can-scrapers/pull/318 to the combined data, addressing https://trello.com/c/IEXT5YRn/1423-blocked-5-26-onward-nebraska-stopped-reporting-cases-at-county-level
