### PR TITLE
Manually install numpy before fastparquet.

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -80,6 +80,13 @@ jobs:
           ${{ runner.os }}-pip-
           ${{ runner.os }}-
 
+    # If you don't manually install the correct version of numpy before
+    # installing modules from requirements.txt, fastparquet may try to install a
+    # newer version of numpy that requires python 3.8 (but we use 3.7).
+    # See https://github.com/dask/fastparquet/issues/632#issuecomment-877871388
+    - run: pip install numpy==1.21.4
+      working-directory: ./covid-data-model
+
     - name: Install Dependencies
       working-directory: ./covid-data-model
       run: pip install -r requirements.txt


### PR DESCRIPTION
Your instructions at https://www.dropbox.com/scl/fi/d2zuir4wx69i3uf84hb62/GitHub-Actions-Runner-on-GCE-Setup.paper were basically spot-on but I ran into one issue with fastparquet not installing successfully. This was the only way I found to get it to work. 🤷 