### PR TITLE
Add option to github action to skip refreshing datasets.

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -15,7 +15,7 @@ on:
         description: 'Sentry environment of build. Should be "production" on main build and "staging" for other branches.'
         required: true
       pyseir_snapshot:
-        description: 'Optionally download an existing pyseir model artifact from a previous snapshot number instead of generating a new one.'     
+        description: 'Optionally download an existing pyseir model artifact from a previous snapshot number instead of generating a new one.'
         required: false
         default: ""
 
@@ -48,7 +48,7 @@ env:
   OPENBLAS_NUM_THREADS: 1
 
   # Optional Snapshot number to use pyseir model output from. An empty string by default
-  PYSEIR_ARTIFACT_SNAPSHOT: ${{ github.event.inputs.pyseir_snapshot }}  
+  PYSEIR_ARTIFACT_SNAPSHOT: ${{ github.event.inputs.pyseir_snapshot }}
 
 jobs:
   build-and-publish-snapshot:
@@ -56,7 +56,7 @@ jobs:
     steps:
     - name: Parse covid data model branch name and set env variable
       run: |
-        echo "COVID_DATA_MODEL_REF=${GITHUB_REF##*/}" >> $GITHUB_ENV
+        echo "COVID_DATA_MODEL_REF=${GITHUB_REF_NAME}" >> $GITHUB_ENV
     - name: Checkout covid-data-model (${{ env.COVID_DATA_MODEL_REF }})
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/update_repo_datasets.yml
+++ b/.github/workflows/update_repo_datasets.yml
@@ -9,6 +9,9 @@ on:
       trigger_api_build:
         description: 'If "true" API snapshot build will be triggered after dataset update.'
         default: 'true'
+      refresh_datasets:
+        description: 'Set to "false" to skip downloading / re-combining the latest datasets.'
+        default: 'true'
   repository_dispatch:
 
 env:
@@ -30,13 +33,15 @@ env:
   # https://github.community/t/how-can-you-use-expressions-as-the-workflow-dispatch-input-default/141454/4
   TRIGGER_API_BUILD: ${{ github.event.inputs.trigger_api_build || 'true' }}
 
+  REFRESH_DATASETS_ARG: ${{ (github.event.inputs.refresh_datasets == 'true') && '--refresh-datasets' || '--no-refresh-datasets' }}
+
 jobs:
   update-and-promote-datasets:
     runs-on: self-hosted
     steps:
     - name: Parse covid data model branch name and set env variable
       run: |
-        echo "COVID_DATA_MODEL_REF=${GITHUB_REF##*/}" >> $GITHUB_ENV
+        echo "COVID_DATA_MODEL_REF=${GITHUB_REF_NAME}" >> $GITHUB_ENV
 
     - name: Checkout covid-data-model
       uses: actions/checkout@v2
@@ -76,7 +81,7 @@ jobs:
     - name: Update and Promote dataset.
       working-directory: ./covid-data-model
       run: |
-        ./run.py data update
+        ./run.py data update ${{env.REFRESH_DATASETS_ARG}}
 
     - name: Create Update Commit
       working-directory: ./covid-data-model


### PR DESCRIPTION
`./run.py data update` accepts a `--no-refresh-datasets` option that tells it to skip fetching / combining datasources and instead re-use the checked-in `combined-raw.pkl.gz` data.  This PR exposes that option to the github action.  This can be used to save time when you just need to block data and re-build the snapshot.

I also tweaked the github actions to work with branches that have `/` in the name.