### PR TITLE
Remove data/multiregion-wide-dates.csv

### DIFF
--- a/data/multiregion-wide-dates.csv
+++ b/data/multiregion-wide-dates.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eb91edfdb39815dfe0ddd7e2fe9030a1279d8c11e7ab7837867766db07e87149
-size 310589995


### PR DESCRIPTION
I should have deleted this in #1296 as it has been replaced by `data/multiregion-wide-dates.csv.gz`