### PR TITLE
Relabel unused columns to be unique.

### DIFF
--- a/libs/pipelines/api_v2_pipeline.py
+++ b/libs/pipelines/api_v2_pipeline.py
@@ -267,13 +267,6 @@ def _model_to_dict(data: dict):
         if isinstance(value, pydantic.BaseModel):
             value = _model_to_dict(value.__dict__)
 
-            # When converting API model objects to dicts, we always add an
-            # "unused" entry to the dict. This allows us to use "unused" as a
-            # column in our CSV output to have a blank column. This is handy
-            # since when we remove an API column we replace it with "unused" to
-            # preserve column ordering).
-            results["unused"] = None
-
         if isinstance(value, list):
             values = []
             for item in value:

--- a/libs/pipelines/csv_column_ordering.py
+++ b/libs/pipelines/csv_column_ordering.py
@@ -24,11 +24,11 @@ SUMMARY_ORDER = [
     "metrics.infectionRateCI90",
     # UPDATE(2021/09/14): ICU Headroom columns have been removed from the API and replaced with
     # "unused" columns.
-    "unused",
-    "unused",
-    "unused",
-    "unused",
-    "unused",
+    "unused1",
+    "unused2",
+    "unused3",
+    "unused4",
+    "unused5",
     "metrics.icuCapacityRatio",
     "riskLevels.overall",
     "riskLevels.testPositivityRatio",
@@ -37,7 +37,7 @@ SUMMARY_ORDER = [
     "riskLevels.infectionRate",
     # UPDATE(2021/09/14): ICU Headroom columns have been removed from the API and replaced with
     # "unused" columns.
-    "unused",
+    "unused6",
     "riskLevels.icuCapacityRatio",
     "actuals.cases",
     "actuals.deaths",
@@ -49,13 +49,13 @@ SUMMARY_ORDER = [
     "actuals.hospitalBeds.currentUsageCovid",
     # UPDATE(2021/09/14): Typical Usage columns have been removed from the API and replaced with
     # "unused" columns.
-    "unused",
+    "unused7",
     "actuals.icuBeds.capacity",
     "actuals.icuBeds.currentUsageTotal",
     "actuals.icuBeds.currentUsageCovid",
     # UPDATE(2021/09/14): Typical Usage columns have been removed from the API and replaced with
     # "unused" columns.
-    "unused",
+    "unused8",
     "actuals.newCases",
     "actuals.vaccinesDistributed",
     "actuals.vaccinationsInitiated",
@@ -91,8 +91,8 @@ SUMMARY_ORDER_NO_HEADROOM_DETAILS = [
     "metrics.infectionRateCI90",
     # UPDATE(2021/09/14): ICU Headroom columns have been removed from the API and replaced with
     # "unused" columns.
-    "unused",
-    "unused",
+    "unused1",
+    "unused2",
     "metrics.icuCapacityRatio",
     "riskLevels.overall",
     "riskLevels.testPositivityRatio",
@@ -101,7 +101,7 @@ SUMMARY_ORDER_NO_HEADROOM_DETAILS = [
     "riskLevels.infectionRate",
     # UPDATE(2021/09/14): ICU Headroom columns have been removed from the API and replaced with
     # "unused" columns.
-    "unused",
+    "unused3",
     "riskLevels.icuCapacityRatio",
     "actuals.cases",
     "actuals.deaths",
@@ -113,13 +113,13 @@ SUMMARY_ORDER_NO_HEADROOM_DETAILS = [
     "actuals.hospitalBeds.currentUsageCovid",
     # UPDATE(2021/09/14): Typical usage columns have been removed from the API and replaced with
     # "unused" columns.
-    "unused",
+    "unused4",
     "actuals.icuBeds.capacity",
     "actuals.icuBeds.currentUsageTotal",
     "actuals.icuBeds.currentUsageCovid",
     # UPDATE(2021/09/14): Typical usage columns have been removed from the API and replaced with
     # "unused" columns.
-    "unused",
+    "unused5",
     "actuals.newCases",
     "actuals.vaccinesDistributed",
     "actuals.vaccinationsInitiated",
@@ -153,13 +153,13 @@ TIMESERIES_ORDER = [
     "actuals.hospitalBeds.currentUsageCovid",
     # UPDATE(2021/09/14): Typical usage columns have been removed from the API and replaced with
     # "unused" columns.
-    "unused",
+    "unused1",
     "actuals.icuBeds.capacity",
     "actuals.icuBeds.currentUsageTotal",
     "actuals.icuBeds.currentUsageCovid",
     # UPDATE(2021/09/14): Typical usage columns have been removed from the API and replaced with
     # "unused" columns.
-    "unused",
+    "unused2",
     "actuals.newCases",
     "actuals.vaccinesDistributed",
     "actuals.vaccinationsInitiated",
@@ -172,8 +172,8 @@ TIMESERIES_ORDER = [
     "metrics.infectionRateCI90",
     # UPDATE(2021/09/14): ICU Headroom columns have been removed from the API and replaced with
     # "unused" columns.
-    "unused",
-    "unused",
+    "unused3",
+    "unused4",
     "metrics.icuCapacityRatio",
     "riskLevels.overall",
     "metrics.vaccinationsInitiatedRatio",

--- a/tests/libs/csv_column_names_test.py
+++ b/tests/libs/csv_column_names_test.py
@@ -43,4 +43,8 @@ def test_csv_columns_match(schema, csv_columns):
     ],
 )
 def test_csv_columns_for_duplicates(csv_columns: List[str]):
+    """
+    Verify CSV files don't have duplicate columns. We got complaints from API users when we
+    temporarily had multiple 'unused' columns.
+    """
     assert len(csv_columns) == len(set(csv_columns))

--- a/tests/libs/csv_column_names_test.py
+++ b/tests/libs/csv_column_names_test.py
@@ -29,5 +29,18 @@ def _build_schema_names(schema: pydantic.BaseModel) -> List[str]:
 )
 def test_csv_columns_match(schema, csv_columns):
     columns = set(csv_columns)
-    possible_names = _build_schema_names(schema) + ["unused"]
+    columns = {x for x in columns if not x.startswith("unused")}
+    possible_names = _build_schema_names(schema)
     assert not columns.difference(possible_names)
+
+
+@pytest.mark.parametrize(
+    "csv_columns",
+    [
+        csv_column_ordering.SUMMARY_ORDER,
+        csv_column_ordering.TIMESERIES_ORDER,
+        csv_column_ordering.TIMESERIES_ORDER,
+    ],
+)
+def test_csv_columns_for_duplicates(csv_columns: List[str]):
+    assert len(csv_columns) == len(set(csv_columns))


### PR DESCRIPTION
Addresses the concern a couple API users have expressed about "unused" API columns being duplicated.