### PR TITLE
Add optional run number to download execute-model results from

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -14,9 +14,9 @@ on:
       sentry_environment:
         description: 'Sentry environment of build. Should be "production" on main build and "staging" for other branches.'
         required: true
-      # pyseir_snapshot:
-      #   description: 'Optionally use pyseir build-all artifacts from a previous snapshot build.'
-      #     required: false
+      pyseir_snapshot:
+        description: 'Optionally use pyseir build-all artifacts from a previous snapshot build.'
+          required: true
 
 env:
 

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -17,7 +17,7 @@ on:
       pyseir_snapshot:
         description: 'Optionally download an existing pyseir model artifact to use instead of generating a new one.'     
         required: false
-        default: '9999'
+        default: ""
 
 env:
 
@@ -47,6 +47,7 @@ env:
   # Setting openblas threading to one to speed up numpy in multiprocessing.
   OPENBLAS_NUM_THREADS: 1
 
+  # Optional Snapshot number to use pyseir model output from. An empty string by default
   PYSEIR_SNAPSHOT: ${{ github.event.inputs.pyseir_snapshot }}  
 
 jobs:
@@ -88,6 +89,8 @@ jobs:
       run: git lfs pull
 
     - name: Build Model Results (run.sh .. .. execute_model)
+      env:
+        GITHUB_TOKEN: ${{ secrets.CAN_ROBOT_PERSONAL_ACCESS_TOKEN }}
       run: |
         ./covid-data-model/run.sh /data/api-results-${{env.SNAPSHOT_ID}} execute_model
 

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -92,7 +92,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.CAN_ROBOT_PERSONAL_ACCESS_TOKEN }}
       run: |
-        ./covid-data-model/run.sh /data/api-results-${{env.SNAPSHOT_ID}} execute_model ${{OPTIONAL_PYSEIR_SNAPSHOT}}
+        ./covid-data-model/run.sh /data/api-results-${{env.SNAPSHOT_ID}} execute_model ${{env.OPTIONAL_PYSEIR_SNAPSHOT}}
 
     - name: Zip Model Results (run.sh .. .. execute_zip_folder)
       run: ./covid-data-model/run.sh /data/api-results-${{env.SNAPSHOT_ID}} execute_zip_folder

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -15,7 +15,7 @@ on:
         description: 'Sentry environment of build. Should be "production" on main build and "staging" for other branches.'
         required: true
       pyseir_snapshot:
-        description: 'Optionally download an existing pyseir model artifact to use instead of generating a new one.'     
+        description: 'Optionally download an existing pyseir model artifact from a previous snapshot instead of generating a new one.'     
         required: false
         default: ""
 
@@ -48,7 +48,7 @@ env:
   OPENBLAS_NUM_THREADS: 1
 
   # Optional Snapshot number to use pyseir model output from. An empty string by default
-  OPTIONAL_PYSEIR_SNAPSHOT: ${{ github.event.inputs.pyseir_snapshot }}  
+  PYSEIR_ARTIFACT_SNAPSHOT: ${{ github.event.inputs.pyseir_snapshot }}  
 
 jobs:
   build-and-publish-snapshot:
@@ -92,7 +92,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.CAN_ROBOT_PERSONAL_ACCESS_TOKEN }}
       run: |
-        ./covid-data-model/run.sh /data/api-results-${{env.SNAPSHOT_ID}} execute_model ${{env.OPTIONAL_PYSEIR_SNAPSHOT}}
+        ./covid-data-model/run.sh /data/api-results-${{env.SNAPSHOT_ID}} execute_model ${{env.PYSEIR_ARTIFACT_SNAPSHOT}}
 
     - name: Zip Model Results (run.sh .. .. execute_zip_folder)
       run: ./covid-data-model/run.sh /data/api-results-${{env.SNAPSHOT_ID}} execute_zip_folder

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -15,8 +15,9 @@ on:
         description: 'Sentry environment of build. Should be "production" on main build and "staging" for other branches.'
         required: true
       pyseir_snapshot:
-        description: 'Optionally use pyseir build-all artifacts from a previous snapshot build.'
-          required: true
+        description: 'Optionally download an existing pyseir model artifact to use instead of generating a new one.'     
+        required: false
+        default: '9999'
 
 env:
 

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -14,9 +14,9 @@ on:
       sentry_environment:
         description: 'Sentry environment of build. Should be "production" on main build and "staging" for other branches.'
         required: true
-      pyseir_snapshot:
-        description: 'Optionally use pyseir build-all artifacts from a previous snapshot build.'
-          required: false
+      # pyseir_snapshot:
+      #   description: 'Optionally use pyseir build-all artifacts from a previous snapshot build.'
+      #     required: false
 
 env:
 

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -14,6 +14,9 @@ on:
       sentry_environment:
         description: 'Sentry environment of build. Should be "production" on main build and "staging" for other branches.'
         required: true
+      pyseir_snapshot:
+        description: 'Optionally use pyseir build-all artifacts from a previous snapshot build.'
+          required: false
 
 env:
 
@@ -42,6 +45,8 @@ env:
 
   # Setting openblas threading to one to speed up numpy in multiprocessing.
   OPENBLAS_NUM_THREADS: 1
+
+  PYSEIR_SNAPSHOT: ${{ github.event.inputs.pyseir_snapshot }}  
 
 jobs:
   build-and-publish-snapshot:

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -48,7 +48,7 @@ env:
   OPENBLAS_NUM_THREADS: 1
 
   # Optional Snapshot number to use pyseir model output from. An empty string by default
-  PYSEIR_SNAPSHOT: ${{ github.event.inputs.pyseir_snapshot }}  
+  OPTIONAL_PYSEIR_SNAPSHOT: ${{ github.event.inputs.pyseir_snapshot }}  
 
 jobs:
   build-and-publish-snapshot:
@@ -92,7 +92,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.CAN_ROBOT_PERSONAL_ACCESS_TOKEN }}
       run: |
-        ./covid-data-model/run.sh /data/api-results-${{env.SNAPSHOT_ID}} execute_model
+        ./covid-data-model/run.sh /data/api-results-${{env.SNAPSHOT_ID}} execute_model ${{OPTIONAL_PYSEIR_SNAPSHOT}}
 
     - name: Zip Model Results (run.sh .. .. execute_zip_folder)
       run: ./covid-data-model/run.sh /data/api-results-${{env.SNAPSHOT_ID}} execute_zip_folder

--- a/matplotlibrc
+++ b/matplotlibrc
@@ -1,7 +1,0 @@
-# On MacOSX, certain backends require a framework build of python to
-# function properly which doesn't play nicely with virtualenv installed python
-# versions.
-# Setting backend to Agg globally to make matplotlib on mac happy.
-# https://matplotlib.org/3.1.0/faq/osx_framework.html
-# https://github.com/pypa/virtualenv/issues/54#issuecomment-491348526
-backend: Agg

--- a/matplotlibrc
+++ b/matplotlibrc
@@ -1,0 +1,7 @@
+# On MacOSX, certain backends require a framework build of python to
+# function properly which doesn't play nicely with virtualenv installed python
+# versions.
+# Setting backend to Agg globally to make matplotlib on mac happy.
+# https://matplotlib.org/3.1.0/faq/osx_framework.html
+# https://github.com/pypa/virtualenv/issues/54#issuecomment-491348526
+backend: Agg

--- a/run.sh
+++ b/run.sh
@@ -78,8 +78,8 @@ execute_model() {
   # Move state output to the expected location.
   mkdir -p ${API_OUTPUT_DIR}/
 
-  Capture all the PDFs pyseir creates in output/pyseir since they are
-  extremely helpful for debugging / QA'ing the model results.
+  # Capture all the PDFs pyseir creates in output/pyseir since they are
+  # extremely helpful for debugging / QA'ing the model results.
   echo ">>> Generating pyseir.zip from PDFs in output/pyseir."
   pushd output
   zip -r "${API_OUTPUT_DIR}/pyseir.zip" pyseir/* -i '*.pdf'

--- a/run.sh
+++ b/run.sh
@@ -15,7 +15,7 @@ prepare () {
     echo "Example: $0 ./api-results/"
     echo "Example: $0 ./api-results/ execute_model"
     echo "Example: $0 ./api-results/ execute_api"
-    echo "Example: $0 ./api-results/ execute_api 2920"
+    echo "Example: $0 ./api-results/ execute_model 2920"
     exit 1
   else
     API_OUTPUT_DIR="$(abs_path $1)"

--- a/run.sh
+++ b/run.sh
@@ -67,11 +67,12 @@ execute_model() {
   cd "$(dirname "$0")"
 
   if [ ! -z "$PYSEIR_ARTIFACT_SNAPSHOT" ]; then
-    echo ">>> Downloading state and county models from existing snapshot ${PYSEIR_ARTIFACT_SNAPSHOT}"
-    ./run.py utils download-model-artifact "${PYSEIR_ARTIFACT_SNAPSHOT}" --output-dir="${API_OUTPUT_DIR}" | tee "${API_OUTPUT_DIR}/stdout.log"
-    echo "FILES IN API_OUTPUT_DIR before: \n `ls ${API_OUTPUT_DIR}`"
-    mv "${API_OUTPUT_DIR}"/api-results-${PYSEIR_ARTIFACT_SNAPSHOT} "${API_OUTPUT_DIR}"/../api-results-${SNAPSHOT_ID}
-    echo "FILES IN API_OUTPUT_DIR after: \n `ls ${API_OUTPUT_DIR}`"
+    echo ">>> Downloading state and county models from existing snapshot ${PYSEIR_ARTIFACT_SNAPSHOT}."
+    ./run.py utils download-model-artifact "${PYSEIR_ARTIFACT_SNAPSHOT}" --output-dir=${API_OUTPUT_DIR%/*}
+    
+    echo ">>> Moving downloaded models to the expected locations."
+    rm -r "${API_OUTPUT_DIR}"  # remove the empty directories created above
+    mv "${API_OUTPUT_DIR%/*}"/api-results-${PYSEIR_ARTIFACT_SNAPSHOT} "${API_OUTPUT_DIR}"
   else
     echo ">>> Generating state and county models to ${API_OUTPUT_DIR}"
     # TODO(#148): We need to clean up the output of these scripts!

--- a/run.sh
+++ b/run.sh
@@ -69,22 +69,25 @@ execute_model() {
   if [ ! -z "$PYSEIR_ARTIFACT_SNAPSHOT" ]; then
     echo ">>> Downloading state and county models from existing snapshot ${PYSEIR_ARTIFACT_SNAPSHOT}"
     ./run.py utils download-model-artifact "${PYSEIR_ARTIFACT_SNAPSHOT}" --output-dir="${API_OUTPUT_DIR}" | tee "${API_OUTPUT_DIR}/stdout.log"
-    mv "${API_OUTPUT_DIR}"/api-results-${PYSEIR_ARTIFACT_SNAPSHOT} "${API_OUTPUT_DIR}"/api-results-${SNAPSHOT_ID}
+    echo "FILES IN API_OUTPUT_DIR before: \n `ls ${API_OUTPUT_DIR}`"
+    mv "${API_OUTPUT_DIR}"/api-results-${PYSEIR_ARTIFACT_SNAPSHOT} "${API_OUTPUT_DIR}"/../api-results-${SNAPSHOT_ID}
+    echo "FILES IN API_OUTPUT_DIR after: \n `ls ${API_OUTPUT_DIR}`"
   else
     echo ">>> Generating state and county models to ${API_OUTPUT_DIR}"
     # TODO(#148): We need to clean up the output of these scripts!
     python pyseir/cli.py build-all --output-dir="${API_OUTPUT_DIR}" | tee "${API_OUTPUT_DIR}/stdout.log"
+  
+
+    # Move state output to the expected location.
+    mkdir -p ${API_OUTPUT_DIR}/
+
+    # Capture all the PDFs pyseir creates in output/pyseir since they are
+    # extremely helpful for debugging / QA'ing the model results.
+    echo ">>> Generating pyseir.zip from PDFs in output/pyseir."
+    pushd output
+    zip -r "${API_OUTPUT_DIR}/pyseir.zip" pyseir/* -i '*.pdf'
+    popd
   fi
-
-  # Move state output to the expected location.
-  mkdir -p ${API_OUTPUT_DIR}/
-
-  # Capture all the PDFs pyseir creates in output/pyseir since they are
-  # extremely helpful for debugging / QA'ing the model results.
-  echo ">>> Generating pyseir.zip from PDFs in output/pyseir."
-  pushd output
-  zip -r "${API_OUTPUT_DIR}/pyseir.zip" pyseir/* -i '*.pdf'
-  popd
 }
 
 execute_api() {

--- a/run.sh
+++ b/run.sh
@@ -31,7 +31,7 @@ prepare () {
   fi
 
   if [ $# -eq 3 ]; then
-    SNAPSHOT_MODEL_ARTIFACT="$2"
+    PYSEIR_ARTIFACT_SNAPSHOT="$3"
   fi
 
   if [ ! -d "${API_OUTPUT_DIR}" ] ; then
@@ -66,9 +66,9 @@ execute_model() {
   # Go to repo root (where run.sh lives).
   cd "$(dirname "$0")"
 
-  if [$SNAPSHOT_MODEL_ARTIFACT] then;
-    echo ">>> Downloading state and county models from snapshot ${SNAPSHOT_MODEL_ARTIFACT}"
-    ./run.py utils download-model-artifact "${SNAPSHOT_MODEL_ARTIFACT}" --output-dir="${API_OUTPUT_DIR}" | tee "${API_OUTPUT_DIR}/stdout.log"
+  if [ ! -z "$PYSEIR_ARTIFACT_SNAPSHOT" ]; then
+    echo ">>> Downloading state and county models from existing snapshot ${PYSEIR_ARTIFACT_SNAPSHOT}"
+    ./run.py utils download-model-artifact "${PYSEIR_ARTIFACT_SNAPSHOT}" --output-dir="${API_OUTPUT_DIR}" | tee "${API_OUTPUT_DIR}/stdout.log"
   else
     echo ">>> Generating state and county models to ${API_OUTPUT_DIR}"
     # TODO(#148): We need to clean up the output of these scripts!
@@ -78,8 +78,8 @@ execute_model() {
   # Move state output to the expected location.
   mkdir -p ${API_OUTPUT_DIR}/
 
-  # Capture all the PDFs pyseir creates in output/pyseir since they are
-  # extremely helpful for debugging / QA'ing the model results.
+  Capture all the PDFs pyseir creates in output/pyseir since they are
+  extremely helpful for debugging / QA'ing the model results.
   echo ">>> Generating pyseir.zip from PDFs in output/pyseir."
   pushd output
   zip -r "${API_OUTPUT_DIR}/pyseir.zip" pyseir/* -i '*.pdf'

--- a/run.sh
+++ b/run.sh
@@ -69,6 +69,7 @@ execute_model() {
   if [ ! -z "$PYSEIR_ARTIFACT_SNAPSHOT" ]; then
     echo ">>> Downloading state and county models from existing snapshot ${PYSEIR_ARTIFACT_SNAPSHOT}"
     ./run.py utils download-model-artifact "${PYSEIR_ARTIFACT_SNAPSHOT}" --output-dir="${API_OUTPUT_DIR}" | tee "${API_OUTPUT_DIR}/stdout.log"
+    mv "${API_OUTPUT_DIR}"/api-results-${PYSEIR_ARTIFACT_SNAPSHOT} "${API_OUTPUT_DIR}"/api-results-${SNAPSHOT_ID}
   else
     echo ">>> Generating state and county models to ${API_OUTPUT_DIR}"
     # TODO(#148): We need to clean up the output of these scripts!

--- a/run.sh
+++ b/run.sh
@@ -70,11 +70,13 @@ execute_model() {
 
   if [ ! -z "$PYSEIR_ARTIFACT_SNAPSHOT" ]; then
     echo ">>> Downloading state and county models from existing snapshot ${PYSEIR_ARTIFACT_SNAPSHOT}."
-    ./run.py utils download-model-artifact "${PYSEIR_ARTIFACT_SNAPSHOT}" --output-dir=${API_OUTPUT_DIR%/*}
+    # TODO(sean): Might be simpler to just download the model results to /tmp/
+    API_OUTPUT_PARENT="${API_OUTPUT_DIR%/*}"
+    ./run.py utils download-model-artifact "${PYSEIR_ARTIFACT_SNAPSHOT}" --output-dir=${API_OUTPUT_PARENT}
     
     echo ">>> Moving downloaded models to the expected locations."
     rm -r "${API_OUTPUT_DIR}"  # remove the empty directories created above
-    mv "${API_OUTPUT_DIR%/*}"/api-results-${PYSEIR_ARTIFACT_SNAPSHOT} "${API_OUTPUT_DIR}"
+    mv "${API_OUTPUT_PARENT}"/api-results-${PYSEIR_ARTIFACT_SNAPSHOT} "${API_OUTPUT_DIR}"
   else
     echo ">>> Generating state and county models to ${API_OUTPUT_DIR}"
     # TODO(#148): We need to clean up the output of these scripts!

--- a/run.sh
+++ b/run.sh
@@ -30,8 +30,10 @@ prepare () {
     EXECUTE_FUNC="${2}"
   fi
 
-  if [ $# -eq 3 ]; then
+  if [ $# -ge 3 ]; then
     PYSEIR_ARTIFACT_SNAPSHOT="$3"
+  else
+    PYSEIR_ARTIFACT_SNAPSHOT=""
   fi
 
   if [ ! -d "${API_OUTPUT_DIR}" ] ; then


### PR DESCRIPTION
Allow API snapshots to be built on an existing `execute-model` run from a previous snapshot. 

Snapshot built on a previous model [here](https://github.com/covid-projections/covid-data-model/runs/5218915753?check_suite_focus=true).

Snapshot building off this branch without an existing model [here](https://github.com/covid-projections/covid-data-model/actions/runs/1854295934)
