### PR TITLE
Add repo dispatch for triggering via HTML request from can-scrapers

### DIFF
--- a/.github/workflows/update_repo_datasets.yml
+++ b/.github/workflows/update_repo_datasets.yml
@@ -2,8 +2,8 @@ name: Update combined datasets
 
 on:
   schedule:
-    # Run job everyday at 5:00 am EST
-    - cron: '0 10 * * *'
+    # Run job everyday at 3:00 and 5:00 am EST
+    - cron: '0 8,10 * * *'
   workflow_dispatch:
     inputs:
       trigger_api_build:

--- a/.github/workflows/update_repo_datasets.yml
+++ b/.github/workflows/update_repo_datasets.yml
@@ -2,13 +2,14 @@ name: Update combined datasets
 
 on:
   schedule:
-    # Run job everyday at 3:00 and 5:00 am EST
-    - cron: '0 8,10 * * *'
+    # Run job everyday at 5:00 am EST
+    - cron: '0 10 * * *'
   workflow_dispatch:
     inputs:
       trigger_api_build:
         description: 'If "true" API snapshot build will be triggered after dataset update.'
         default: 'true'
+  repository_dispatch:
 
 env:
 


### PR DESCRIPTION
Adds a `repository_dispatch` option to allow the action to be triggered by a `post` request in can-scrapers. This would replace the cron scheduler currently used (although I've kept the schedule active for now). 

I've been following the steps outlined [here](https://dev.to/rikurouvila/how-to-trigger-a-github-action-with-an-htt-request-545), and have a [PR in the works to make the trigger request in can-scrapers](https://github.com/covid-projections/can-scrapers/pull/413).