### PR TITLE
Fix case data truncation

### DIFF
--- a/libs/metrics/top_level_metrics.py
+++ b/libs/metrics/top_level_metrics.py
@@ -217,7 +217,7 @@ def copy_test_positivity(
     return test_positivity, TestPositivityRatioDetails(source=method)
 
 
-def _calculate_smoothed_daily_cases(new_cases: pd.Series, smooth: int = 7, stall_length: int = 15):
+def _calculate_smoothed_daily_cases(new_cases: pd.Series, smooth: int = 7, stall_length: int = 14):
 
     if new_cases.first_valid_index() is None:
         return new_cases
@@ -228,7 +228,7 @@ def _calculate_smoothed_daily_cases(new_cases: pd.Series, smooth: int = 7, stall
     # pulled towards zero in between reporting days. This is because the backfilling removes some of the
     # weekly cases out of the 7-day window. To combat this, we remove trailing zeros from the data.
 
-    # After a certain number of days (15 by default) we consider trailing
+    # After a certain number of days (14 by default) we consider trailing
     # zeros to be real data and not a reporting lag.
     # After this threshold we no longer remove the trailing zeros.
     new_cases = _remove_trailing_zeros_until_threshold(new_cases, stall_length)
@@ -248,7 +248,7 @@ def calculate_case_density(
     population: int,
     smooth: int = 7,
     normalize_by: int = 100_000,
-    stall_length: int = 10,
+    stall_length: int = 14,
 ) -> pd.Series:
     """Calculates normalized daily case density.
 


### PR DESCRIPTION
https://github.com/covid-projections/covid-data-model/pull/1261 Only increased the default value, but the 10-day value was still being specified when the truncation function was called, so trailing zeros we're still only being truncated for 10 days. 

Also, I think we only need to truncate 14 days not 15