### PR TITLE
Read parquet file directly from GCS

### DIFF
--- a/cli/data.py
+++ b/cli/data.py
@@ -31,7 +31,7 @@ from libs.datasets import new_cases_and_deaths
 from libs.datasets import vaccine_backfills
 from libs.datasets.dataset_utils import DATA_DIRECTORY
 from libs.datasets import tail_filter
-from libs.datasets.sources import can_scraper_helpers, zeros_filter
+from libs.datasets.sources import zeros_filter
 from libs.pipeline import Region
 from libs.pipeline import RegionMask
 from libs.us_state_abbrev import ABBREV_US_UNKNOWN_COUNTY_FIPS
@@ -101,8 +101,6 @@ def update(
     path_prefix = dataset_utils.DATA_DIRECTORY.relative_to(dataset_utils.REPO_ROOT)
 
     if refresh_datasets:
-        # fetch parquet file from GCS and persist it in data/
-        can_scraper_helpers.CanScraperLoader.persist_parquet()
         timeseries_field_datasets = load_datasets_by_field(
             ALL_TIMESERIES_FEATURE_DEFINITION, state=state, fips=fips
         )

--- a/data/can_scrape_api_covid_us.parquet
+++ b/data/can_scrape_api_covid_us.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:539396d70f7e21d3f771c5a713d48dd11eee33a24706ceb445ea2decdf7433bf
-size 769384019

--- a/libs/datasets/data_source.py
+++ b/libs/datasets/data_source.py
@@ -137,7 +137,7 @@ class CanScraperBase(DataSource, abc.ABC, metaclass=_CanScraperBaseMeta):
     @staticmethod
     @lru_cache(None)
     def _get_covid_county_dataset() -> ccd_helpers.CanScraperLoader:
-        return ccd_helpers.CanScraperLoader.load_from_local()
+        return ccd_helpers.CanScraperLoader.load_from_gcs()
 
     @classmethod
     @lru_cache(None)

--- a/libs/datasets/sources/can_scraper_helpers.py
+++ b/libs/datasets/sources/can_scraper_helpers.py
@@ -5,7 +5,6 @@ import enum
 import dataclasses
 from typing import Optional
 from typing import Tuple
-import requests
 import more_itertools
 import structlog
 import pandas as pd
@@ -25,9 +24,6 @@ from libs.datasets.demographics import DistributionBucket
 GCS_PARQUET_PATH = (
     "https://storage.googleapis.com/can-scrape-outputs/final/can_scrape_api_covid_us.parquet"
 )
-
-LOCAL_PARQUET_PATH = dataset_utils.DATA_DIRECTORY / "can_scrape_api_covid_us.parquet"
-
 
 _logger = structlog.getLogger()
 
@@ -277,16 +273,7 @@ class CanScraperLoader:
                 )
 
     @staticmethod
-    def persist_parquet():
-        """Fetches the up-to-date Parquet file from GCS and stores it in data/"""
-        payload = requests.get(GCS_PARQUET_PATH).content
-        with (LOCAL_PARQUET_PATH) as file:
-            file.write_bytes(payload)
-
-    @staticmethod
-    def load_from_local() -> "CanScraperLoader":
+    def load_from_gcs() -> "CanScraperLoader":
         """Returns a CanScraperLoader which holds data loaded from the CAN Scraper."""
-
-        all_df = pd.read_parquet(LOCAL_PARQUET_PATH)
-
+        all_df = pd.read_parquet(GCS_PARQUET_PATH)
         return CanScraperLoader(all_df)


### PR DESCRIPTION
Tweak the data pipeline such that the scraper data parquet file does not get persisted to `data/` during each pipeline run
