### PR TITLE
Add state-provided backup boosters source

### DIFF
--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -310,6 +310,7 @@ ALL_TIMESERIES_FEATURE_DEFINITION: FeatureDataSourceMap = {
         CDCNewVaccinesCompletedBoosterCountiesWithoutExceptions,
     ],
     CommonFields.VACCINATIONS_ADDITIONAL_DOSE: [
+        CANScraperCountyProviders,
         CDCVaccinesStatesAndNationDataset,
         CDCNewVaccinesCompletedBoosterCountiesWithoutExceptions,
     ],

--- a/scripts/can_raw_location_page_urls.py
+++ b/scripts/can_raw_location_page_urls.py
@@ -2,9 +2,9 @@ import structlog
 import click
 import requests
 import pandas as pd
-from covidactnow.datapublic import common_init
-from covidactnow.datapublic import common_df
-from covidactnow.datapublic.common_fields import CommonFields
+from datapublic import common_init
+from datapublic import common_df
+from datapublic.common_fields import CommonFields
 from libs.datasets.dataset_utils import DATA_DIRECTORY
 
 


### PR DESCRIPTION
Add data to allow state-provided booster data to flow through the pipeline.

Necessary to have CA state-provided data surfaced on the website. Related to https://github.com/covid-projections/can-scrapers/pull/404