### PR TITLE
Fix model artifact rename to work across devices.

### DIFF
--- a/libs/github_utils.py
+++ b/libs/github_utils.py
@@ -3,6 +3,7 @@ import shutil
 import click
 import tempfile
 import io
+import shutil
 
 import zipfile
 import pathlib
@@ -107,4 +108,4 @@ def download_model_artifact(
                     shutil.rmtree(output_path)
 
             _logger.info(f"Extracted {path.name} to  {str(output_dir)}")
-            path.rename(output_dir / path.name)
+            shutil.move(path, output_dir / path.name)


### PR DESCRIPTION
This fixes an error I ran into when I was doing some perf testing on a new github actions runner.  When I set up the runner, I gave it a small (10GB) OS drive and a large drive for the action runner / data file stuff.  But this caused the `PYSEIR_ARTIFACT_SNAPSHOT` option to not work because it ended up trying to `rename` a file from one device to another, which apparently isn't supported.

```
OSError: [Errno 18] Invalid cross-device link: '/tmp/tmppf9_1nlo/data/api-results-3355' -> '/mnt/data/covid-data-model/covid-data-model/api-results-3355'
```
