### PR TITLE
Fix provider.region in serverless.yml and pin serverless version.

### DIFF
--- a/.github/workflows/deploy_aws_api_infrastructure_dev.yml
+++ b/.github/workflows/deploy_aws_api_infrastructure_dev.yml
@@ -36,7 +36,7 @@ jobs:
       run: pip install -r requirements_test.txt -r requirements.txt
     - name: Install Serverless Framework and NPM dependencies
       run: |
-        npm install -g serverless
+        npm install -g serverless@2.72.3
         npm install
     - name: Deploy
       env:

--- a/api/awsauth/serverless.yml
+++ b/api/awsauth/serverless.yml
@@ -41,6 +41,7 @@ plugins:
 
 provider:
   name: aws
+  region: us-east-1
   runtime: python3.7
 
   stage: ${opt:stage, 'dev'}

--- a/api/awsauth/serverless.yml
+++ b/api/awsauth/serverless.yml
@@ -18,7 +18,7 @@ service: awsauth
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-frameworkVersion: '2'
+frameworkVersion: '2.72.3'
 
 
 custom:


### PR DESCRIPTION
Fixes issue encountered in https://github.com/covid-projections/covid-data-model/runs/8100141218?check_suite_focus=true

It seems like serverless v3 broke us.  I fixed one issue, but hit a different issue, so I'm pinning at 2.72.3.