### PR TITLE
Don't remove trailing zeros on an all-zero series

### DIFF
--- a/libs/metrics/top_level_metrics.py
+++ b/libs/metrics/top_level_metrics.py
@@ -155,6 +155,9 @@ def _remove_trailing_zeros_until_threshold(series: pd.Series, stall_length: int)
     last_nonzero_index = series.loc[series != 0].last_valid_index()
     last_index = series.last_valid_index()
 
+    if last_nonzero_index is None:
+        return series
+
     # If data has been zero for at least stall_length days then
     # we consider the data reported to be actual zeros instead of a reporting stall.
     # When this is the case we do not want to remove the trailing zeros.


### PR DESCRIPTION
If the timeseries is all zeros then `last_nonzero_index` is `None`, causing the comparison on line 164 to fail. 

This change means that we will never truncate the trailing zeros for an all-zero series (even if the series is shorter than `stall_length`)

this addresses the sentry error: https://sentry.io/organizations/covidactnow/issues/2907283165/?environment=Environment.PRODUCTION&project=5203044&referrer=alert_email