### PR TITLE
Replace Hubspot API key

### DIFF
--- a/.github/workflows/update_api_usage.yml
+++ b/.github/workflows/update_api_usage.yml
@@ -1,7 +1,9 @@
 name: Update API User Usage
 
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - smcclure17/hubspot
   schedule:
      # Run every 4 hours at the top of the hour
    - cron: '0 */6 * * *'

--- a/.github/workflows/update_api_usage.yml
+++ b/.github/workflows/update_api_usage.yml
@@ -36,7 +36,7 @@ env:
 
   AWS_ACCESS_KEY_ID: ${{ secrets.API_USAGE_UPDATER_ACCESS_KEY_ID }}
 
-  HUBSPOT_API_KEY: ${{ secrets.HUBSPOT_API_KEY }}
+  HUBSPOT_AUTH_TOKEN: ${{ secrets.HUBSPOT_AUTH_TOKEN }}
 
 jobs:
   update-and-promote-datasets:

--- a/.github/workflows/update_api_usage.yml
+++ b/.github/workflows/update_api_usage.yml
@@ -1,16 +1,13 @@
 name: Update API User Usage
 
 on:
-  push:
-    branches:
-      - smcclure17/hubspot
   schedule:
      # Run every 4 hours at the top of the hour
    - cron: '0 */6 * * *'
 
 env:
   # !!! Change this to your BRANCH if you want to test it
-  COVID_DATA_MODEL_REF: 'smcclure17/hubspot'
+  COVID_DATA_MODEL_REF: 'main'
 
   # To pin to an old data sets, put the branch/tag/commit here:
   COVID_DATA_PUBLIC_REF: 'main'

--- a/.github/workflows/update_api_usage.yml
+++ b/.github/workflows/update_api_usage.yml
@@ -1,6 +1,7 @@
 name: Update API User Usage
 
 on:
+  workflow_dispatch:
   schedule:
      # Run every 4 hours at the top of the hour
    - cron: '0 */6 * * *'

--- a/.github/workflows/update_api_usage.yml
+++ b/.github/workflows/update_api_usage.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   # !!! Change this to your BRANCH if you want to test it
-  COVID_DATA_MODEL_REF: 'main'
+  COVID_DATA_MODEL_REF: 'smcclure17/hubspot'
 
   # To pin to an old data sets, put the branch/tag/commit here:
   COVID_DATA_PUBLIC_REF: 'main'

--- a/.github/workflows/update_api_usage.yml
+++ b/.github/workflows/update_api_usage.yml
@@ -1,6 +1,9 @@
 name: Update API User Usage
 
 on:
+  push:
+    branches:
+      - smcclure17/hubspot
   schedule:
      # Run every 4 hours at the top of the hour
    - cron: '0 */6 * * *'

--- a/.github/workflows/update_api_usage.yml
+++ b/.github/workflows/update_api_usage.yml
@@ -1,9 +1,6 @@
 name: Update API User Usage
 
 on:
-  push:
-    branches:
-      - smcclure17/hubspot
   schedule:
      # Run every 4 hours at the top of the hour
    - cron: '0 */6 * * *'

--- a/libs/update_api_user_metrics.py
+++ b/libs/update_api_user_metrics.py
@@ -25,7 +25,7 @@ GROUP BY email
 
 
 ATHENA_BUCKET = "s3://covidactnow-athena-results"
-HUBSPOT_OATH_TOKEN = os.getenv("HUBSPOT_OATH_TOKEN")
+HUBSPOT_AUTH_TOKEN = os.getenv("HUBSPOT_AUTH_TOKEN")
 
 
 class CloudWatchQueryError(Exception):
@@ -42,7 +42,7 @@ def update_hubspot_activity(email, latest_active_at, days_active):
 
     response = requests.post(
         url,
-        headers={"Authorization": f"Bearer {HUBSPOT_OATH_TOKEN}"},
+        headers={"Authorization": f"Bearer {HUBSPOT_AUTH_TOKEN}"},
         json={
             "email": email,
             "properties": [
@@ -54,6 +54,8 @@ def update_hubspot_activity(email, latest_active_at, days_active):
     if not response.ok:
         _logger.warning(f"Failed to update hubspot activity for {email}")
         return
+    else:
+        _logger.info(f"Updated hubspot activity for {email} with status {response.status_code}")
 
     _logger.info(f"Successfully updated {email}")
 
@@ -180,7 +182,7 @@ def update_hubspot_users(data: List[Dict[str, Any]], only_update_recent: bool = 
         data: List of query results.
         only_update_recent: If True only updates users with usage in the past 2 days.
     """
-    if not HUBSPOT_OATH_TOKEN:
+    if not HUBSPOT_AUTH_TOKEN:
         _logger.warning("Hubspot API key not provided, skipping hubspot update")
         return
 

--- a/libs/update_api_user_metrics.py
+++ b/libs/update_api_user_metrics.py
@@ -40,6 +40,7 @@ def update_hubspot_activity(email, latest_active_at, days_active):
     date = datetime.datetime.strptime(latest_active_at + " +0000", "%Y-%m-%d %z")
     url = f"https://api.hubapi.com/contacts/v1/contact/createOrUpdate/email/{email}"
 
+    _logger.warning(f"Updating Hubspot contact {email}")
     response = requests.post(
         url,
         headers={"Authorization": f"Bearer {HUBSPOT_AUTH_TOKEN}"},
@@ -54,8 +55,6 @@ def update_hubspot_activity(email, latest_active_at, days_active):
     if not response.ok:
         _logger.warning(f"Failed to update hubspot activity for {email}")
         return
-    else:
-        _logger.info(f"Updated hubspot activity for {email} with status {response.status_code}")
 
     _logger.info(f"Successfully updated {email}")
 

--- a/libs/update_api_user_metrics.py
+++ b/libs/update_api_user_metrics.py
@@ -42,7 +42,7 @@ def update_hubspot_activity(email, latest_active_at, days_active):
 
     response = requests.post(
         url,
-        headers={"Authorization": f"Bearer {HUBSPOT_AUTH_TOKEN}"},
+        headers={"Authorization": f"Bearer no token"},
         json={
             "email": email,
             "properties": [

--- a/libs/update_api_user_metrics.py
+++ b/libs/update_api_user_metrics.py
@@ -40,7 +40,6 @@ def update_hubspot_activity(email, latest_active_at, days_active):
     date = datetime.datetime.strptime(latest_active_at + " +0000", "%Y-%m-%d %z")
     url = f"https://api.hubapi.com/contacts/v1/contact/createOrUpdate/email/{email}"
 
-    _logger.warning(f"Updating Hubspot contact {email}")
     response = requests.post(
         url,
         headers={"Authorization": f"Bearer {HUBSPOT_AUTH_TOKEN}"},

--- a/libs/update_api_user_metrics.py
+++ b/libs/update_api_user_metrics.py
@@ -25,7 +25,7 @@ GROUP BY email
 
 
 ATHENA_BUCKET = "s3://covidactnow-athena-results"
-HUBSPOT_API_KEY = os.getenv("HUBSPOT_API_KEY")
+HUBSPOT_OATH_TOKEN = os.getenv("HUBSPOT_OATH_TOKEN")
 
 
 class CloudWatchQueryError(Exception):
@@ -34,9 +34,6 @@ class CloudWatchQueryError(Exception):
 
 def update_hubspot_activity(email, latest_active_at, days_active):
     """Updates Hubspot contact with latest activity dates."""
-    contacts_url = "https://api.hubapi.com/crm/v3/objects/contacts"
-
-    query_string = {"hapikey": HUBSPOT_API_KEY}
 
     # Hubspot date field should be at UTC midnight. When the %z directive is provided to the
     # strptime() method, a TZ aware datetime object will be produced.
@@ -45,7 +42,7 @@ def update_hubspot_activity(email, latest_active_at, days_active):
 
     response = requests.post(
         url,
-        params=query_string,
+        headers={"Authorization": f"Bearer {HUBSPOT_OATH_TOKEN}"},
         json={
             "email": email,
             "properties": [
@@ -183,7 +180,7 @@ def update_hubspot_users(data: List[Dict[str, Any]], only_update_recent: bool = 
         data: List of query results.
         only_update_recent: If True only updates users with usage in the past 2 days.
     """
-    if not HUBSPOT_API_KEY:
+    if not HUBSPOT_OATH_TOKEN:
         _logger.warning("Hubspot API key not provided, skipping hubspot update")
         return
 

--- a/libs/update_api_user_metrics.py
+++ b/libs/update_api_user_metrics.py
@@ -42,7 +42,7 @@ def update_hubspot_activity(email, latest_active_at, days_active):
 
     response = requests.post(
         url,
-        headers={"Authorization": f"Bearer no token"},
+        headers={"Authorization": f"Bearer {HUBSPOT_AUTH_TOKEN}"},
         json={
             "email": email,
             "properties": [


### PR DESCRIPTION
#766  Updates Hubspot to use a Bearer auth token following: https://developers.hubspot.com/docs/api/migrate-an-api-key-integration-to-a-private-app

Appears to be working per: https://app.hubspot.com/private-apps/8617439/1285491/logs/api