### PR TITLE
Remove the 3:00 AM EST Update Combined Datasets scheduled run

### DIFF
--- a/.github/workflows/update_repo_datasets.yml
+++ b/.github/workflows/update_repo_datasets.yml
@@ -2,8 +2,8 @@ name: Update combined datasets
 
 on:
   schedule:
-    # Run job everyday at 3:00 and 5:00 am EST
-    - cron: '0 8,10 * * *'
+    # Run job everyday at 5:00 am EST
+    - cron: '0 10 * * *'
   workflow_dispatch:
     inputs:
       trigger_api_build:


### PR DESCRIPTION
Remove the 3:00 AM EST Update Combined Datasets run to rely on the [runs triggered from Prefect](https://github.com/covid-projections/can-scrapers/pull/413). 

I've left the 5:00 AM run active as a backup for now, in case anything goes wrong with the Prefect triggers
