### PR TITLE
Block NC state-level data from CDC vaccine dataset

### DIFF
--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -158,6 +158,9 @@ JOPLIN_COUNTIES = [
 # so this region mask might not always be in use.
 NE_COUNTIES = RegionMask(AggregationLevel.COUNTY, states=["NE"])
 
+# 02/01/2022: CDC NC data is inaccurate due to an issue with categorizing
+# booster shots. So we instead use state-provided data
+NC_STATE = Region.from_state("NC")
 
 # NY Times has cases and deaths for all boroughs aggregated into 36061 / New York County.
 # Remove all the NYC data so that USAFacts (which reports each borough separately) is used.
@@ -177,7 +180,9 @@ CDCVaccinesCountiesDataset = datasource_regions(
 )
 
 CDCVaccinesStatesAndNationDataset = datasource_regions(
-    CDCVaccinesDataset, [RegionMask(AggregationLevel.STATE), RegionMask(AggregationLevel.COUNTRY)]
+    CDCVaccinesDataset,
+    [RegionMask(AggregationLevel.STATE), RegionMask(AggregationLevel.COUNTRY)],
+    exclude=[NC_STATE],
 )
 
 CDC_COUNTY_EXCLUSIONS = [


### PR DESCRIPTION
I believe that [`CANScraperStateProvidersWithoutFLCounties`](https://github.com/covid-projections/covid-data-model/pull/1239/files#diff-42917a247dcc7f465b77be023ee9800e3597bb2bb5dd1b09fbf1d2253a14c01bL236) should automatically include state-level data because no aggregation level was specified, so this should pick up the NC state-level data without any changes. If I'm missing something or am misunderstanding, let me know. 

Once the NC data is ingested from `can-scrapers` I'll create a test snapshot.