### PR TITLE
Convert `location_id` column type from categorical to object

### DIFF
--- a/datapublic/common_fields.py
+++ b/datapublic/common_fields.py
@@ -79,8 +79,6 @@ class CommonFields(GetByValueMixin, ValueAsStrMixin, FieldName, enum.Enum):
 
     DATE = "date", None
 
-    LOCATION = "location", None
-
     # In the style of CovidAtlas/Project Li `locationID`. See
     # https://github.com/covidatlas/li/blob/master/docs/reports-v1.md#general-notes
     LOCATION_ID = "location_id", None

--- a/datapublic/common_fields.py
+++ b/datapublic/common_fields.py
@@ -79,6 +79,8 @@ class CommonFields(GetByValueMixin, ValueAsStrMixin, FieldName, enum.Enum):
 
     DATE = "date", None
 
+    LOCATION = "location", None
+
     # In the style of CovidAtlas/Project Li `locationID`. See
     # https://github.com/covidatlas/li/blob/master/docs/reports-v1.md#general-notes
     LOCATION_ID = "location_id", None

--- a/libs/datasets/sources/can_scraper_helpers.py
+++ b/libs/datasets/sources/can_scraper_helpers.py
@@ -274,4 +274,6 @@ class CanScraperLoader:
     def load_from_gcs() -> "CanScraperLoader":
         """Returns a CanScraperLoader which holds data loaded from the CAN Scraper."""
         all_df = pd.read_parquet(GCS_PARQUET_PATH)
+        # Change location/fips column type from int32 to object/string
+        all_df[CommonFields.LOCATION] = all_df[Fields.LOCATION].astype("object")
         return CanScraperLoader(all_df)

--- a/libs/datasets/sources/can_scraper_helpers.py
+++ b/libs/datasets/sources/can_scraper_helpers.py
@@ -274,6 +274,9 @@ class CanScraperLoader:
     def load_from_gcs() -> "CanScraperLoader":
         """Returns a CanScraperLoader which holds data loaded from the CAN Scraper."""
         all_df = pd.read_parquet(GCS_PARQUET_PATH)
-        # Change location/fips column type from int32 to object/string
-        all_df[CommonFields.LOCATION] = all_df[Fields.LOCATION].astype("object")
+        # The location_id column is stored as a categorical in the parquet file to save memory.
+        # location_id is used as an index, and categoricals create a special CategoryIndex
+        # which causes issues further down the pipeline.
+        # So we convert it back to a regular object here.
+        all_df[CommonFields.LOCATION_ID] = all_df[CommonFields.LOCATION_ID].astype("object")
         return CanScraperLoader(all_df)


### PR DESCRIPTION
context: https://sentry.io/organizations/covidactnow/issues/3807149066/?project=5203044&referrer=slack

Issue was raised by https://github.com/covid-projections/can-scrapers/pull/448

Combined datasets run tested locally with `./run.py data update --states CT --refresh-datasets`