### PR TITLE
add disclaimer copied from Texas DSHS

### DIFF
--- a/data/region-overrides.json
+++ b/data/region-overrides.json
@@ -21,6 +21,16 @@
       "end_date": ""
     },
     {
+      "include": "subregions",
+      "metric": "metrics.caseDensity",
+      "region": "TX",
+      "context": "https://twitter.com/TexasDSHS/status/1407806450135666699",
+      "disclaimer": "Texas DSHS: This week's increase in new cases is due to some catch-up in case reporting by counties",
+      "blocked": false,
+      "start_date": "",
+      "end_date": ""
+    },
+    {
       "include": "region-and-subregions",
       "metric": "metrics.testPositivityRatio",
       "region": "NY",


### PR DESCRIPTION
Adds disclaimer copied from https://twitter.com/TexasDSHS/status/1407806450135666699 though it is unclear exactly what dates this applies to and if it makes sense to leave it up for those dates in the future (even though the FE doesn't support date ranges) or take it down in about a week.