### PR TITLE
reduced vaccine estimation backfill threshold by one day

### DIFF
--- a/libs/datasets/vaccine_backfills.py
+++ b/libs/datasets/vaccine_backfills.py
@@ -18,7 +18,7 @@ MOST_RECENT_DATE = "most_recent_date"
 
 # We'll apply the 1st dose estimation backfill if 1st dose data is missing for
 # at least this "lookback days" threshold.
-APPLY_BACKFILL_LOOKBACK_DAYS = 16
+APPLY_BACKFILL_LOOKBACK_DAYS = 15
 
 
 def derive_vaccine_pct(ds_in: MultiRegionDataset) -> MultiRegionDataset:

--- a/tests/libs/datasets/vaccine_backfill_test.py
+++ b/tests/libs/datasets/vaccine_backfill_test.py
@@ -113,8 +113,8 @@ def test_estimate_initiated_from_state_ratio():
 
 
 def test_estimate_initiated_from_state_ratio_respects_lookback_days():
-    # lookback period is 16 days so we'll start our data 17 days back.
-    start_date = (datetime.today() - timedelta(days=17)).strftime("%Y-%m-%d")
+    # lookback period is 15 days so we'll start our data 16 days back.
+    start_date = (datetime.today() - timedelta(days=16)).strftime("%Y-%m-%d")
 
     region_to_estimate = Region.from_fips("22071")  # Orleans Parish
     metrics_unmodified_regions = {


### PR DESCRIPTION
Reduces the number of days until the 1+ dose estimation kicks in so that estimation will start immediately once the data would go stale. This should prevent counties that are switching to estimation from going gray/stale for one day in between. 

### Please Check
- [ ] Are the [JSON schemas](https://github.com/covid-projections/covid-data-model/tree/main/api/schemas) updated?
- [ ] Are tests passing?
