### PR TITLE
Revert duplicates hack

### DIFF
--- a/libs/datasets/sources/can_scraper_helpers.py
+++ b/libs/datasets/sources/can_scraper_helpers.py
@@ -242,12 +242,10 @@ class CanScraperLoader:
 
         dups = indexed_rows.index.duplicated(keep=False)
         if dups.any():
-            # TODO(michael): Remove this. We shouldn't be getting duplicates.
-            indexed_rows = indexed_rows[~indexed_rows.index.duplicated(keep="first")]
-            # raise NotImplementedError(
-            #     f"No support for aggregating duplicate observations:\n"
-            #     f"{indexed_rows.loc[dups].to_string(line_width=200, max_rows=200, max_colwidth=40)}"
-            # )
+            raise NotImplementedError(
+                f"No support for aggregating duplicate observations:\n"
+                f"{indexed_rows.loc[dups].to_string(line_width=200, max_rows=200, max_colwidth=40)}"
+            )
 
         # For now only making a source tag for observations with bucket "all".
         tag_df = taglib.Source.rename_and_make_tag_df(

--- a/tests/libs/datasets/sources/can_scraper_helpers_test.py
+++ b/tests/libs/datasets/sources/can_scraper_helpers_test.py
@@ -212,8 +212,6 @@ def test_query_multiple_variables_extra_field():
         data.query_multiple_variables([variable], source_type="MySource")
 
 
-# TODO(michael): Reenable.
-@pytest.mark.skip(reason="Temporary hack to allow / remove duplicates.")
 def test_query_multiple_variables_duplicate_observation():
     variable = ccd_helpers.ScraperVariable(
         variable_name="cases",


### PR DESCRIPTION
I've:
- Reverted the database to a backup from Oct. 22nd, 2022 (before the duplicates issue began)
- Ran the HHS facility-level scraper and generated a new parquet file
- Tested an [Update Combined Datasets](https://github.com/covid-projections/covid-data-model/actions/runs/3330302904) run off of my testing branch. This made it past the point where it would previously break

