### PR TITLE
remove ND from CDC exclusion list

### DIFF
--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -177,10 +177,6 @@ CDCVaccinesStatesAndNationDataset = datasource_regions(
 )
 
 CDC_COUNTY_EXCLUSIONS = [
-    # Glacier County, MT - reports 99.9% of 12+ population vaccinated [7/2021]
-    Region.from_fips("30035"),
-    # Santa Cruz County, AZ - reports 99.9% of 12+ population vaccinated [7/2021]
-    Region.from_fips("04023"),
     # Arecibo Municipio, PR - reports 99.9% of 12+ population vaccinated [7/2021]
     Region.from_fips("72013"),
     # Bristol Bay Borough, AK - reports 99.9% of 12+ population vaccinated [7/2021]
@@ -198,10 +194,6 @@ CDC_STATE_EXCLUSIONS = RegionMask(
         "GA",
         "IL",
         "NM",
-        "ND",
-        # PA - Data irregularities including very high rates in several counties
-        # (e.g. Montgomery, Chester)
-        "PA",
         # SD - Missing a lot of counties and 1st dose data.
         "SD",
         # VA - Very low coverage.

--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -177,6 +177,10 @@ CDCVaccinesStatesAndNationDataset = datasource_regions(
 )
 
 CDC_COUNTY_EXCLUSIONS = [
+    # Glacier County, MT - reports 99.9% of 12+ population vaccinated [7/2021]
+    Region.from_fips("30035"),
+    # Santa Cruz County, AZ - reports 99.9% of 12+ population vaccinated [7/2021]
+    Region.from_fips("04023"),
     # Arecibo Municipio, PR - reports 99.9% of 12+ population vaccinated [7/2021]
     Region.from_fips("72013"),
     # Bristol Bay Borough, AK - reports 99.9% of 12+ population vaccinated [7/2021]

--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -194,6 +194,9 @@ CDC_STATE_EXCLUSIONS = RegionMask(
         "GA",
         "IL",
         "NM",
+        # PA - Data irregularities including very high rates in several counties
+        # (e.g. Montgomery, Chester)
+        "PA",
         # SD - Missing a lot of counties and 1st dose data.
         "SD",
         # VA - Very low coverage.


### PR DESCRIPTION
This removes ND from the exclusion list such that the pipeline will now use CDC data. 

It looks like the ND scraper was previously collecting `% of 12+ population vaccinated` as `% of total population vaccinated` causing our data to be inflated. 

For example Cass County has a population of 185,181,  and is [reporting 104,220 people with at least one dose](https://www.health.nd.gov/covid19vaccine/dashboard): `104,220 / 185,181 = 0.56`, which fairly closely lines up with the [CDC's reported value](https://data.cdc.gov/Vaccinations/COVID-19-Vaccinations-in-the-United-States-County/8xkx-amqh/data) of 54%. Previously we were reporting over 60% (we we're multiplying the `12 and older at least one dose` percentage by the total population). 


I think it makes sense to:
- delete the incorrect historical data
- switch to the CDC source such that we surface the historical data (and because that data appears to be of good/fair quality)

---
screenshot of Cass County dashboard:
![image](https://user-images.githubusercontent.com/55333380/133511336-54d3bb9c-f8fe-40cc-a6d7-7b783d625165.png)

