### PR TITLE
Regenerate test combined datasets data (and fix tests).

### DIFF
--- a/tests/data/test-combined-static.csv
+++ b/tests/data/test-combined-static.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cf0caaa5e899f35f460933f9fae419412114336dd743e16de4c40ac618353539
-size 27933
+oid sha256:48e7d3ad18ea92a58bf1bb38ca4e6be7806183b0370f3da7f58d2ef824f1d3a6
+size 28470

--- a/tests/data/test-combined-wide-dates.csv
+++ b/tests/data/test-combined-wide-dates.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:efd80b67a20618cdc9ded8590b0af1640f06433dae064652a9215703b46ec914
-size 1433183
+oid sha256:bcc24a3a80306ae1a430cf46d0d867e6f2702a3d38ee42eee9825193dc13027e
+size 2319203

--- a/tests/libs/build_api_v2_test.py
+++ b/tests/libs/build_api_v2_test.py
@@ -62,6 +62,11 @@ def test_build_summary_for_fips(
         type=FieldSourceType.OTHER,
         url="https://healthdata.gov/Hospital/COVID-19-Reported-Patient-Impact-and-Hospital-Capa/anag-cw7u",
     )
+    field_source_cdcvaccine = FieldSource(
+        name="Centers for Disease Control and Prevention",
+        type=FieldSourceType.OTHER,
+        url="https://data.cdc.gov/Vaccinations/COVID-19-Vaccinations-in-the-United-States-County/8xkx-amqh",
+    )
     expected = RegionSummary(
         population=nyc_latest["population"],
         state="NY",
@@ -111,13 +116,13 @@ def test_build_summary_for_fips(
             newDeaths=FieldAnnotations(
                 anomalies=[
                     {
-                        "date": datetime.date(2020, 4, 14),
-                        "original_observation": 345.0,
+                        "date": datetime.date(2021, 3, 13),
+                        "original_observation": 110.0,
                         "type": "zscore_outlier",
                     },
                     {
-                        "date": datetime.date(2020, 12, 28),
-                        "original_observation": 49.0,
+                        "date": datetime.date(2021, 4, 9),
+                        "original_observation": 182.0,
                         "type": "zscore_outlier",
                     },
                 ],
@@ -139,24 +144,10 @@ def test_build_summary_for_fips(
                 ],
             ),
             vaccinationsCompleted=FieldAnnotations(
-                sources=[
-                    FieldSource(
-                        name="New York State Department of Health",
-                        type=FieldSourceType.CANScrapersStateProviders,
-                        url="https://covid19vaccine.health.ny.gov/covid-19-vaccine-tracker",
-                    )
-                ],
-                anomalies=[],
+                sources=[field_source_cdcvaccine], anomalies=[],
             ),
             vaccinationsInitiated=FieldAnnotations(
-                sources=[
-                    FieldSource(
-                        name="New York State Department of Health",
-                        type=FieldSourceType.CANScrapersStateProviders,
-                        url="https://covid19vaccine.health.ny.gov/covid-19-vaccine-tracker",
-                    )
-                ],
-                anomalies=[],
+                sources=[field_source_cdcvaccine], anomalies=[],
             ),
             caseDensity=FieldAnnotations(sources=[field_source_usafacts], anomalies=[],),
             icuCapacityRatio=FieldAnnotations(sources=[field_source_hhshospital], anomalies=[]),

--- a/tests/libs/datasets/timeseries_test.py
+++ b/tests/libs/datasets/timeseries_test.py
@@ -2104,7 +2104,7 @@ def test_pickle_test_dataset_size(tmp_path: pathlib.Path):
     test_dataset = test_helpers.load_test_dataset()
     test_dataset.get_timeseries_not_bucketed_wide_dates(CommonFields.CASES)
     test_dataset.to_compressed_pickle(pkl_path)
-    assert pkl_path.stat().st_size < 480_000
+    assert pkl_path.stat().st_size < 800_000
 
     loaded_dataset = timeseries.MultiRegionDataset.from_compressed_pickle(pkl_path)
 


### PR DESCRIPTION
This is the result of running `./run.py data update-test-combined-data` to update our test combined datasets file (basically just a subset of the full one to make it easier for tests to load) now that we have staffed_beds in it.  But getting new data required me to update some tests.