### PR TITLE
Add cdc transmission levels

### DIFF
--- a/api/can_api_v2_definition.py
+++ b/api/can_api_v2_definition.py
@@ -403,6 +403,21 @@ class RiskLevel(enum.Enum):
     EXTREME = 5
 
 
+@enum.unique
+class CDCTransmissionLevel(enum.Enum):
+    """CDC transmission level."""
+
+    LOW = 0
+
+    MODERATE = 1
+
+    SUBSTANTIAL = 2
+
+    HIGH = 3
+
+    UNKNOWN = 4
+
+
 class RiskLevels(base_model.APIBaseModel):
     """COVID risk levels for a region."""
 
@@ -482,6 +497,11 @@ class RegionSummary(base_model.APIBaseModel):
     )
     metrics: Metrics = pydantic.Field(...)
     riskLevels: RiskLevels = pydantic.Field(..., description="Risk levels for region.")
+
+    cdcTransmissionLevel: CDCTransmissionLevel = pydantic.Field(
+        ..., description="CDC transmission levels for region."
+    )
+
     actuals: Actuals = pydantic.Field(...)
     annotations: Annotations = pydantic.Field(...)
 

--- a/api/can_api_v2_definition.py
+++ b/api/can_api_v2_definition.py
@@ -406,7 +406,7 @@ class RiskLevel(enum.Enum):
 
 @enum.unique
 class CDCTransmissionLevel(enum.Enum):
-    """CDC transmission level."""
+    """CDC community transmission level."""
 
     LOW = 0
 
@@ -504,6 +504,13 @@ class RegionSummary(base_model.APIBaseModel):
         description=textwrap.dedent(
             """
             CDC community transmission level for region.
+
+            Possible values:
+             - 0: Low
+             - 1: Moderate
+             - 2: Substantial
+             - 3: High
+             - 4: Unknown
 
             See [definitions of CDC community transmission levels](
             https://covid.cdc.gov/covid-data-tracker/#cases_community)

--- a/api/can_api_v2_definition.py
+++ b/api/can_api_v2_definition.py
@@ -1,5 +1,6 @@
 from typing import List, Optional, Dict
 import enum
+import textwrap
 
 from libs.datasets.dataset_utils import AggregationLevel
 from libs import base_model
@@ -499,7 +500,16 @@ class RegionSummary(base_model.APIBaseModel):
     riskLevels: RiskLevels = pydantic.Field(..., description="Risk levels for region.")
 
     cdcTransmissionLevel: CDCTransmissionLevel = pydantic.Field(
-        ..., description="CDC transmission level for region."
+        ...,
+        description=textwrap.dedent(
+            """
+            CDC community transmission level for region.
+
+            See [definitions of CDC community transmission levels](
+            https://covid.cdc.gov/covid-data-tracker/#cases_community)
+            for more details.
+            """
+        ),
     )
 
     actuals: Actuals = pydantic.Field(...)

--- a/api/can_api_v2_definition.py
+++ b/api/can_api_v2_definition.py
@@ -499,7 +499,7 @@ class RegionSummary(base_model.APIBaseModel):
     riskLevels: RiskLevels = pydantic.Field(..., description="Risk levels for region.")
 
     cdcTransmissionLevel: CDCTransmissionLevel = pydantic.Field(
-        ..., description="CDC transmission levels for region."
+        ..., description="CDC transmission level for region."
     )
 
     actuals: Actuals = pydantic.Field(...)

--- a/api/docs/docs/updates.md
+++ b/api/docs/docs/updates.md
@@ -7,13 +7,13 @@ description: Updates to the Covid Act Now API.
 
 Updates to the API will be reflected here.
 
-### CDC Transmission Levels
-_Added on 2021_07-29_
+### CDC Community Transmission Levels
+_Added on 2021-07-30_
 
-You can now access the current CDC Transmissions levels in the Covid Act Now API.
+You can now access the current CDC Community transmissions levels in the Covid Act Now API.
 
-The CDC transmission levels are similar to the Covid Act Now risk levels, but have slightly different thresholds.  
-See [definitions of CDC Transmission levels](https://covid.cdc.gov/covid-data-tracker/#cases_community) for more details.
+The CDC community transmission levels are similar to the Covid Act Now risk levels, but have slightly different thresholds.  
+See [definitions of CDC community transmission levels](https://covid.cdc.gov/covid-data-tracker/#cases_community) for more details.
 
 ### Aggregated US data
 _Added on 2021-03-31_

--- a/api/docs/docs/updates.md
+++ b/api/docs/docs/updates.md
@@ -7,6 +7,14 @@ description: Updates to the Covid Act Now API.
 
 Updates to the API will be reflected here.
 
+### CDC Transmission Levels
+_Added on 2021_07-29_
+
+You can now access the current CDC Transmissions levels in the Covid Act Now API.
+
+The CDC transmission levels are similar to the Covid Act Now risk levels, but have slightly different thresholds.  
+See [definitions of CDC Transmission levels](https://covid.cdc.gov/covid-data-tracker/#cases_community) for more details.
+
 ### Aggregated US data
 _Added on 2021-03-31_
 

--- a/api/docs/open_api_schema.json
+++ b/api/docs/open_api_schema.json
@@ -1888,7 +1888,7 @@
           3,
           4
         ],
-        "description": "CDC transmission level."
+        "description": "CDC community transmission level."
       },
       "FieldSourceType": {
         "title": "FieldSourceType",
@@ -2341,7 +2341,7 @@
                 "$ref": "#/components/schemas/CDCTransmissionLevel"
               }
             ],
-            "description": "CDC transmission levels for region."
+            "description": "\nCDC community transmission level for region.\n\nPossible values:\n - 0: Low\n - 1: Moderate\n - 2: Substantial\n - 3: High\n - 4: Unknown\n\nSee [definitions of CDC community transmission levels](\nhttps://covid.cdc.gov/covid-data-tracker/#cases_community)\nfor more details.\n"
           },
           "actuals": {
             "$ref": "#/components/schemas/Actuals"
@@ -2875,7 +2875,7 @@
                 "$ref": "#/components/schemas/CDCTransmissionLevel"
               }
             ],
-            "description": "CDC transmission levels for region."
+            "description": "\nCDC community transmission level for region.\n\nPossible values:\n - 0: Low\n - 1: Moderate\n - 2: Substantial\n - 3: High\n - 4: Unknown\n\nSee [definitions of CDC community transmission levels](\nhttps://covid.cdc.gov/covid-data-tracker/#cases_community)\nfor more details.\n"
           },
           "actuals": {
             "$ref": "#/components/schemas/Actuals"

--- a/api/docs/open_api_schema.json
+++ b/api/docs/open_api_schema.json
@@ -1879,6 +1879,17 @@
         },
         "description": "COVID risk levels for a region."
       },
+      "CDCTransmissionLevel": {
+        "title": "CDCTransmissionLevel",
+        "enum": [
+          0,
+          1,
+          2,
+          3,
+          4
+        ],
+        "description": "CDC transmission level."
+      },
       "FieldSourceType": {
         "title": "FieldSourceType",
         "enum": [
@@ -2227,6 +2238,7 @@
           "population",
           "metrics",
           "riskLevels",
+          "cdcTransmissionLevel",
           "actuals",
           "annotations",
           "lastUpdatedDate",
@@ -2322,6 +2334,14 @@
               }
             ],
             "description": "Risk levels for region."
+          },
+          "cdcTransmissionLevel": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CDCTransmissionLevel"
+              }
+            ],
+            "description": "CDC transmission levels for region."
           },
           "actuals": {
             "$ref": "#/components/schemas/Actuals"
@@ -2749,6 +2769,7 @@
           "population",
           "metrics",
           "riskLevels",
+          "cdcTransmissionLevel",
           "actuals",
           "annotations",
           "lastUpdatedDate",
@@ -2847,6 +2868,14 @@
               }
             ],
             "description": "Risk levels for region."
+          },
+          "cdcTransmissionLevel": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CDCTransmissionLevel"
+              }
+            ],
+            "description": "CDC transmission levels for region."
           },
           "actuals": {
             "$ref": "#/components/schemas/Actuals"

--- a/api/schemas_v2/AggregateRegionSummary.json
+++ b/api/schemas_v2/AggregateRegionSummary.json
@@ -332,7 +332,7 @@
     },
     "CDCTransmissionLevel": {
       "title": "CDCTransmissionLevel",
-      "description": "CDC transmission level.",
+      "description": "CDC community transmission level.",
       "enum": [
         0,
         1,
@@ -1080,7 +1080,7 @@
           ]
         },
         "cdcTransmissionLevel": {
-          "description": "CDC transmission levels for region.",
+          "description": "\nCDC community transmission level for region.\n\nPossible values:\n - 0: Low\n - 1: Moderate\n - 2: Substantial\n - 3: High\n - 4: Unknown\n\nSee [definitions of CDC community transmission levels](\nhttps://covid.cdc.gov/covid-data-tracker/#cases_community)\nfor more details.\n",
           "allOf": [
             {
               "$ref": "#/definitions/CDCTransmissionLevel"

--- a/api/schemas_v2/AggregateRegionSummary.json
+++ b/api/schemas_v2/AggregateRegionSummary.json
@@ -330,6 +330,17 @@
         "icuCapacityRatio"
       ]
     },
+    "CDCTransmissionLevel": {
+      "title": "CDCTransmissionLevel",
+      "description": "CDC transmission level.",
+      "enum": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ]
+    },
     "HospitalResourceUtilization": {
       "title": "HospitalResourceUtilization",
       "description": "Base model for API output.",
@@ -1068,6 +1079,14 @@
             }
           ]
         },
+        "cdcTransmissionLevel": {
+          "description": "CDC transmission levels for region.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CDCTransmissionLevel"
+            }
+          ]
+        },
         "actuals": {
           "$ref": "#/definitions/Actuals"
         },
@@ -1105,6 +1124,7 @@
         "population",
         "metrics",
         "riskLevels",
+        "cdcTransmissionLevel",
         "actuals",
         "annotations",
         "lastUpdatedDate",

--- a/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
@@ -332,7 +332,7 @@
     },
     "CDCTransmissionLevel": {
       "title": "CDCTransmissionLevel",
-      "description": "CDC transmission level.",
+      "description": "CDC community transmission level.",
       "enum": [
         0,
         1,
@@ -1457,7 +1457,7 @@
           ]
         },
         "cdcTransmissionLevel": {
-          "description": "CDC transmission levels for region.",
+          "description": "\nCDC community transmission level for region.\n\nPossible values:\n - 0: Low\n - 1: Moderate\n - 2: Substantial\n - 3: High\n - 4: Unknown\n\nSee [definitions of CDC community transmission levels](\nhttps://covid.cdc.gov/covid-data-tracker/#cases_community)\nfor more details.\n",
           "allOf": [
             {
               "$ref": "#/definitions/CDCTransmissionLevel"

--- a/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
@@ -330,6 +330,17 @@
         "icuCapacityRatio"
       ]
     },
+    "CDCTransmissionLevel": {
+      "title": "CDCTransmissionLevel",
+      "description": "CDC transmission level.",
+      "enum": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ]
+    },
     "HospitalResourceUtilization": {
       "title": "HospitalResourceUtilization",
       "description": "Base model for API output.",
@@ -1445,6 +1456,14 @@
             }
           ]
         },
+        "cdcTransmissionLevel": {
+          "description": "CDC transmission levels for region.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CDCTransmissionLevel"
+            }
+          ]
+        },
         "actuals": {
           "$ref": "#/definitions/Actuals"
         },
@@ -1503,6 +1522,7 @@
         "population",
         "metrics",
         "riskLevels",
+        "cdcTransmissionLevel",
         "actuals",
         "annotations",
         "lastUpdatedDate",

--- a/api/schemas_v2/RegionSummary.json
+++ b/api/schemas_v2/RegionSummary.json
@@ -92,6 +92,14 @@
         }
       ]
     },
+    "cdcTransmissionLevel": {
+      "description": "CDC transmission levels for region.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CDCTransmissionLevel"
+        }
+      ]
+    },
     "actuals": {
       "$ref": "#/definitions/Actuals"
     },
@@ -129,6 +137,7 @@
     "population",
     "metrics",
     "riskLevels",
+    "cdcTransmissionLevel",
     "actuals",
     "annotations",
     "lastUpdatedDate",
@@ -457,6 +466,17 @@
         "infectionRate",
         "icuHeadroomRatio",
         "icuCapacityRatio"
+      ]
+    },
+    "CDCTransmissionLevel": {
+      "title": "CDCTransmissionLevel",
+      "description": "CDC transmission level.",
+      "enum": [
+        0,
+        1,
+        2,
+        3,
+        4
       ]
     },
     "HospitalResourceUtilization": {

--- a/api/schemas_v2/RegionSummary.json
+++ b/api/schemas_v2/RegionSummary.json
@@ -93,7 +93,7 @@
       ]
     },
     "cdcTransmissionLevel": {
-      "description": "CDC transmission levels for region.",
+      "description": "\nCDC community transmission level for region.\n\nPossible values:\n - 0: Low\n - 1: Moderate\n - 2: Substantial\n - 3: High\n - 4: Unknown\n\nSee [definitions of CDC community transmission levels](\nhttps://covid.cdc.gov/covid-data-tracker/#cases_community)\nfor more details.\n",
       "allOf": [
         {
           "$ref": "#/definitions/CDCTransmissionLevel"
@@ -470,7 +470,7 @@
     },
     "CDCTransmissionLevel": {
       "title": "CDCTransmissionLevel",
-      "description": "CDC transmission level.",
+      "description": "CDC community transmission level.",
       "enum": [
         0,
         1,

--- a/api/schemas_v2/RegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/RegionSummaryWithTimeseries.json
@@ -93,7 +93,7 @@
       ]
     },
     "cdcTransmissionLevel": {
-      "description": "CDC transmission levels for region.",
+      "description": "\nCDC community transmission level for region.\n\nPossible values:\n - 0: Low\n - 1: Moderate\n - 2: Substantial\n - 3: High\n - 4: Unknown\n\nSee [definitions of CDC community transmission levels](\nhttps://covid.cdc.gov/covid-data-tracker/#cases_community)\nfor more details.\n",
       "allOf": [
         {
           "$ref": "#/definitions/CDCTransmissionLevel"
@@ -494,7 +494,7 @@
     },
     "CDCTransmissionLevel": {
       "title": "CDCTransmissionLevel",
-      "description": "CDC transmission level.",
+      "description": "CDC community transmission level.",
       "enum": [
         0,
         1,

--- a/api/schemas_v2/RegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/RegionSummaryWithTimeseries.json
@@ -92,6 +92,14 @@
         }
       ]
     },
+    "cdcTransmissionLevel": {
+      "description": "CDC transmission levels for region.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CDCTransmissionLevel"
+        }
+      ]
+    },
     "actuals": {
       "$ref": "#/definitions/Actuals"
     },
@@ -150,6 +158,7 @@
     "population",
     "metrics",
     "riskLevels",
+    "cdcTransmissionLevel",
     "actuals",
     "annotations",
     "lastUpdatedDate",
@@ -481,6 +490,17 @@
         "infectionRate",
         "icuHeadroomRatio",
         "icuCapacityRatio"
+      ]
+    },
+    "CDCTransmissionLevel": {
+      "title": "CDCTransmissionLevel",
+      "description": "CDC transmission level.",
+      "enum": [
+        0,
+        1,
+        2,
+        3,
+        4
       ]
     },
     "HospitalResourceUtilization": {

--- a/libs/build_api_v2.py
+++ b/libs/build_api_v2.py
@@ -13,6 +13,7 @@ from api.can_api_v2_definition import (
     Metrics,
     RiskLevels,
     RiskLevelsRow,
+    CDCTransmissionLevel,
     RegionSummary,
     RegionSummaryWithTimeseries,
     RegionTimeseriesRowWithHeader,
@@ -107,6 +108,7 @@ def build_region_summary(
     one_region: timeseries.OneRegionTimeseriesDataset,
     latest_metrics: Optional[Metrics],
     risk_levels: RiskLevels,
+    transmission_level: CDCTransmissionLevel,
     log,
 ) -> RegionSummary:
     latest_values = one_region.latest
@@ -126,6 +128,7 @@ def build_region_summary(
         actuals=actuals,
         metrics=latest_metrics,
         riskLevels=risk_levels,
+        cdcTransmissionLevel=transmission_level,
         lastUpdatedDate=datetime.utcnow(),
         locationId=region.location_id,
         url=latest_values.get(CommonFields.CAN_LOCATION_PAGE_URL),

--- a/libs/build_api_v2.py
+++ b/libs/build_api_v2.py
@@ -108,7 +108,7 @@ def build_region_summary(
     one_region: timeseries.OneRegionTimeseriesDataset,
     latest_metrics: Optional[Metrics],
     risk_levels: RiskLevels,
-    transmission_level: CDCTransmissionLevel,
+    cdc_transmission_level: CDCTransmissionLevel,
     log,
 ) -> RegionSummary:
     latest_values = one_region.latest
@@ -128,7 +128,7 @@ def build_region_summary(
         actuals=actuals,
         metrics=latest_metrics,
         riskLevels=risk_levels,
-        cdcTransmissionLevel=transmission_level,
+        cdcTransmissionLevel=cdc_transmission_level,
         lastUpdatedDate=datetime.utcnow(),
         locationId=region.location_id,
         url=latest_values.get(CommonFields.CAN_LOCATION_PAGE_URL),

--- a/libs/metrics/cdc_transmission_levels.py
+++ b/libs/metrics/cdc_transmission_levels.py
@@ -70,7 +70,7 @@ def top_level_transmission_level(
     elif TransmissionLevel.UNKNOWN in level_list:
         return TransmissionLevel.UNKNOWN
 
-    return RiskLevel.LOW
+    return TransmissionLevel.LOW
 
 
 def calculate_transmission_level_from_metrics(

--- a/libs/metrics/cdc_transmission_levels.py
+++ b/libs/metrics/cdc_transmission_levels.py
@@ -87,5 +87,5 @@ def calculate_transmission_level_from_metrics(
     case_density_level = case_density_transmission_level(metrics.caseDensity)
     test_positivity_level = test_positivity_transmission_level(metrics.testPositivityRatio)
 
-    overall_level = top_level_transmission_level(case_density_level, test_positivity_level)
+    overall_level = overall_transmission_level(case_density_level, test_positivity_level)
     return overall_level

--- a/libs/metrics/cdc_transmission_levels.py
+++ b/libs/metrics/cdc_transmission_levels.py
@@ -1,0 +1,112 @@
+from typing import List, Optional
+import math
+import numpy as np
+import pandas as pd
+
+from covidactnow.datapublic.common_fields import CommonFields
+from libs.metrics.top_level_metrics import MetricsFields
+from libs.metrics import top_level_metrics
+from api import can_api_v2_definition
+
+TransmissionLevel = can_api_v2_definition.CDCTransmissionLevel
+
+
+def calc_transmission_level(value: Optional[float], thresholds: List[float]) -> TransmissionLevel:
+    """Check the value against thresholds to determine the transmission level for the metric.
+
+    Each threshold is the upper limit for the risk level.
+
+    Args:
+        value: value of the metric.
+        thresholds: list of values corresponding to thresholds for different risk levels
+
+    Returns:
+        A CDCTranmissionLevel.
+    """
+    assert len(thresholds) == 3, "Must pass low, med and substantial thresholds."
+    if len(thresholds) == 3:
+        level_low, level_moderate, level_substantial = thresholds
+        level_high = math.inf
+
+    if value is None or math.isinf(value) or np.isnan(value):
+        return TransmissionLevel.UNKNOWN
+
+    if value < level_low:
+        return TransmissionLevel.LOW
+    elif value < level_moderate:
+        return TransmissionLevel.MODERATE
+    elif value < level_substantial:
+        return TransmissionLevel.SUBSTANTIAL
+
+    return TransmissionLevel.HIGH
+
+
+def case_density_transmission_level(value: float) -> TransmissionLevel:
+    thresholds = [10 / 7.0, 50 / 7.0, 100 / 7.0]
+    return calc_transmission_level(value, thresholds)
+
+
+def test_positivity_transmission_level(value: float) -> TransmissionLevel:
+    thresholds = [0.05, 0.08, 0.10]
+    return calc_transmission_level(value, thresholds)
+
+
+def top_level_transmission_level(
+    case_density_level: TransmissionLevel, test_positivity_level: TransmissionLevel,
+) -> TransmissionLevel:
+    """Calculate the overall risk for a region based on metric risk levels."""
+
+    level_list = [
+        test_positivity_level,
+        case_density_level,
+    ]
+
+    if TransmissionLevel.HIGH in level_list:
+        return TransmissionLevel.HIGH
+    elif TransmissionLevel.SUBSTANTIAL in level_list:
+        return TransmissionLevel.SUBSTANTIAL
+    elif TransmissionLevel.MODERATE in level_list:
+        return TransmissionLevel.MODERATE
+    elif TransmissionLevel.UNKNOWN in level_list:
+        return TransmissionLevel.UNKNOWN
+
+    return RiskLevel.LOW
+
+
+def calculate_transmission_level_from_metrics(
+    metrics: can_api_v2_definition.Metrics,
+) -> can_api_v2_definition.CDCTransmissionLevel:
+    case_density_level = case_density_transmission_level(metrics.caseDensity)
+    test_positivity_level = test_positivity_transmission_level(metrics.testPositivityRatio)
+
+    overall_level = top_level_transmission_level(case_density_level, test_positivity_level)
+    return overall_level
+
+
+def calculate_transmission_level_from_row(row: pd.Series):
+
+    case_density_level = case_density_transmission_level(row[MetricsFields.CASE_DENSITY_RATIO])
+    test_positivity_level = test_positivity_transmission_level(row[MetricsFields.TEST_POSITIVITY])
+
+    return top_level_transmission_level(case_density_level, test_positivity_level)
+
+
+def calculate_transmission_level_timeseries(
+    metrics_df: pd.DataFrame, metric_max_lookback=top_level_metrics.MAX_METRIC_LOOKBACK_DAYS
+):
+    metrics_df = metrics_df.copy()
+    # Shift infection rate to align with infection rate delay
+    infection_rate = metrics_df[MetricsFields.INFECTION_RATE].shift(
+        top_level_metrics.RT_TRUNCATION_DAYS
+    )
+    metrics_df[MetricsFields.INFECTION_RATE] = infection_rate
+    metrics_df = metrics_df.set_index([CommonFields.DATE, CommonFields.FIPS])
+
+    # We use the last available data within `MAX_METRIC_LOOKBACK_DAYS` to cacluate
+    # the transmission. Propagate the last value forward that many days so calculation for a given
+    # day is the same as `top_level_metrics.calculate_latest_metrics`
+    metrics_df.ffill(limit=metric_max_lookback - 1, inplace=True)
+
+    overall_transmission = metrics_df.apply(calculate_transmission_level_from_row, axis=1)
+
+    return pd.DataFrame({"overall": overall_transmission,}).reset_index()

--- a/libs/metrics/cdc_transmission_levels.py
+++ b/libs/metrics/cdc_transmission_levels.py
@@ -1,11 +1,7 @@
 from typing import List, Optional
 import math
 import numpy as np
-import pandas as pd
 
-from covidactnow.datapublic.common_fields import CommonFields
-from libs.metrics.top_level_metrics import MetricsFields
-from libs.metrics import top_level_metrics
 from api import can_api_v2_definition
 
 TransmissionLevel = can_api_v2_definition.CDCTransmissionLevel

--- a/libs/metrics/cdc_transmission_levels.py
+++ b/libs/metrics/cdc_transmission_levels.py
@@ -42,6 +42,9 @@ def calc_transmission_level(value: Optional[float], thresholds: List[float]) -> 
 
 
 def case_density_transmission_level(value: float) -> TransmissionLevel:
+    # CDC thresholds are number of cases over a 7 day average. Our case density
+    # metrics are cases over a 7 day average.  To square the two, we should divide
+    # CDC thresholds by 7 to get the equivalent threshold for our 7-day averages.
     thresholds = [10 / 7.0, 50 / 7.0, 100 / 7.0]
     return calc_transmission_level(value, thresholds)
 

--- a/libs/pipelines/api_v2_pipeline.py
+++ b/libs/pipelines/api_v2_pipeline.py
@@ -141,11 +141,11 @@ def build_timeseries_for_region(
             metrics_results
         )
         risk_levels = top_level_metric_risk_levels.calculate_risk_level_from_metrics(metrics_latest)
-        transmission_level = cdc_transmission_levels.calculate_transmission_level_from_metrics(
+        cdc_transmission_level = cdc_transmission_levels.calculate_transmission_level_from_metrics(
             metrics_latest
         )
         region_summary = build_api_v2.build_region_summary(
-            regional_input.timeseries, metrics_latest, risk_levels, transmission_level, log
+            regional_input.timeseries, metrics_latest, risk_levels, cdc_transmission_level, log
         )
         region_timeseries = build_api_v2.build_region_timeseries(
             region_summary, fips_timeseries, metrics_results, risk_timeseries,

--- a/libs/pipelines/api_v2_pipeline.py
+++ b/libs/pipelines/api_v2_pipeline.py
@@ -18,10 +18,11 @@ from api.can_api_v2_definition import RegionSummary
 from libs import dataset_deployer
 from libs.metrics import top_level_metrics
 from libs.metrics import top_level_metric_risk_levels
+from libs.metrics import cdc_transmission_levels
+
 from libs import parallel_utils
 from libs import pipeline
 from libs import build_api_v2
-
 from libs.datasets import timeseries
 from libs.datasets import vaccine_backfills
 from libs.datasets.timeseries import OneRegionTimeseriesDataset
@@ -140,11 +141,14 @@ def build_timeseries_for_region(
             metrics_results
         )
         risk_levels = top_level_metric_risk_levels.calculate_risk_level_from_metrics(metrics_latest)
+        transmission_level = cdc_transmission_levels.calculate_transmission_level_from_metrics(
+            metrics_latest
+        )
         region_summary = build_api_v2.build_region_summary(
-            regional_input.timeseries, metrics_latest, risk_levels, log
+            regional_input.timeseries, metrics_latest, risk_levels, transmission_level, log
         )
         region_timeseries = build_api_v2.build_region_timeseries(
-            region_summary, fips_timeseries, metrics_results, risk_timeseries
+            region_summary, fips_timeseries, metrics_results, risk_timeseries,
         )
     except Exception:
         log.exception(f"Failed to build timeseries for fips.")

--- a/libs/pipelines/csv_column_ordering.py
+++ b/libs/pipelines/csv_column_ordering.py
@@ -58,6 +58,7 @@ SUMMARY_ORDER = [
     "metrics.vaccinationsCompletedRatio",
     "actuals.newDeaths",
     "actuals.vaccinesAdministered",
+    "cdcTransmissionLevel",
 ]
 
 # Due to an inconsistency with how we previously were generating column names,
@@ -113,6 +114,7 @@ SUMMARY_ORDER_NO_HEADROOM_DETAILS = [
     "metrics.vaccinationsCompletedRatio",
     "actuals.newDeaths",
     "actuals.vaccinesAdministered",
+    "cdcTransmissionLevel",
 ]
 
 

--- a/tests/libs/metrics/cdc_transmission_level_test.py
+++ b/tests/libs/metrics/cdc_transmission_level_test.py
@@ -1,10 +1,7 @@
 import pytest
-import pandas as pd
 from api.can_api_v2_definition import Metrics
 from libs.metrics.cdc_transmission_levels import TransmissionLevel
 from libs.metrics import cdc_transmission_levels
-from libs.metrics import top_level_metrics
-from tests.libs.metrics import top_level_metrics_test
 
 
 def test_calc_transmission_level_below_limit():

--- a/tests/libs/metrics/cdc_transmission_level_test.py
+++ b/tests/libs/metrics/cdc_transmission_level_test.py
@@ -1,0 +1,44 @@
+import pytest
+import pandas as pd
+from api.can_api_v2_definition import Metrics
+from libs.metrics.cdc_transmission_levels import TransmissionLevel
+from libs.metrics import cdc_transmission_levels
+from libs.metrics import top_level_metrics
+from tests.libs.metrics import top_level_metrics_test
+
+
+def test_calc_transmission_level_below_limit():
+    """
+    Value in between two transmission levels should take the higher level.
+    """
+    assert (
+        cdc_transmission_levels.calc_transmission_level(2, [1, 3, 4]) == TransmissionLevel.MODERATE
+    )
+
+
+def test_calc_transmission_level_high():
+    assert cdc_transmission_levels.calc_transmission_level(5, [1, 3, 4]) == TransmissionLevel.HIGH
+
+
+def test_calc_transmission_level_at_limit():
+    # Value at upper limit of a transmission level should equal the transmission level above
+    assert (
+        cdc_transmission_levels.calc_transmission_level(1, [1, 3, 4]) == TransmissionLevel.MODERATE
+    )
+
+
+@pytest.mark.parametrize(
+    "test_positivity,case_density,expected_level",
+    [
+        (0.0, 9.99 / 7, TransmissionLevel.LOW),
+        (0.10, 0.0 / 7, TransmissionLevel.HIGH),
+        (0.0, 100.0 / 7, TransmissionLevel.HIGH),
+        (0.0, 99.9 / 7, TransmissionLevel.SUBSTANTIAL),
+    ],
+)
+def test_calc_transmission_levels(test_positivity, case_density, expected_level):
+    metrics = Metrics.empty()
+    metrics.testPositivityRatio = test_positivity
+    metrics.caseDensity = case_density
+    output = cdc_transmission_levels.calculate_transmission_level_from_metrics(metrics)
+    assert expected_level == output


### PR DESCRIPTION
This adds the latest cdc transmission level to the json adn csv output.

Note that this does not add to the timeseries data.  it's not a ton more work, but figured this was the minimum steps to get it working. 