### PR TITLE
Disable sentry performance transactions.

### DIFF
--- a/api/awsauth/awsauth/auth_app.py
+++ b/api/awsauth/awsauth/auth_app.py
@@ -52,7 +52,8 @@ def init():
         dsn=Config.Constants.SENTRY_DSN,
         environment=Config.Constants.SENTRY_ENVIRONMENT,
         integrations=[AwsLambdaIntegration()],
-        traces_sample_rate=1.0,  # adjust the sample rate in production as needed
+        # We don't care about performance traces and they use up our transaction quota.
+        traces_sample_rate=0,
     )
 
 


### PR DESCRIPTION
I've been meaning to do this for a while so we don't use up our Sentry transaction quota every month and get email notifications... 🤷 