### PR TITLE
Restore demographic vaccine data

### DIFF
--- a/libs/datasets/custom_patches.py
+++ b/libs/datasets/custom_patches.py
@@ -35,7 +35,7 @@ def patch_maryland_missing_case_data(
     # Need to convert timestamp to strings to match the index dtype.
     dates_to_replace = [str(date.date()) for date in dates_to_replace]
 
-    modified_ts = location_ds.timeseries
+    modified_ts = location_ds.timeseries_bucketed
     missing_dates_index = modified_ts.index.get_level_values("date").isin(dates_to_replace)
 
     # backfill the data within the date range and paste this data into the series.
@@ -46,5 +46,5 @@ def patch_maryland_missing_case_data(
     )
     modified_ts.loc[missing_dates_index, CommonFields.NEW_CASES] = backfilled_data
 
-    subset_ds = dataclasses.replace(location_ds, timeseries=modified_ts, timeseries_bucketed=None)
+    subset_ds = dataclasses.replace(location_ds, timeseries_bucketed=modified_ts)
     return other.append_regions(subset_ds)


### PR DESCRIPTION
Demographic data was getting clobbered/removed from the `MultiregionDatasets` due to my use of `timeseries` instead of `timeseries_bucketed`. This updates the code where necessary to restore demographic data

post-fix: https://gist.githubusercontent.com/smcclure17/a50c3c6395bb37552771104b11279c8f/raw/a1ad4a60a4fd6af40d1807f26b7ec0d2d23f3a12/ca-06037.json

pre-fix: https://gist.githubusercontent.com/smcclure17/2365b842dbbb510d620453298957ce52/raw/4edb7fe774f88e8f80bfd90a8ba9a9407efb9418/ca-06037.json