### PR TITLE
Fix serverless version for prod deploy.

### DIFF
--- a/.github/workflows/deploy_aws_api_infrastructure_dev.yml
+++ b/.github/workflows/deploy_aws_api_infrastructure_dev.yml
@@ -87,7 +87,7 @@ jobs:
       run: pip install -r requirements_test.txt -r requirements.txt
     - name: Install Serverless Framework and NPM dependencies
       run: |
-        npm install -g serverless
+        npm install -g serverless@2.72.3
         npm install
     - name: Deploy
       env:


### PR DESCRIPTION
I missed a spot where we need to pin the serverless version (for the prod deploy).