### PR TITLE
Use NYT anomalies to filter daily new cases and deaths.

### DIFF
--- a/cli/data.py
+++ b/cli/data.py
@@ -15,6 +15,7 @@ from covidactnow.datapublic.common_fields import FieldName
 from libs import google_sheet_helpers
 from libs import pipeline
 from libs.datasets import combined_dataset_utils
+from libs.datasets import nytimes_anomalies
 from libs.datasets import custom_aggregations
 from libs.datasets import manual_filter
 from libs.datasets import statistical_areas
@@ -166,6 +167,10 @@ def update(
     multiregion_dataset = new_cases_and_deaths.add_new_deaths(multiregion_dataset)
     if print_stats:
         multiregion_dataset.print_stats("new_cases_and_deaths")
+
+    multiregion_dataset = nytimes_anomalies.filter_by_nyt_anomalies(multiregion_dataset)
+    if print_stats:
+        multiregion_dataset.print_stats("nytimes_anomalies")
 
     multiregion_dataset = outlier_detection.drop_new_case_outliers(multiregion_dataset)
     multiregion_dataset = outlier_detection.drop_new_deaths_outliers(multiregion_dataset)

--- a/libs/datasets/nytimes_anomalies.py
+++ b/libs/datasets/nytimes_anomalies.py
@@ -1,0 +1,179 @@
+import enum
+from functools import lru_cache
+from typing import List
+import dataclasses
+import pathlib
+
+import pandas as pd
+import numpy as np
+from covidactnow.datapublic.common_fields import CommonFields
+from covidactnow.datapublic.common_fields import FieldName
+from covidactnow.datapublic.common_fields import GetByValueMixin
+from covidactnow.datapublic.common_fields import ValueAsStrMixin
+from covidactnow.datapublic.common_fields import PdFields
+
+from libs.datasets import taglib
+from libs.datasets import timeseries
+from libs.datasets import dataset_utils
+
+MultiRegionDataset = timeseries.MultiRegionDataset
+
+
+NYTIMES_ANOMALIES_CSV = dataset_utils.LOCAL_PUBLIC_DATA_PATH / pathlib.Path(
+    "data/cases-nytimes/anomalies.csv"
+)
+
+
+@enum.unique
+class NYTimesFields(GetByValueMixin, ValueAsStrMixin, FieldName, enum.Enum):
+    """Fields used in the NYTimes anomalies file"""
+
+    DATE = "date"
+    END_DATE = "end_date"
+    COUNTY = "county"
+    STATE = "state"
+    GEOID = "geoid"
+    TYPE = "type"
+    OMIT_FROM_ROLLING_AVERAGE = "omit_from_rolling_average"
+    OMIT_FROM_ROLLING_AVERAGE_ON_SUBGEOGRAPHIES = "omit_from_rolling_average_on_subgeographies"
+    DESCRIPTION = "description"
+
+
+@lru_cache(None)
+def read_nytimes_anomalies():
+    df = pd.read_csv(
+        NYTIMES_ANOMALIES_CSV, parse_dates=[NYTimesFields.DATE, NYTimesFields.END_DATE]
+    )
+
+    # Extract fips from geoid column.
+    df[CommonFields.FIPS] = df[NYTimesFields.GEOID].str.replace("USA-", "")
+
+    # Denormalize data so that each row represents a single date+location+metric anomaly
+    df = _denormalize_nyt_anomalies(df)
+
+    # Add LOCATION_ID column (must happen after denormalizing since denormalizing can add additional
+    # rows for subgeographies).
+    df[CommonFields.LOCATION_ID] = df[CommonFields.FIPS].map(dataset_utils.get_fips_to_location())
+
+    # A few locations (e.g. NYC aggregated FIPS 36998) don't have location IDs. That's okay, just remove them.
+    df = df.loc[df[CommonFields.LOCATION_ID].notna()]
+
+    # Convert "type" column into "variable" column using new_cases / new_deaths as the variable.
+    assert df[NYTimesFields.TYPE].isin(["cases", "deaths"]).all()
+    df[PdFields.VARIABLE] = df[NYTimesFields.TYPE].map(
+        {"cases": CommonFields.NEW_CASES, "deaths": CommonFields.NEW_DEATHS}
+    )
+
+    # Add demographic bucket (all) to make it more compatible with our dataset structure.
+    df[PdFields.DEMOGRAPHIC_BUCKET] = "all"
+
+    return df
+
+
+# TODO(mikelehen): This should probably live somewhere more central, but I'm not sure where.
+def _get_county_fips_codes_for_state(state_fips_code: str) -> List[str]:
+    """Helper to get county FIPS codes for all counties in a given state."""
+    geo_data = dataset_utils.get_geo_data()
+    state = geo_data.set_index("fips").at[state_fips_code, "state"]
+    counties_df = geo_data.loc[
+        (geo_data["state"] == state) & (geo_data["aggregate_level"] == "county")
+    ]
+    counties_fips = counties_df["fips"].to_list()
+    return counties_fips
+
+
+def _denormalize_nyt_anomalies(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    The NYT anomaly data is normalized such that each row can represent an
+    anomaly for multiple dates, locations, and metrics. We want to denormalize
+    it so that each row represents a single date+location+metric anomaly.
+    """
+
+    # Look for rows with an end_date and create separate rows for each date in the [date, end_date] range.
+    df = df.assign(
+        date=df.apply(
+            lambda row: pd.date_range(
+                row[NYTimesFields.DATE],
+                row[NYTimesFields.DATE]
+                if pd.isna(row[NYTimesFields.END_DATE])
+                else row[NYTimesFields.END_DATE],
+                freq="d",
+            ),
+            axis=1,
+        ),
+        end_date=pd.NaT,
+    ).explode(NYTimesFields.DATE)
+
+    # Look for state rows with omit_from_rolling_average_on_subgeographies and add new rows for each county within the state
+    omit_subgeographies_mask = (
+        df[NYTimesFields.OMIT_FROM_ROLLING_AVERAGE_ON_SUBGEOGRAPHIES] == "yes"
+    ) & (df[CommonFields.FIPS].str.len() == 2)
+    df_subgeography_rows = df.loc[omit_subgeographies_mask].copy()
+    df_subgeography_rows = df_subgeography_rows.assign(
+        fips=df_subgeography_rows.apply(
+            lambda row: _get_county_fips_codes_for_state(row[CommonFields.FIPS]), axis=1
+        ),
+        omit_from_rolling_average="yes",
+    ).explode(CommonFields.FIPS)
+    df = df.append(df_subgeography_rows)
+
+    # Look for rows with type=='both' and replace with two rows ('cases' and 'deaths')
+    df = df.assign(
+        type=df.apply(
+            lambda row: ["cases", "deaths"]
+            if row[NYTimesFields.TYPE] == "both"
+            else row[NYTimesFields.TYPE],
+            axis=1,
+        )
+    ).explode(NYTimesFields.TYPE)
+
+    return df.reset_index()
+
+
+def filter_by_nyt_anomalies(dataset) -> MultiRegionDataset:
+    """
+    Applies NYT anomalies data, dropping case and death data marked with omit_from_rolling_average
+    and tagging all anomalies.
+    """
+    nyt_anomalies = read_nytimes_anomalies()
+
+    new_tags = taglib.TagCollection()
+    timeseries_copy = dataset.timeseries_bucketed.copy()
+
+    # Find the applicable anomalies by intersecting indexes.
+    assert timeseries_copy.index.names == [
+        CommonFields.LOCATION_ID,
+        PdFields.DEMOGRAPHIC_BUCKET,
+        CommonFields.DATE,
+    ]
+    nyt_anomalies_indexed = nyt_anomalies.set_index(
+        [CommonFields.LOCATION_ID, PdFields.DEMOGRAPHIC_BUCKET, CommonFields.DATE,]
+    )
+    overlapping_index = timeseries_copy.index.intersection(nyt_anomalies_indexed.index)
+    if overlapping_index.size == 0:
+        return dataset
+
+    # Get the applicable anomalies.
+    applicable_nyt_anomalies = nyt_anomalies_indexed.loc[overlapping_index].reset_index()
+
+    for index, row in applicable_nyt_anomalies.iterrows():
+        if row[NYTimesFields.OMIT_FROM_ROLLING_AVERAGE] == "yes":
+            location_id = row[CommonFields.LOCATION_ID]
+            bucket = row[PdFields.DEMOGRAPHIC_BUCKET]
+            date = row[NYTimesFields.DATE]
+            description = "NYTimes: {}".format(row["description"])
+            variable = row[PdFields.VARIABLE]
+            assert location_id and bucket and date and description and variable
+
+            new_tags.add(
+                taglib.KnownIssue(public_note=description, date=date.date()),
+                location_id=location_id,
+                variable=variable,
+                bucket=bucket,
+            )
+            timeseries_copy.at[(location_id, bucket, date), variable] = np.nan
+
+    # Return dataset with filtered timeseries.
+    return dataclasses.replace(dataset, timeseries_bucketed=timeseries_copy).append_tag_df(
+        new_tags.as_dataframe()
+    )

--- a/tests/libs/datasets/nytimes_anomalies_test.py
+++ b/tests/libs/datasets/nytimes_anomalies_test.py
@@ -9,7 +9,8 @@ from libs.pipeline import Region
 
 
 def test_read_nytimes_anomalies():
-    nytimes_anomalies.read_nytimes_anomalies()
+    anomalies = nytimes_anomalies.read_nytimes_anomalies()
+    assert anomalies.size > 0
 
 
 def test_filter_nytimes_anomalies_expand_subgeographies():

--- a/tests/libs/datasets/nytimes_anomalies_test.py
+++ b/tests/libs/datasets/nytimes_anomalies_test.py
@@ -1,0 +1,123 @@
+import numpy as np
+from covidactnow.datapublic.common_fields import CommonFields
+
+from tests import test_helpers
+from tests.test_helpers import TimeseriesLiteral
+from libs.datasets import nytimes_anomalies
+from libs.datasets.taglib import TagType
+from libs.pipeline import Region
+
+
+def test_read_nytimes_anomalies():
+    nytimes_anomalies.read_nytimes_anomalies()
+
+
+def test_filter_nytimes_anomalies_expand_subgeographies():
+    # Test that this anomaly applies to WI counties but not the state.
+    # 2020-09-04,,,Wisconsin,USA-55,cases,,yes,Wisconsin began reporting probable cases at the county level.
+
+    region_wi = Region.from_state("WI")
+    region_milwaukee = Region.from_fips("55079")
+
+    ds_in = test_helpers.build_dataset(
+        {
+            region_wi: {CommonFields.NEW_CASES: [1.0, 2.0, 3.0]},
+            region_milwaukee: {CommonFields.NEW_CASES: [4.0, 5.0, 6.0]},
+        },
+        start_date="2020-09-03",
+    )
+
+    expected_tag = test_helpers.make_tag(
+        TagType.KNOWN_ISSUE,
+        date="2020-09-04",
+        public_note="NYTimes: Wisconsin began reporting probable cases at the county level.",
+    )
+    ds_expected = test_helpers.build_dataset(
+        {
+            region_wi: {CommonFields.NEW_CASES: [1.0, 2.0, 3.0]},
+            region_milwaukee: {
+                CommonFields.NEW_CASES: TimeseriesLiteral(
+                    [4.0, np.nan, 6.0], annotation=[expected_tag]
+                )
+            },
+        },
+        start_date="2020-09-03",
+    )
+
+    ds_out = nytimes_anomalies.filter_by_nyt_anomalies(ds_in)
+    test_helpers.assert_dataset_like(ds_out, ds_expected, drop_na_dates=True)
+
+
+def test_filter_nytimes_anomalies_deaths_expand_dates():
+    # Test that this anomaly applies to OH dates within range.
+    # 2021-03-05,2021-03-08,,Ohio,USA-39,deaths,yes,,Ohio added more than 400 deaths of residents who died out of state.
+
+    region_oh = Region.from_state("OH")
+
+    ds_in = test_helpers.build_dataset(
+        {region_oh: {CommonFields.NEW_DEATHS: [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]},},
+        start_date="2021-03-04",
+    )
+
+    expected_tags = [
+        test_helpers.make_tag(
+            TagType.KNOWN_ISSUE,
+            date=date,
+            public_note="NYTimes: Ohio added more than 400 deaths of residents who died out of state.",
+        )
+        for date in ["2021-03-05", "2021-03-06", "2021-03-07", "2021-03-08"]
+    ]
+
+    ds_expected = test_helpers.build_dataset(
+        {
+            region_oh: {
+                CommonFields.NEW_DEATHS: TimeseriesLiteral(
+                    [1.0, np.nan, np.nan, np.nan, np.nan, 6.0], annotation=expected_tags
+                )
+            }
+        },
+        start_date="2021-03-04",
+    )
+
+    ds_out = nytimes_anomalies.filter_by_nyt_anomalies(ds_in)
+    test_helpers.assert_dataset_like(ds_out, ds_expected, drop_na_dates=True)
+
+
+def test_filter_nytimes_anomalies_deaths_expand_both_to_cases_and_deaths():
+    # Test that this anomaly applies to both cases and deaths in MI.
+    # 2020-06-01,,,Michigan,USA-26,both,yes,,The Times began including probable cases and deaths reported by Michigan's county and regional health districts.
+
+    region_mi = Region.from_state("MI")
+
+    ds_in = test_helpers.build_dataset(
+        {
+            region_mi: {
+                CommonFields.NEW_CASES: [1.0, 2.0, 3.0],
+                CommonFields.NEW_DEATHS: [4.0, 5.0, 6.0],
+            }
+        },
+        start_date="2020-05-31",
+    )
+
+    expected_tag = test_helpers.make_tag(
+        TagType.KNOWN_ISSUE,
+        date="2020-06-01",
+        public_note="NYTimes: The Times began including probable cases and deaths reported by Michigan's county and regional health districts.",
+    )
+
+    ds_expected = test_helpers.build_dataset(
+        {
+            region_mi: {
+                CommonFields.NEW_CASES: TimeseriesLiteral(
+                    [1.0, np.nan, 3.0], annotation=[expected_tag]
+                ),
+                CommonFields.NEW_DEATHS: TimeseriesLiteral(
+                    [4.0, np.nan, 6.0], annotation=[expected_tag]
+                ),
+            }
+        },
+        start_date="2020-05-31",
+    )
+
+    ds_out = nytimes_anomalies.filter_by_nyt_anomalies(ds_in)
+    test_helpers.assert_dataset_like(ds_out, ds_expected, drop_na_dates=True)


### PR DESCRIPTION
Uses the NYT anomalies dataset to filter our new cases and new deaths timeseries, removing data points that NYT has flagged as anomalies.  This is in addition to our existing outlier detection but may give us some future leeway to remove outlier detection or make it less sensitive.

The net effect (given our outlier detection) is fairly small but detectable.
Compare links:
* States: https://covidactnow.org/internal/compare?left=2361&locations=1&metric=5&right=2362&sort=2
* Top Counties: https://covidactnow.org/internal/compare?left=2361&locations=2&metric=5&right=2362&sort=2

FWIW- It can be a bit easier to pick out the deltas if you actually open the link in two tabs, but swap left/right in one of the tabs and then you can switch back and forth between the tags to see them overlaid.