### PR TITLE
Replace CANScraperCountyProviders with CANScraperStateProviders for booster data

### DIFF
--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -310,7 +310,7 @@ ALL_TIMESERIES_FEATURE_DEFINITION: FeatureDataSourceMap = {
         CDCNewVaccinesCompletedBoosterCountiesWithoutExceptions,
     ],
     CommonFields.VACCINATIONS_ADDITIONAL_DOSE: [
-        CANScraperCountyProviders,
+        CANScraperStateProvidersWithoutFLCounties,
         CDCVaccinesStatesAndNationDataset,
         CDCNewVaccinesCompletedBoosterCountiesWithoutExceptions,
     ],


### PR DESCRIPTION
I misinterpreted "ScraperCountyProviders" as "a source providing data for counties" instead of "a county health department source". We want to use scraper data from state health department dashboards