### PR TITLE
Add cdcTransmissionLevel timeseries data to API.

### DIFF
--- a/api/docs/open_api_schema.json
+++ b/api/docs/open_api_schema.json
@@ -1672,6 +1672,17 @@
         },
         "description": "Base model for API output."
       },
+      "CDCTransmissionLevel": {
+        "title": "CDCTransmissionLevel",
+        "enum": [
+          0,
+          1,
+          2,
+          3,
+          4
+        ],
+        "description": "CDC community transmission level."
+      },
       "RegionTimeseriesRowWithHeader": {
         "title": "RegionTimeseriesRowWithHeader",
         "required": [
@@ -1685,7 +1696,8 @@
           "locationId",
           "actuals",
           "metrics",
-          "riskLevels"
+          "riskLevels",
+          "cdcTransmissionLevel"
         ],
         "type": "object",
         "properties": {
@@ -1784,6 +1796,14 @@
               }
             ],
             "description": "Risk Levels for given day"
+          },
+          "cdcTransmissionLevel": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CDCTransmissionLevel"
+              }
+            ],
+            "description": "\nCommunity transmission level for region, calculated using the CDC definition.\n\nPossible values:\n    - 0: Low\n    - 1: Moderate\n    - 2: Substantial\n    - 3: High\n    - 4: Unknown\n\nSee [definitions of CDC community transmission levels](\nhttps://covid.cdc.gov/covid-data-tracker/#cases_community) for more\ndetails.\n\nNote that the value may differ from what the CDC website reports\ngiven we have different data sources. We have also introduced an\n\"Unknown\" level for when both case data and test positivity data are\nmissing for at least 15 days. The CDC does not have an \"Unknown\"\nlevel and instead will designate a location as \"Low\" when case and\ntest positivity data are missing.\n"
           }
         },
         "description": "Prediction timeseries row with location information."
@@ -1878,17 +1898,6 @@
           }
         },
         "description": "COVID risk levels for a region."
-      },
-      "CDCTransmissionLevel": {
-        "title": "CDCTransmissionLevel",
-        "enum": [
-          0,
-          1,
-          2,
-          3,
-          4
-        ],
-        "description": "CDC community transmission level."
       },
       "FieldSourceType": {
         "title": "FieldSourceType",
@@ -2341,7 +2350,7 @@
                 "$ref": "#/components/schemas/CDCTransmissionLevel"
               }
             ],
-            "description": "\nCDC community transmission level for region.\n\nPossible values:\n - 0: Low\n - 1: Moderate\n - 2: Substantial\n - 3: High\n - 4: Unknown\n\nSee [definitions of CDC community transmission levels](\nhttps://covid.cdc.gov/covid-data-tracker/#cases_community)\nfor more details.\n"
+            "description": "\nCommunity transmission level for region, calculated using the CDC definition.\n\nPossible values:\n    - 0: Low\n    - 1: Moderate\n    - 2: Substantial\n    - 3: High\n    - 4: Unknown\n\nSee [definitions of CDC community transmission levels](\nhttps://covid.cdc.gov/covid-data-tracker/#cases_community) for more\ndetails.\n\nNote that the value may differ from what the CDC website reports\ngiven we have different data sources. We have also introduced an\n\"Unknown\" level for when both case data and test positivity data are\nmissing for at least 15 days. The CDC does not have an \"Unknown\"\nlevel and instead will designate a location as \"Low\" when case and\ntest positivity data are missing.\n"
           },
           "actuals": {
             "$ref": "#/components/schemas/Actuals"
@@ -2755,6 +2764,31 @@
         },
         "description": "Timeseries data for risk levels. Currently only surfacing overall risk level for region."
       },
+      "CdcTransmissionLevelTimeseriesRow": {
+        "title": "CdcTransmissionLevelTimeseriesRow",
+        "required": [
+          "date",
+          "cdcTransmissionLevel"
+        ],
+        "type": "object",
+        "properties": {
+          "date": {
+            "title": "Date",
+            "type": "string",
+            "description": "Date of timeseries data point",
+            "format": "date"
+          },
+          "cdcTransmissionLevel": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CDCTransmissionLevel"
+              }
+            ],
+            "description": "\nCommunity transmission level for region, calculated using the CDC definition.\n\nPossible values:\n    - 0: Low\n    - 1: Moderate\n    - 2: Substantial\n    - 3: High\n    - 4: Unknown\n\nSee [definitions of CDC community transmission levels](\nhttps://covid.cdc.gov/covid-data-tracker/#cases_community) for more\ndetails.\n\nNote that the value may differ from what the CDC website reports\ngiven we have different data sources. We have also introduced an\n\"Unknown\" level for when both case data and test positivity data are\nmissing for at least 15 days. The CDC does not have an \"Unknown\"\nlevel and instead will designate a location as \"Low\" when case and\ntest positivity data are missing.\n"
+          }
+        },
+        "description": "Base model for API output."
+      },
       "RegionSummaryWithTimeseries": {
         "title": "RegionSummaryWithTimeseries",
         "required": [
@@ -2776,7 +2810,8 @@
           "url",
           "metricsTimeseries",
           "actualsTimeseries",
-          "riskLevelsTimeseries"
+          "riskLevelsTimeseries",
+          "cdcTransmissionLevelTimeseries"
         ],
         "type": "object",
         "properties": {
@@ -2875,7 +2910,7 @@
                 "$ref": "#/components/schemas/CDCTransmissionLevel"
               }
             ],
-            "description": "\nCDC community transmission level for region.\n\nPossible values:\n - 0: Low\n - 1: Moderate\n - 2: Substantial\n - 3: High\n - 4: Unknown\n\nSee [definitions of CDC community transmission levels](\nhttps://covid.cdc.gov/covid-data-tracker/#cases_community)\nfor more details.\n"
+            "description": "\nCommunity transmission level for region, calculated using the CDC definition.\n\nPossible values:\n    - 0: Low\n    - 1: Moderate\n    - 2: Substantial\n    - 3: High\n    - 4: Unknown\n\nSee [definitions of CDC community transmission levels](\nhttps://covid.cdc.gov/covid-data-tracker/#cases_community) for more\ndetails.\n\nNote that the value may differ from what the CDC website reports\ngiven we have different data sources. We have also introduced an\n\"Unknown\" level for when both case data and test positivity data are\nmissing for at least 15 days. The CDC does not have an \"Unknown\"\nlevel and instead will designate a location as \"Low\" when case and\ntest positivity data are missing.\n"
           },
           "actuals": {
             "$ref": "#/components/schemas/Actuals"
@@ -2920,6 +2955,13 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/RiskLevelTimeseriesRow"
+            }
+          },
+          "cdcTransmissionLevelTimeseries": {
+            "title": "Cdctransmissionleveltimeseries",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CdcTransmissionLevelTimeseriesRow"
             }
           }
         },

--- a/api/schemas_v2/AggregateFlattenedTimeseries.json
+++ b/api/schemas_v2/AggregateFlattenedTimeseries.json
@@ -584,6 +584,17 @@
         "caseDensity"
       ]
     },
+    "CDCTransmissionLevel": {
+      "title": "CDCTransmissionLevel",
+      "description": "CDC community transmission level.",
+      "enum": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ]
+    },
     "RegionTimeseriesRowWithHeader": {
       "title": "RegionTimeseriesRowWithHeader",
       "description": "Prediction timeseries row with location information.",
@@ -684,6 +695,14 @@
               "$ref": "#/definitions/RiskLevelsRow"
             }
           ]
+        },
+        "cdcTransmissionLevel": {
+          "description": "\nCommunity transmission level for region, calculated using the CDC definition.\n\nPossible values:\n    - 0: Low\n    - 1: Moderate\n    - 2: Substantial\n    - 3: High\n    - 4: Unknown\n\nSee [definitions of CDC community transmission levels](\nhttps://covid.cdc.gov/covid-data-tracker/#cases_community) for more\ndetails.\n\nNote that the value may differ from what the CDC website reports\ngiven we have different data sources. We have also introduced an\n\"Unknown\" level for when both case data and test positivity data are\nmissing for at least 15 days. The CDC does not have an \"Unknown\"\nlevel and instead will designate a location as \"Low\" when case and\ntest positivity data are missing.\n",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CDCTransmissionLevel"
+            }
+          ]
         }
       },
       "required": [
@@ -697,7 +716,8 @@
         "locationId",
         "actuals",
         "metrics",
-        "riskLevels"
+        "riskLevels",
+        "cdcTransmissionLevel"
       ]
     }
   }

--- a/api/schemas_v2/AggregateRegionSummary.json
+++ b/api/schemas_v2/AggregateRegionSummary.json
@@ -1080,7 +1080,7 @@
           ]
         },
         "cdcTransmissionLevel": {
-          "description": "\nCDC community transmission level for region.\n\nPossible values:\n - 0: Low\n - 1: Moderate\n - 2: Substantial\n - 3: High\n - 4: Unknown\n\nSee [definitions of CDC community transmission levels](\nhttps://covid.cdc.gov/covid-data-tracker/#cases_community)\nfor more details.\n",
+          "description": "\nCommunity transmission level for region, calculated using the CDC definition.\n\nPossible values:\n    - 0: Low\n    - 1: Moderate\n    - 2: Substantial\n    - 3: High\n    - 4: Unknown\n\nSee [definitions of CDC community transmission levels](\nhttps://covid.cdc.gov/covid-data-tracker/#cases_community) for more\ndetails.\n\nNote that the value may differ from what the CDC website reports\ngiven we have different data sources. We have also introduced an\n\"Unknown\" level for when both case data and test positivity data are\nmissing for at least 15 days. The CDC does not have an \"Unknown\"\nlevel and instead will designate a location as \"Low\" when case and\ntest positivity data are missing.\n",
           "allOf": [
             {
               "$ref": "#/definitions/CDCTransmissionLevel"

--- a/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/AggregateRegionSummaryWithTimeseries.json
@@ -1362,6 +1362,31 @@
         "date"
       ]
     },
+    "CdcTransmissionLevelTimeseriesRow": {
+      "title": "CdcTransmissionLevelTimeseriesRow",
+      "description": "Base model for API output.",
+      "type": "object",
+      "properties": {
+        "date": {
+          "title": "Date",
+          "description": "Date of timeseries data point",
+          "type": "string",
+          "format": "date"
+        },
+        "cdcTransmissionLevel": {
+          "description": "\nCommunity transmission level for region, calculated using the CDC definition.\n\nPossible values:\n    - 0: Low\n    - 1: Moderate\n    - 2: Substantial\n    - 3: High\n    - 4: Unknown\n\nSee [definitions of CDC community transmission levels](\nhttps://covid.cdc.gov/covid-data-tracker/#cases_community) for more\ndetails.\n\nNote that the value may differ from what the CDC website reports\ngiven we have different data sources. We have also introduced an\n\"Unknown\" level for when both case data and test positivity data are\nmissing for at least 15 days. The CDC does not have an \"Unknown\"\nlevel and instead will designate a location as \"Low\" when case and\ntest positivity data are missing.\n",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CDCTransmissionLevel"
+            }
+          ]
+        }
+      },
+      "required": [
+        "date",
+        "cdcTransmissionLevel"
+      ]
+    },
     "RegionSummaryWithTimeseries": {
       "title": "RegionSummaryWithTimeseries",
       "description": "Summary data for a region with prediction timeseries data and actual timeseries data.",
@@ -1457,7 +1482,7 @@
           ]
         },
         "cdcTransmissionLevel": {
-          "description": "\nCDC community transmission level for region.\n\nPossible values:\n - 0: Low\n - 1: Moderate\n - 2: Substantial\n - 3: High\n - 4: Unknown\n\nSee [definitions of CDC community transmission levels](\nhttps://covid.cdc.gov/covid-data-tracker/#cases_community)\nfor more details.\n",
+          "description": "\nCommunity transmission level for region, calculated using the CDC definition.\n\nPossible values:\n    - 0: Low\n    - 1: Moderate\n    - 2: Substantial\n    - 3: High\n    - 4: Unknown\n\nSee [definitions of CDC community transmission levels](\nhttps://covid.cdc.gov/covid-data-tracker/#cases_community) for more\ndetails.\n\nNote that the value may differ from what the CDC website reports\ngiven we have different data sources. We have also introduced an\n\"Unknown\" level for when both case data and test positivity data are\nmissing for at least 15 days. The CDC does not have an \"Unknown\"\nlevel and instead will designate a location as \"Low\" when case and\ntest positivity data are missing.\n",
           "allOf": [
             {
               "$ref": "#/definitions/CDCTransmissionLevel"
@@ -1508,6 +1533,13 @@
           "items": {
             "$ref": "#/definitions/RiskLevelTimeseriesRow"
           }
+        },
+        "cdcTransmissionLevelTimeseries": {
+          "title": "Cdctransmissionleveltimeseries",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CdcTransmissionLevelTimeseriesRow"
+          }
         }
       },
       "required": [
@@ -1529,7 +1561,8 @@
         "url",
         "metricsTimeseries",
         "actualsTimeseries",
-        "riskLevelsTimeseries"
+        "riskLevelsTimeseries",
+        "cdcTransmissionLevelTimeseries"
       ]
     }
   }

--- a/api/schemas_v2/CdcTransmissionLevelRow.json
+++ b/api/schemas_v2/CdcTransmissionLevelRow.json
@@ -1,0 +1,31 @@
+{
+  "title": "CdcTransmissionLevelRow",
+  "description": "Base model for API output.",
+  "type": "object",
+  "properties": {
+    "cdcTransmissionLevel": {
+      "description": "\nCommunity transmission level for region, calculated using the CDC definition.\n\nPossible values:\n    - 0: Low\n    - 1: Moderate\n    - 2: Substantial\n    - 3: High\n    - 4: Unknown\n\nSee [definitions of CDC community transmission levels](\nhttps://covid.cdc.gov/covid-data-tracker/#cases_community) for more\ndetails.\n\nNote that the value may differ from what the CDC website reports\ngiven we have different data sources. We have also introduced an\n\"Unknown\" level for when both case data and test positivity data are\nmissing for at least 15 days. The CDC does not have an \"Unknown\"\nlevel and instead will designate a location as \"Low\" when case and\ntest positivity data are missing.\n",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CDCTransmissionLevel"
+        }
+      ]
+    }
+  },
+  "required": [
+    "cdcTransmissionLevel"
+  ],
+  "definitions": {
+    "CDCTransmissionLevel": {
+      "title": "CDCTransmissionLevel",
+      "description": "CDC community transmission level.",
+      "enum": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ]
+    }
+  }
+}

--- a/api/schemas_v2/CdcTransmissionLevelTimeseriesRow.json
+++ b/api/schemas_v2/CdcTransmissionLevelTimeseriesRow.json
@@ -1,0 +1,38 @@
+{
+  "title": "CdcTransmissionLevelTimeseriesRow",
+  "description": "Base model for API output.",
+  "type": "object",
+  "properties": {
+    "date": {
+      "title": "Date",
+      "description": "Date of timeseries data point",
+      "type": "string",
+      "format": "date"
+    },
+    "cdcTransmissionLevel": {
+      "description": "\nCommunity transmission level for region, calculated using the CDC definition.\n\nPossible values:\n    - 0: Low\n    - 1: Moderate\n    - 2: Substantial\n    - 3: High\n    - 4: Unknown\n\nSee [definitions of CDC community transmission levels](\nhttps://covid.cdc.gov/covid-data-tracker/#cases_community) for more\ndetails.\n\nNote that the value may differ from what the CDC website reports\ngiven we have different data sources. We have also introduced an\n\"Unknown\" level for when both case data and test positivity data are\nmissing for at least 15 days. The CDC does not have an \"Unknown\"\nlevel and instead will designate a location as \"Low\" when case and\ntest positivity data are missing.\n",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CDCTransmissionLevel"
+        }
+      ]
+    }
+  },
+  "required": [
+    "date",
+    "cdcTransmissionLevel"
+  ],
+  "definitions": {
+    "CDCTransmissionLevel": {
+      "title": "CDCTransmissionLevel",
+      "description": "CDC community transmission level.",
+      "enum": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ]
+    }
+  }
+}

--- a/api/schemas_v2/RegionSummary.json
+++ b/api/schemas_v2/RegionSummary.json
@@ -93,7 +93,7 @@
       ]
     },
     "cdcTransmissionLevel": {
-      "description": "\nCDC community transmission level for region.\n\nPossible values:\n - 0: Low\n - 1: Moderate\n - 2: Substantial\n - 3: High\n - 4: Unknown\n\nSee [definitions of CDC community transmission levels](\nhttps://covid.cdc.gov/covid-data-tracker/#cases_community)\nfor more details.\n",
+      "description": "\nCommunity transmission level for region, calculated using the CDC definition.\n\nPossible values:\n    - 0: Low\n    - 1: Moderate\n    - 2: Substantial\n    - 3: High\n    - 4: Unknown\n\nSee [definitions of CDC community transmission levels](\nhttps://covid.cdc.gov/covid-data-tracker/#cases_community) for more\ndetails.\n\nNote that the value may differ from what the CDC website reports\ngiven we have different data sources. We have also introduced an\n\"Unknown\" level for when both case data and test positivity data are\nmissing for at least 15 days. The CDC does not have an \"Unknown\"\nlevel and instead will designate a location as \"Low\" when case and\ntest positivity data are missing.\n",
       "allOf": [
         {
           "$ref": "#/definitions/CDCTransmissionLevel"

--- a/api/schemas_v2/RegionSummaryWithTimeseries.json
+++ b/api/schemas_v2/RegionSummaryWithTimeseries.json
@@ -93,7 +93,7 @@
       ]
     },
     "cdcTransmissionLevel": {
-      "description": "\nCDC community transmission level for region.\n\nPossible values:\n - 0: Low\n - 1: Moderate\n - 2: Substantial\n - 3: High\n - 4: Unknown\n\nSee [definitions of CDC community transmission levels](\nhttps://covid.cdc.gov/covid-data-tracker/#cases_community)\nfor more details.\n",
+      "description": "\nCommunity transmission level for region, calculated using the CDC definition.\n\nPossible values:\n    - 0: Low\n    - 1: Moderate\n    - 2: Substantial\n    - 3: High\n    - 4: Unknown\n\nSee [definitions of CDC community transmission levels](\nhttps://covid.cdc.gov/covid-data-tracker/#cases_community) for more\ndetails.\n\nNote that the value may differ from what the CDC website reports\ngiven we have different data sources. We have also introduced an\n\"Unknown\" level for when both case data and test positivity data are\nmissing for at least 15 days. The CDC does not have an \"Unknown\"\nlevel and instead will designate a location as \"Low\" when case and\ntest positivity data are missing.\n",
       "allOf": [
         {
           "$ref": "#/definitions/CDCTransmissionLevel"
@@ -144,6 +144,13 @@
       "items": {
         "$ref": "#/definitions/RiskLevelTimeseriesRow"
       }
+    },
+    "cdcTransmissionLevelTimeseries": {
+      "title": "Cdctransmissionleveltimeseries",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/CdcTransmissionLevelTimeseriesRow"
+      }
     }
   },
   "required": [
@@ -165,7 +172,8 @@
     "url",
     "metricsTimeseries",
     "actualsTimeseries",
-    "riskLevelsTimeseries"
+    "riskLevelsTimeseries",
+    "cdcTransmissionLevelTimeseries"
   ],
   "definitions": {
     "AggregationLevel": {
@@ -1522,6 +1530,31 @@
         "overall",
         "caseDensity",
         "date"
+      ]
+    },
+    "CdcTransmissionLevelTimeseriesRow": {
+      "title": "CdcTransmissionLevelTimeseriesRow",
+      "description": "Base model for API output.",
+      "type": "object",
+      "properties": {
+        "date": {
+          "title": "Date",
+          "description": "Date of timeseries data point",
+          "type": "string",
+          "format": "date"
+        },
+        "cdcTransmissionLevel": {
+          "description": "\nCommunity transmission level for region, calculated using the CDC definition.\n\nPossible values:\n    - 0: Low\n    - 1: Moderate\n    - 2: Substantial\n    - 3: High\n    - 4: Unknown\n\nSee [definitions of CDC community transmission levels](\nhttps://covid.cdc.gov/covid-data-tracker/#cases_community) for more\ndetails.\n\nNote that the value may differ from what the CDC website reports\ngiven we have different data sources. We have also introduced an\n\"Unknown\" level for when both case data and test positivity data are\nmissing for at least 15 days. The CDC does not have an \"Unknown\"\nlevel and instead will designate a location as \"Low\" when case and\ntest positivity data are missing.\n",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CDCTransmissionLevel"
+            }
+          ]
+        }
+      },
+      "required": [
+        "date",
+        "cdcTransmissionLevel"
       ]
     }
   }

--- a/api/schemas_v2/RegionTimeseriesRowWithHeader.json
+++ b/api/schemas_v2/RegionTimeseriesRowWithHeader.json
@@ -98,6 +98,14 @@
           "$ref": "#/definitions/RiskLevelsRow"
         }
       ]
+    },
+    "cdcTransmissionLevel": {
+      "description": "\nCommunity transmission level for region, calculated using the CDC definition.\n\nPossible values:\n    - 0: Low\n    - 1: Moderate\n    - 2: Substantial\n    - 3: High\n    - 4: Unknown\n\nSee [definitions of CDC community transmission levels](\nhttps://covid.cdc.gov/covid-data-tracker/#cases_community) for more\ndetails.\n\nNote that the value may differ from what the CDC website reports\ngiven we have different data sources. We have also introduced an\n\"Unknown\" level for when both case data and test positivity data are\nmissing for at least 15 days. The CDC does not have an \"Unknown\"\nlevel and instead will designate a location as \"Low\" when case and\ntest positivity data are missing.\n",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CDCTransmissionLevel"
+        }
+      ]
     }
   },
   "required": [
@@ -111,7 +119,8 @@
     "locationId",
     "actuals",
     "metrics",
-    "riskLevels"
+    "riskLevels",
+    "cdcTransmissionLevel"
   ],
   "definitions": {
     "HospitalResourceUtilization": {
@@ -690,6 +699,17 @@
       "required": [
         "overall",
         "caseDensity"
+      ]
+    },
+    "CDCTransmissionLevel": {
+      "title": "CDCTransmissionLevel",
+      "description": "CDC community transmission level.",
+      "enum": [
+        0,
+        1,
+        2,
+        3,
+        4
       ]
     }
   }

--- a/libs/build_api_v2.py
+++ b/libs/build_api_v2.py
@@ -13,7 +13,6 @@ from api.can_api_v2_definition import (
     DemographicDistributions,
     Metrics,
     RiskLevels,
-    RiskLevelsRow,
     CDCTransmissionLevel,
     RegionSummary,
     RegionSummaryWithTimeseries,
@@ -328,18 +327,11 @@ def build_bulk_flattened_timeseries(
         }
         dates = sorted({*metrics_by_date.keys(), *actuals_by_date.keys()})
         for date in dates:
-            risk_levels = risk_levels_by_date.get(date)
-            risk_levels_row = None
-            if risk_levels:
-                risk_levels_row = RiskLevelsRow(
-                    overall=risk_levels.overall, caseDensity=risk_levels.caseDensity
-                )
-
             data = {
                 "date": date,
                 "actuals": actuals_by_date.get(date),
                 "metrics": metrics_by_date.get(date),
-                "riskLevels": risk_levels_row,
+                "riskLevels": risk_levels_by_date.get(date),
                 "cdcTransmissionLevel": cdc_transmission_levels_by_date.get(
                     date
                 ).cdcTransmissionLevel,

--- a/libs/metrics/cdc_transmission_levels.py
+++ b/libs/metrics/cdc_transmission_levels.py
@@ -41,7 +41,7 @@ def calc_transmission_level(value: Optional[float], thresholds: List[float]) -> 
     return TransmissionLevel.HIGH
 
 
-def case_density_transmission_level(value: float) -> TransmissionLevel:
+def case_density_transmission_level(value: Optional[float]) -> TransmissionLevel:
     # CDC thresholds are number of cases over a 7 day average. Our case density
     # metrics are cases over a 7 day average.  To square the two, we should divide
     # CDC thresholds by 7 to get the equivalent threshold for our 7-day averages.
@@ -49,7 +49,7 @@ def case_density_transmission_level(value: float) -> TransmissionLevel:
     return calc_transmission_level(value, thresholds)
 
 
-def test_positivity_transmission_level(value: float) -> TransmissionLevel:
+def test_positivity_transmission_level(value: Optional[float]) -> TransmissionLevel:
     thresholds = [0.05, 0.08, 0.10]
     return calc_transmission_level(value, thresholds)
 
@@ -82,7 +82,7 @@ def overall_transmission_level(
 
 
 def calculate_transmission_level(
-    case_density: float, test_positivity_ratio: float
+    case_density: Optional[float], test_positivity_ratio: Optional[float]
 ) -> can_api_v2_definition.CDCTransmissionLevel:
     case_density_level = case_density_transmission_level(case_density)
     test_positivity_level = test_positivity_transmission_level(test_positivity_ratio)
@@ -110,7 +110,7 @@ def calculate_transmission_level_timeseries(
     metrics_df = metrics_df.copy()
     metrics_df = metrics_df.set_index([CommonFields.DATE, CommonFields.FIPS])
 
-    # We use the last available data within `MAX_METRIC_LOOKBACK_DAYS` to cacluate
+    # We use the last available data within `MAX_METRIC_LOOKBACK_DAYS` to calculate
     # the cdc_transmission_level. Propagate the last value forward that many
     # days so calculation for a given day is the same as
     # `top_level_metrics.calculate_latest_metrics`

--- a/libs/pipelines/api_v2_pipeline.py
+++ b/libs/pipelines/api_v2_pipeline.py
@@ -141,14 +141,23 @@ def build_timeseries_for_region(
             metrics_results
         )
         risk_levels = top_level_metric_risk_levels.calculate_risk_level_from_metrics(metrics_latest)
+
+        cdc_transmission_level_timeseries = cdc_transmission_levels.calculate_transmission_level_timeseries(
+            metrics_results
+        )
         cdc_transmission_level = cdc_transmission_levels.calculate_transmission_level_from_metrics(
             metrics_latest
         )
+
         region_summary = build_api_v2.build_region_summary(
             regional_input.timeseries, metrics_latest, risk_levels, cdc_transmission_level, log
         )
         region_timeseries = build_api_v2.build_region_timeseries(
-            region_summary, fips_timeseries, metrics_results, risk_timeseries,
+            region_summary,
+            fips_timeseries,
+            metrics_results,
+            risk_timeseries,
+            cdc_transmission_level_timeseries,
         )
     except Exception:
         log.exception(f"Failed to build timeseries for fips.")

--- a/libs/pipelines/csv_column_ordering.py
+++ b/libs/pipelines/csv_column_ordering.py
@@ -159,4 +159,5 @@ TIMESERIES_ORDER = [
     "actuals.newDeaths",
     "actuals.vaccinesAdministered",
     "riskLevels.caseDensity",
+    "cdcTransmissionLevel",
 ]

--- a/tests/libs/build_api_v2_test.py
+++ b/tests/libs/build_api_v2_test.py
@@ -184,12 +184,19 @@ def test_generate_timeseries_for_fips(nyc_region, nyc_rt_dataset):
     transmission_level = cdc_transmission_levels.calculate_transmission_level_from_metrics(
         latest_metric
     )
+    transmission_level_timeseries = cdc_transmission_levels.calculate_transmission_level_timeseries(
+        metrics_series
+    )
 
     region_summary = build_api_v2.build_region_summary(
         nyc_timeseries, latest_metric, risk_levels, transmission_level, log
     )
     region_timeseries = build_api_v2.build_region_timeseries(
-        region_summary, nyc_timeseries, metrics_series, risk_timeseries
+        region_summary,
+        nyc_timeseries,
+        metrics_series,
+        risk_timeseries,
+        transmission_level_timeseries,
     )
 
     # Test vaccination fields aren't in before start date


### PR DESCRIPTION
This adds cdcTransmissionLevel timeseries data to the JSON and CSV api endpoints.  In JSON it shows up as:

```
"cdcTransmissionLevelTimeseries": [
  {
    "date": "2020-01-14"
    "cdcTransmissionLevel": 0,
  },
  ...
}
```

In the CSV timeseries files it shows up as a new `csvTransmissionLevel` column.

In general I modeled the code off of the existing code for `riskLevelsTimeseries`.

Snapshot 2249 was built with these changes. Example endpoints with the new data:
* https://data.covidactnow.org/snapshot/2249/v2/state/WA.timeseries.json
* https://data.covidactnow.org/snapshot/2249/v2/state/WA.timeseries.csv

