### PR TITLE
Ingest Hospital admissions and CDC Community Levels

### DIFF
--- a/datapublic/common_fields.py
+++ b/datapublic/common_fields.py
@@ -143,6 +143,12 @@ class CommonFields(GetByValueMixin, ValueAsStrMixin, FieldName, enum.Enum):
     CURRENT_HOSPITALIZED_TOTAL = "current_hospitalized_total", FieldGroup.HEALTHCARE_CAPACITY
     CURRENT_ICU_TOTAL = "current_icu_total", FieldGroup.HEALTHCARE_CAPACITY
 
+    NEW_HOSPITAL_ADMISSIONS_COVID = "new_hospital_admissions_covid", FieldGroup.HEALTHCARE_CAPACITY
+    WEEKLY_NEW_HOSPITAL_ADMISSIONS_COVID = (
+        "weekly_new_hospital_admissions_covid",
+        FieldGroup.HEALTHCARE_CAPACITY,
+    )
+
     CONTACT_TRACERS_COUNT = "contact_tracers_count", FieldGroup.HEALTHCARE_CAPACITY
     LATITUDE = "latitude", None
     LONGITUDE = "longitude", None
@@ -170,6 +176,9 @@ class CommonFields(GetByValueMixin, ValueAsStrMixin, FieldName, enum.Enum):
     VACCINATIONS_ADDITIONAL_DOSE_PCT = "vaccinations_additional_dose_pct", FieldGroup.VACCINES
     VACCINATIONS_COMPLETED = "vaccinations_completed", FieldGroup.VACCINES
     VACCINATIONS_COMPLETED_PCT = "vaccinations_completed_pct", FieldGroup.VACCINES
+
+    # The "raw" CDC community level, directly from the CDC source.
+    CDC_COMMUNITY_LEVEL = "cdc_community_level", None
 
 
 COMMON_FIELD_TO_GROUP = {f: f.field_group for f in CommonFields if f.field_group}

--- a/libs/datasets/combined_datasets.py
+++ b/libs/datasets/combined_datasets.py
@@ -9,6 +9,7 @@ from typing import TypeVar
 from typing import Union
 
 import pandas as pd
+from libs.datasets.sources.cdc_community_levels_dataset import CDCCommunityLevelsDataset
 import structlog
 
 from datapublic.common_fields import CommonFields
@@ -284,6 +285,8 @@ ALL_TIMESERIES_FEATURE_DEFINITION: FeatureDataSourceMap = {
         HHSHospitalCountyDataset,
         HHSHospitalStateDataset,
     ],
+    CommonFields.NEW_HOSPITAL_ADMISSIONS_COVID: [HHSHospitalStateDataset],
+    CommonFields.WEEKLY_NEW_HOSPITAL_ADMISSIONS_COVID: [HHSHospitalCountyDataset],
     CommonFields.NEGATIVE_TESTS: [HHSTestingDataset],
     CommonFields.POSITIVE_TESTS: [HHSTestingDataset],
     CommonFields.POSITIVE_TESTS_VIRAL: [CANScraperStateProviders],
@@ -327,6 +330,7 @@ ALL_TIMESERIES_FEATURE_DEFINITION: FeatureDataSourceMap = {
         CANScraperStateProvidersWithoutFLCounties,
         CANScraperCountyProviders,
     ],
+    CommonFields.CDC_COMMUNITY_LEVEL: [CDCCommunityLevelsDataset],
 }
 
 ALL_FIELDS_FEATURE_DEFINITION: FeatureDataSourceMap = {

--- a/libs/datasets/sources/cdc_community_levels_dataset.py
+++ b/libs/datasets/sources/cdc_community_levels_dataset.py
@@ -1,0 +1,20 @@
+from libs.datasets import data_source
+from datapublic.common_fields import CommonFields
+from libs.datasets.sources import can_scraper_helpers as ccd_helpers
+
+
+class CDCCommunityLevelsDataset(data_source.CanScraperBase):
+    SOURCE_TYPE = "CDCCommunityLevelsDataset"
+
+    VARIABLES = [
+        ccd_helpers.ScraperVariable(
+            variable_name="cdc_community",
+            measurement="current",
+            unit="risk_level",
+            provider="cdc_community_level",
+            common_field=CommonFields.CDC_COMMUNITY_LEVEL,
+        ),
+        # Note: we don't import the rest of the fields
+        # (covid_inpatient_bed_utilization, covid_hospital_admissions_per_100k,
+        # covid_cases_per_100k) since we don't currently use the CDC data.
+    ]

--- a/libs/datasets/sources/hhs_hospital_dataset.py
+++ b/libs/datasets/sources/hhs_hospital_dataset.py
@@ -64,6 +64,16 @@ class HHSHospitalStateDataset(data_source.CanScraperBase):
     VARIABLES = [
         make_hhs_variable(can_field, common_field, "current")
         for can_field, common_field in FIELD_MAPPING.items()
+    ] + [
+        # hospital admissions are daily at the state-level and weekly at the
+        # county-level so we specify them separate from FIELD_MAPPING.
+        ccd_helpers.ScraperVariable(
+            variable_name="hospital_admissions_covid",
+            measurement="new",
+            unit="people",
+            provider="hhs",
+            common_field=CommonFields.NEW_HOSPITAL_ADMISSIONS_COVID,
+        ),
     ]
 
     @classmethod
@@ -80,6 +90,16 @@ class HHSHospitalCountyDataset(data_source.CanScraperBase):
     VARIABLES = [
         make_hhs_variable(can_field, common_field, "rolling_average_7_day")
         for can_field, common_field in FIELD_MAPPING.items()
+    ] + [
+        # hospital admissions are daily at the state-level and weekly at the
+        # county-level so we specify them separate from FIELD_MAPPING.
+        ccd_helpers.ScraperVariable(
+            variable_name="hospital_admissions_covid",
+            measurement="new_7_day",
+            unit="people",
+            provider="hhs",
+            common_field=CommonFields.WEEKLY_NEW_HOSPITAL_ADMISSIONS_COVID,
+        )
     ]
 
     @classmethod


### PR DESCRIPTION
Pulls in hospital admissions data from HHS and CDC Community Levels from CDC from the parquet and into our combined datasets data.

Tested via `./run.py data update --state CT` and inspecting the resulting data/multiregion-wide-dates.csv file for the expected fields.