### PR TITLE
trigger API build on scheduled Update combined datasets actions

### DIFF
--- a/.github/workflows/update_repo_datasets.yml
+++ b/.github/workflows/update_repo_datasets.yml
@@ -29,7 +29,7 @@ env:
   # Use trigger_api_build if specified, else use true. This automatically triggers
   # the API build on scheduled runs where trigger_api_build is not defined.
   # https://github.community/t/how-can-you-use-expressions-as-the-workflow-dispatch-input-default/141454/4
-  TRIGGER_API_BUILD: ${{ github.event.inputs.trigger_api_build || 'true'}}
+  TRIGGER_API_BUILD: ${{ github.event.inputs.trigger_api_build || 'true' }}
 
 jobs:
   update-and-promote-datasets:

--- a/.github/workflows/update_repo_datasets.yml
+++ b/.github/workflows/update_repo_datasets.yml
@@ -2,11 +2,8 @@ name: Update combined datasets
 
 on:
   schedule:
-    # Run job everyday at 2:00 and 4:00 am EST
+    # Run job everyday at 3:00 and 5:00 am EST
     - cron: '0 8,10 * * *'
-  # This workflow is automatically triggered by
-  # https://github.com/covid-projections/covid-data-public/blob/main/.github/workflows/update_data.yml
-  # after covid-data-public datasets have been updated.
   workflow_dispatch:
     inputs:
       trigger_api_build:
@@ -29,7 +26,10 @@ env:
 
   GOOGLE_SHEETS_SERVICE_ACCOUNT_DATA: ${{ secrets.GOOGLE_SHEETS_SERVICE_ACCOUNT_DATA }}
 
-  TRIGGER_API_BUILD: ${{ github.event.inputs.trigger_api_build }}
+  # Use trigger_api_build if specified, else use true. This automatically triggers
+  # the API build on scheduled runs where trigger_api_build is not defined.
+  # https://github.community/t/how-can-you-use-expressions-as-the-workflow-dispatch-input-default/141454/4
+  TRIGGER_API_BUILD: ${{ github.event.inputs.trigger_api_build || 'true'}}
 
 jobs:
   update-and-promote-datasets:


### PR DESCRIPTION
The scheduled runs are not triggering the API build because `trigger_api_build` is only defined using `workflow_dispatch`. This should default to `true` if no `trigger_api_build` input exists (according to https://github.community/t/how-can-you-use-expressions-as-the-workflow-dispatch-input-default/141454/2)

Not sure of a great way to test this, as I'm not sure if scheduled runs will be triggered on non-main branches. I'll take a quick look into this