### PR TITLE
Bump Metric Lookback

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,8 @@ repos:
     hooks:
       - id: black
         language_version: python3.7
+        additional_dependencies: ['click==8.0.4']
+
   - repo: https://github.com/kynan/nbstripout
     rev: 0.3.9
     hooks:

--- a/libs/metrics/top_level_metrics.py
+++ b/libs/metrics/top_level_metrics.py
@@ -26,9 +26,12 @@ CONTACT_TRACERS_PER_CASE = 5
 RT_TRUNCATION_DAYS = 7
 
 
-# CMS and HHS testing data can both lag by more than 7 days. Let's use it unless it's >2 weeks old.
-# TODO(michael): Consider having different lookback values per metric, but this is fine for now.
-MAX_METRIC_LOOKBACK_DAYS = 15
+# 14 April 2023: Bumped this lookback mask to 21 days. It's interacting with
+# the DNC ffill causing a single day unknown before ffill takes over. I'm
+# bumping this, as opposed to the pulling ffill earlier because I want DNC to
+# stay at latest non-zero value for as long as possible. I could make this DNC
+# specific, but I'm okay with this general relaxation for now.
+MAX_METRIC_LOOKBACK_DAYS = 21
 
 
 EMPTY_TS = pd.Series([], dtype="float64")


### PR DESCRIPTION
The main change is to push back the metric lookback date to three weeks. This has only been an issue with DNC recently, and it's been causing locations to turn Unknown for one day before the DNC ffill override kicks in. So the observed behavior is "Green-Grey-Green". I'd rather just have it remain green, which screws with the email alerts less.

There's a secondary fix to the pre-commit hooks. The pre-commit black uses it's own internal environment which accidentally broke with a dependency upgrade (click) ([see black issue](https://github.com/psf/black/issues/2964)). I tried to just upgrade the pre-commit black, but it has different suggestions than the pinned black+click, so the pre-commit and GH-CI tools got into a recursive fight over formatting. I could update the main environmental black, but we use click for our own cli, so this would be a pretty big package upgrade that I don't want to test right now.
