### PR TITLE
Make data update pull right before pushing in case other changes were committed.

### DIFF
--- a/tools/push-data-update.sh
+++ b/tools/push-data-update.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Do a fresh pull in case any changes have been pushed to the branch.
+git pull "https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:${GITHUB_REF}
+
 now=$(date)
 git config --local user.email "action@github.com"
 git config --local user.name "GitHub Action"


### PR DESCRIPTION
Should avoid some of the recent failures.