### PR TITLE
Estimate 1st dose data if it's been missing recently.

### DIFF
--- a/tests/libs/datasets/vaccine_backfill_test.py
+++ b/tests/libs/datasets/vaccine_backfill_test.py
@@ -1,5 +1,6 @@
 from covidactnow.datapublic.common_fields import CommonFields
-from datetime import datetime, timedelta
+from datetime import datetime
+from datetime import timedelta
 
 from libs.datasets.taglib import TagType
 from libs.pipeline import Region


### PR DESCRIPTION
Previously we wouldn't estimate 1st dose data from completed if there was any
1st dose data at all (even if it was really stale).

With this change, we look back 16 days and if there's no 1st dose data in that
span, then we estimate 1st dose from completed. This is necessary since some
of the new CDC timeseries data has stale 1st dose data for some reason and we
want to go ahead and replace it with estimated data so we can use it on the website.

Tested via: `./run.py data update`.  Data didn't change (we don't have any providers with up-to-date complete data but stale 1st dose data presently).  

cc/ @smcclure17 
